### PR TITLE
feat(ui): add homepage FAQ with internal LLM Gateway entry

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import screenshotWelcome from '../../../assets/images/screenshots/screenshot-welcome.png';
 import screenshotOverlay from '../../../assets/images/screenshots/screenshot-overlay.png';
 import screenshotEditor from '../../../assets/images/screenshots/screenshot-editor.png';
@@ -70,6 +70,61 @@ const PLATFORM_META = [
         ),
     },
 ] as const;
+
+const FAQ_ITEMS = ['update', 'security', 'official', 'llmGateway'] as const;
+
+const FAQ_RICH_COMPONENTS = {
+    code: <code className="faq-code" />,
+    strong: <strong />,
+};
+
+function FAQSection() {
+    const { t } = useTranslation();
+    const [ref, inView] = useInView<HTMLElement>(0.12);
+    return (
+        <section
+            ref={ref}
+            id="faq"
+            className={`faq-section${inView ? ' is-visible' : ''}`}
+            aria-labelledby="faq-title"
+        >
+            <div className="section-heading">
+                <p className="section-kicker">{t('home.faq.kicker')}</p>
+                <h2 id="faq-title">{t('home.faq.title')}</h2>
+            </div>
+            <div className="faq-list">
+                {FAQ_ITEMS.map(id => (
+                    <details key={id} className="faq-item">
+                        <summary className="faq-question">
+                            <span>
+                                <Trans
+                                    t={t}
+                                    i18nKey={`home.faq.${id}.question`}
+                                    components={FAQ_RICH_COMPONENTS}
+                                />
+                            </span>
+                            <svg
+                                className="faq-chevron"
+                                width="16" height="16" viewBox="0 0 24 24"
+                                fill="none" stroke="currentColor" strokeWidth="2"
+                                strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"
+                            >
+                                <polyline points="6 9 12 15 18 9" />
+                            </svg>
+                        </summary>
+                        <p className="faq-answer">
+                            <Trans
+                                t={t}
+                                i18nKey={`home.faq.${id}.answer`}
+                                components={FAQ_RICH_COMPONENTS}
+                            />
+                        </p>
+                    </details>
+                ))}
+            </div>
+        </section>
+    );
+}
 
 function FeatureSection({ section, index }: { section: typeof FEATURE_SECTIONS[number]; index: number }) {
     const { t } = useTranslation();
@@ -157,6 +212,8 @@ export default function App() {
                         ))}
                     </div>
                 </section>
+
+                <FAQSection />
 
                 <section className="download" aria-labelledby="download-title">
                     <h2 id="download-title">{t('home.download.title')}</h2>

--- a/apps/ui/src/SiteChrome.tsx
+++ b/apps/ui/src/SiteChrome.tsx
@@ -138,6 +138,7 @@ export function SiteFooter() {
             <span className="footer-brand">Workbench</span>
             <div className="footer-links">
                 <a href={DOCS_URL}>{t('chrome.footer.documentation')}</a>
+                <a href="/#faq">{t('chrome.footer.faq')}</a>
                 <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
                     {t('chrome.footer.github')}
                 </a>

--- a/apps/ui/src/locales/de.json
+++ b/apps/ui/src/locales/de.json
@@ -8,6 +8,7 @@
         },
         "footer": {
             "documentation": "Dokumentation",
+            "faq": "FAQ",
             "github": "GitHub",
             "copyright": "© {{year}} Workbench"
         },
@@ -67,6 +68,26 @@
             "title": "In wenigen Minuten loslegen",
             "body": "Fügen Sie die Erweiterung hinzu, verbinden Sie Ihre Org und erhalten Sie ein Panel, einen VS Code-Editor, Metadaten-Tools und einen KI-Agenten – direkt in Ihrem Browser.",
             "cta": "Erweiterung hinzufügen"
+        },
+        "faq": {
+            "kicker": "Fragen",
+            "title": "Häufige Fragen",
+            "update": {
+                "question": "Meine Chrome-Erweiterung wird nicht aktualisiert – was kann ich tun?",
+                "answer": "Chrome aktualisiert Erweiterungen alle paar Stunden automatisch, aber Sie können das Update auch erzwingen. Öffnen Sie chrome://extensions, aktivieren Sie oben rechts den Entwicklermodus und klicken Sie dann auf die Schaltfläche „Aktualisieren“. Starten Sie Chrome anschließend neu. Falls die neuesten Funktionen weiterhin fehlen, deinstallieren Sie die Erweiterung und installieren Sie sie aus dem Chrome Web Store erneut – Ihre Sitzungen liegen im Browser, es geht nichts verloren."
+            },
+            "security": {
+                "question": "Ist Workbench sicher?",
+                "answer": "Ja. Workbench ist vollständig Open Source – jeder kann den Code auf GitHub prüfen. Die Erweiterung kommuniziert direkt mit Salesforce über die OAuth-Token Ihres Browsers; Ihr Passwort wird nie abgefragt, gesehen oder gespeichert. Sitzungen liegen ausschließlich im lokalen Chrome-Speicher. Der Proxy api.sf-workbench.com ist zustandslos und wird nur verwendet, wenn CORS direkte Aufrufe verhindert – er protokolliert oder speichert weder Ihre Token noch Ihre Org-Daten."
+            },
+            "official": {
+                "question": "Ist das ein offizielles Salesforce-Tool?",
+                "answer": "Nein – Workbench ist ein unabhängiges, von der Community getragenes Open-Source-Projekt und ist nicht mit Salesforce, Inc. verbunden, von Salesforce empfohlen oder gesponsert. Allerdings wird das Projekt überwiegend von Ingenieuren entwickelt und gepflegt, die bei Salesforce arbeiten, und es ist intern bei vielen Salesforce-Ingenieuren das tägliche Standardwerkzeug. Der Name lehnt sich an das ursprüngliche Salesforce Workbench an, weil Workbench dessen modernes Pendant sein möchte – entwickelt und gepflegt wird das Projekt jedoch unabhängig."
+            },
+            "llmGateway": {
+                "question": "Ich bin ein Salesforce-Mitarbeiter und nutze das interne LLM Gateway. Ich sehe <code>Authentication Error, Key is blocked</code>. Wie behebe ich das?",
+                "answer": "Das bedeutet, dass Ihr bisheriger LLM-Gateway-Schlüssel widerrufen wurde – meist weil Sie für eine andere interne Anwendung einen neuen Schlüssel generiert haben, was den alten automatisch sperrt. Sie müssen <code>/key/unblock</code> nicht aufrufen: Nehmen Sie einfach den neu generierten Schlüssel und ersetzen Sie den alten unter <strong>Settings → AI → AI Providers</strong>. Nur der Schlüssel muss geändert werden – die Endpoint-URLs sind bereits konfiguriert."
+            }
         }
     },
     "welcome": {

--- a/apps/ui/src/locales/en.json
+++ b/apps/ui/src/locales/en.json
@@ -8,6 +8,7 @@
         },
         "footer": {
             "documentation": "Documentation",
+            "faq": "FAQ",
             "github": "GitHub",
             "copyright": "© {{year}} Workbench"
         },
@@ -67,6 +68,26 @@
             "title": "Get started in minutes",
             "body": "Add the web extension, connect your org, and get an overlay, a VS Code editor, metadata tools, and an AI agent — right inside your browser.",
             "cta": "Add Web Extension"
+        },
+        "faq": {
+            "kicker": "Questions",
+            "title": "Frequently asked",
+            "update": {
+                "question": "My Chrome extension didn't update — what should I do?",
+                "answer": "Chrome auto-updates extensions every few hours, but you can force it manually. Open chrome://extensions, turn on Developer mode in the top-right, then click the Update button. Restart Chrome afterwards. If you still don't see the latest features, remove and reinstall the extension from the Chrome Web Store — your saved sessions live in your browser, so nothing is lost."
+            },
+            "security": {
+                "question": "Is Workbench secure?",
+                "answer": "Yes. Workbench is fully open source — anyone can audit the code on GitHub. The extension talks to Salesforce directly using the OAuth tokens issued to your browser; it never asks for, sees, or stores your password. Sessions are kept only in your local Chrome storage. The api.sf-workbench.com proxy is stateless and used only when CORS blocks direct calls — it never logs or persists your tokens or your org data."
+            },
+            "official": {
+                "question": "Is it an official Salesforce tool?",
+                "answer": "No — Workbench is an independent, community-driven open-source project and is not affiliated with, endorsed by, or sponsored by Salesforce, Inc. That said, it is developed and maintained primarily by engineers from Salesforce, and it is the everyday tool many Salesforce engineers rely on internally. The name is inspired by the original Salesforce Workbench because this aims to be a modern replacement — but it is built and maintained independently."
+            },
+            "llmGateway": {
+                "question": "I'm a Salesforce employee using the internal LLM Gateway and I see <code>Authentication Error, Key is blocked</code>. How do I fix it?",
+                "answer": "This means your previous LLM Gateway key has been revoked — typically because you generated a new key for another internal app, which automatically blocks the old one. You don't need to call <code>/key/unblock</code>: just take the new key you generated and replace the old one in <strong>Settings → AI → AI Providers</strong>. Only the key needs to change — the endpoint URLs are already configured."
+            }
         }
     },
     "welcome": {

--- a/apps/ui/src/locales/es.json
+++ b/apps/ui/src/locales/es.json
@@ -8,6 +8,7 @@
         },
         "footer": {
             "documentation": "Documentación",
+            "faq": "FAQ",
             "github": "GitHub",
             "copyright": "© {{year}} Workbench"
         },
@@ -67,6 +68,26 @@
             "title": "Empieza en minutos",
             "body": "Añade la extensión web, conecta tu org y obtén un panel superpuesto, un editor VS Code, herramientas de metadatos y un agente de IA — directamente en tu navegador.",
             "cta": "Añadir extensión web"
+        },
+        "faq": {
+            "kicker": "Preguntas",
+            "title": "Preguntas frecuentes",
+            "update": {
+                "question": "Mi extensión de Chrome no se actualiza — ¿qué hago?",
+                "answer": "Chrome actualiza las extensiones automáticamente cada pocas horas, pero puedes forzar la actualización manualmente. Abre chrome://extensions, activa el «Modo desarrollador» en la esquina superior derecha y pulsa el botón «Actualizar». Reinicia Chrome a continuación. Si aún no ves las novedades, desinstala y vuelve a instalar la extensión desde la Chrome Web Store — tus sesiones se guardan en el navegador, así que no perderás nada."
+            },
+            "security": {
+                "question": "¿Es seguro Workbench?",
+                "answer": "Sí. Workbench es totalmente código abierto — cualquiera puede auditar el código en GitHub. La extensión se comunica directamente con Salesforce usando los tokens OAuth emitidos a tu navegador; nunca pide, ve ni almacena tu contraseña. Las sesiones permanecen únicamente en el almacenamiento local de Chrome. El proxy api.sf-workbench.com es sin estado y solo se utiliza cuando CORS impide las llamadas directas — nunca registra ni conserva tus tokens ni los datos de tu org."
+            },
+            "official": {
+                "question": "¿Es una herramienta oficial de Salesforce?",
+                "answer": "No — Workbench es un proyecto open source independiente, impulsado por la comunidad, y no está afiliado, respaldado ni patrocinado por Salesforce, Inc. Dicho esto, el proyecto está desarrollado y mantenido principalmente por ingenieros de Salesforce, y es la herramienta cotidiana que muchos ingenieros de Salesforce utilizan internamente. El nombre se inspira en el Salesforce Workbench original porque busca ser un reemplazo moderno — pero está construido y mantenido de forma independiente."
+            },
+            "llmGateway": {
+                "question": "Soy empleado de Salesforce y uso el LLM Gateway interno. Veo <code>Authentication Error, Key is blocked</code>. ¿Cómo lo soluciono?",
+                "answer": "Significa que tu clave anterior del LLM Gateway ha sido revocada — normalmente porque generaste una nueva clave para otra aplicación interna, lo que bloquea automáticamente la antigua. No necesitas llamar a <code>/key/unblock</code>: simplemente toma la nueva clave que acabas de generar y reemplaza la antigua en <strong>Settings → AI → AI Providers</strong>. Solo hay que cambiar la clave — las URL de los endpoints ya están configuradas."
+            }
         }
     },
     "welcome": {

--- a/apps/ui/src/locales/fr.json
+++ b/apps/ui/src/locales/fr.json
@@ -8,6 +8,7 @@
         },
         "footer": {
             "documentation": "Documentation",
+            "faq": "FAQ",
             "github": "GitHub",
             "copyright": "© {{year}} Workbench"
         },
@@ -67,6 +68,26 @@
             "title": "Démarrez en quelques minutes",
             "body": "Ajoutez l'extension, connectez votre org et bénéficiez d'un panneau superposé, d'un éditeur VS Code, d'outils de métadonnées et d'un agent IA — directement dans votre navigateur.",
             "cta": "Ajouter l'extension"
+        },
+        "faq": {
+            "kicker": "Questions",
+            "title": "Questions fréquentes",
+            "update": {
+                "question": "Mon extension Chrome ne se met pas à jour — que faire ?",
+                "answer": "Chrome met à jour les extensions automatiquement toutes les quelques heures, mais vous pouvez forcer la mise à jour manuellement. Ouvrez chrome://extensions, activez le « Mode développeur » en haut à droite, puis cliquez sur le bouton « Mettre à jour ». Redémarrez ensuite Chrome. Si les nouveautés n'apparaissent toujours pas, désinstallez puis réinstallez l'extension depuis le Chrome Web Store — vos sessions sont stockées dans votre navigateur, vous ne perdrez rien."
+            },
+            "security": {
+                "question": "Workbench est-il sécurisé ?",
+                "answer": "Oui. Workbench est entièrement open source — chacun peut auditer le code sur GitHub. L'extension communique directement avec Salesforce via les jetons OAuth délivrés à votre navigateur ; elle ne demande, ne voit ni ne stocke jamais votre mot de passe. Les sessions restent uniquement dans le stockage local de Chrome. Le proxy api.sf-workbench.com est sans état et n'est utilisé que lorsque CORS empêche les appels directs — il n'enregistre ni ne conserve jamais vos jetons ni vos données d'org."
+            },
+            "official": {
+                "question": "Est-ce un outil officiel Salesforce ?",
+                "answer": "Non — Workbench est un projet open source indépendant, porté par la communauté. Il n'est ni affilié, ni approuvé, ni sponsorisé par Salesforce, Inc. Cela dit, le projet est développé et maintenu principalement par des ingénieurs Salesforce, et il est largement utilisé en interne par les ingénieurs Salesforce comme outil quotidien d'administration. Le nom s'inspire du Salesforce Workbench original car l'objectif est d'en proposer un remplaçant moderne — mais le projet reste conçu et maintenu de manière indépendante."
+            },
+            "llmGateway": {
+                "question": "Je suis un employé Salesforce et j'utilise le LLM Gateway interne. J'obtiens <code>Authentication Error, Key is blocked</code>. Comment corriger ?",
+                "answer": "Cela signifie que votre précédente clé LLM Gateway a été révoquée — généralement parce que vous avez généré une nouvelle clé pour une autre application interne, ce qui bloque automatiquement l'ancienne. Pas besoin d'appeler <code>/key/unblock</code> : reprenez simplement la nouvelle clé que vous venez de générer et remplacez l'ancienne dans <strong>Settings → AI → AI Providers</strong>. Seule la clé doit être modifiée — les URL des endpoints sont déjà configurées."
+            }
         }
     },
     "welcome": {

--- a/apps/ui/src/locales/ja.json
+++ b/apps/ui/src/locales/ja.json
@@ -8,6 +8,7 @@
         },
         "footer": {
             "documentation": "ドキュメント",
+            "faq": "FAQ",
             "github": "GitHub",
             "copyright": "© {{year}} Workbench"
         },
@@ -67,6 +68,26 @@
             "title": "数分で始められます",
             "body": "拡張機能を追加して Org を接続するだけで、オーバーレイパネル、VS Code エディタ、メタデータツール、AI エージェントがブラウザ内で使えるようになります。",
             "cta": "拡張機能を追加"
+        },
+        "faq": {
+            "kicker": "よくある質問",
+            "title": "よくお寄せいただく質問",
+            "update": {
+                "question": "Chrome 拡張機能が更新されません — どうすればよいですか？",
+                "answer": "Chrome は数時間ごとに拡張機能を自動更新しますが、手動で更新することもできます。chrome://extensions を開き、右上の「デベロッパーモード」をオンにして、「更新」ボタンをクリックしてください。その後 Chrome を再起動します。それでも新機能が反映されない場合は、Chrome ウェブストアから拡張機能を一度削除して再インストールしてください — 保存済みのセッションはブラウザ側に保持されているため失われません。"
+            },
+            "security": {
+                "question": "Workbench は安全ですか？",
+                "answer": "はい。Workbench は完全にオープンソースで、誰でも GitHub 上のコードを検証できます。拡張機能はブラウザに発行された OAuth トークンを用いて Salesforce と直接通信します。パスワードを要求・参照・保存することは一切ありません。セッション情報はローカルの Chrome ストレージにのみ保存されます。プロキシ api.sf-workbench.com はステートレスで、CORS のために直接呼び出せない API のみを中継し、トークンや Org データを記録・保持することはありません。"
+            },
+            "official": {
+                "question": "Salesforce 公式のツールですか？",
+                "answer": "いいえ。Workbench はコミュニティ主導の独立したオープンソースプロジェクトで、Salesforce, Inc. と提携・推奨・スポンサー関係はありません。ただし、本プロジェクトは主に Salesforce に勤務するエンジニアによって開発・運営されており、Salesforce 社内では多くのエンジニアが日常的な管理ツールとして利用しています。名前はオリジナルの Salesforce Workbench に由来していますが、それはあくまで「現代的な代替」を目指しているためであり、本プロジェクトは独立して開発・運営されています。"
+            },
+            "llmGateway": {
+                "question": "Salesforce 社員で、内部 LLM Gateway を使用しています。<code>Authentication Error, Key is blocked</code> が表示されますが、どう対処すればよいですか？",
+                "answer": "これは、以前の LLM Gateway キーが失効したことを意味します。通常は別の社内アプリ用に新しいキーを発行した結果、以前のキーが自動的にブロックされたケースです。<code>/key/unblock</code> を呼び出す必要はありません。発行された新しいキーをそのまま <strong>Settings → AI → AI Providers</strong> に貼り付け、古いキーを置き換えてください。変更が必要なのはキーのみで、エンドポイント URL はすでに設定済みです。"
+            }
         }
     },
     "welcome": {

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -654,6 +654,109 @@ h1 {
     pointer-events: none;
 }
 
+/* ─── FAQ ─────────────────────────────────────────────────── */
+
+.faq-section {
+    padding: 5rem 0 3rem;
+    border-top: 1px solid var(--color-border);
+    opacity: 0;
+    transform: translateY(24px);
+    transition: opacity 0.7s ease, transform 0.7s ease;
+}
+
+.faq-section.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.faq-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-top: 1.4rem;
+    max-width: 56rem;
+}
+
+.faq-item {
+    border: 1px solid var(--color-border);
+    border-radius: 0.9rem;
+    background: var(--color-surface);
+    box-shadow: 0 10px 28px -22px rgba(28, 67, 133, 0.5);
+    transition: box-shadow 0.2s ease, border-color 0.2s ease;
+    overflow: hidden;
+}
+
+.faq-item:hover {
+    border-color: #c0d4f7;
+    box-shadow: 0 14px 32px -18px rgba(28, 67, 133, 0.4);
+}
+
+.faq-item[open] {
+    border-color: #c0d4f7;
+    background: var(--color-surface-soft);
+}
+
+.faq-question {
+    list-style: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.1rem 1.4rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-text);
+    line-height: 1.45;
+}
+
+.faq-question::-webkit-details-marker {
+    display: none;
+}
+
+.faq-question:focus-visible {
+    outline: 2px solid var(--color-brand);
+    outline-offset: -2px;
+    border-radius: 0.9rem;
+}
+
+.faq-chevron {
+    flex-shrink: 0;
+    color: var(--color-brand);
+    transition: transform 0.2s ease;
+}
+
+.faq-item[open] .faq-chevron {
+    transform: rotate(180deg);
+}
+
+.faq-answer {
+    margin: 0;
+    padding: 0 1.4rem 1.2rem;
+    color: var(--color-text-muted);
+    font-size: 0.96rem;
+    line-height: 1.65;
+}
+
+.faq-code {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.86em;
+    padding: 0.1em 0.4em;
+    border-radius: 0.35rem;
+    background: var(--color-surface-alt);
+    border: 1px solid var(--color-border);
+    color: var(--color-text);
+    white-space: nowrap;
+}
+
+.faq-question .faq-code {
+    background: rgba(255, 255, 255, 0.6);
+}
+
+.faq-item[open] .faq-question .faq-code {
+    background: var(--color-surface);
+}
+
 /* ─── Download CTA ────────────────────────────────────────── */
 
 .download {


### PR DESCRIPTION
## Summary

Adds a **Frequently Asked** section to the marketing-site homepage (`https://www.sf-workbench.com`) covering the four most commonly asked questions, fully localized in all five supported languages.

| # | Question | Audience |
|---|---|---|
| 1 | My Chrome extension didn't update — what should I do? | Public |
| 2 | Is Workbench secure? | Public |
| 3 | Is it an official Salesforce tool? | Public |
| 4 | Internal LLM Gateway: `Authentication Error, Key is blocked` recovery flow | Salesforce employees |

The new section sits between **Available platforms** and **Get started in minutes** on the homepage, and a **FAQ** link is added to the site footer (deep-links to `/#faq`).

## Why this PR

- Recurring user questions land in support channels and Slack — moving the canonical answers onto the homepage cuts repetitive triage and gives users a stable URL to share.
- The "Is it official?" answer was deliberately written to keep the legal posture clean (independent / not affiliated / not endorsed) while still surfacing the fact that the project is built and used internally by Salesforce engineers.
- The LLM Gateway entry documents the most common failure mode internal users hit when rotating keys (regenerated key in another app blocks the previous one) — saves a Slack ping each time it happens.

## Implementation

- **Native `<details>` / `<summary>`** accordion — keyboard accessible and screen-reader friendly without any JS state. Chevron rotates 180° on open.
- **Rich content via `<Trans>`** with a shared `FAQ_RICH_COMPONENTS` map (`<code>` → `.faq-code`, `<strong>` → `<strong/>`). Tag-less entries fall through to plain text, so existing entries are unaffected.
- **Visual language mirrors `.platform-card`** (rounded surface, soft border, subtle shadow) plus a fade/slide-in entrance via the existing `is-visible` IntersectionObserver pattern used elsewhere in `App.tsx`.
- **i18n parity** across `en/fr/de/es/ja`. Literal app paths (`Settings → AI → AI Providers`, `/key/unblock`, `Authentication Error, Key is blocked`) are kept verbatim across all locales because the extension's settings page is English-only (verified in `packages/lwc/app/pages/settings/app/app.html:494`) and these are quoted error/path strings.

## Files changed

| File | Purpose |
|---|---|
| `apps/ui/src/App.tsx` | New `FAQSection` component, slotted into homepage |
| `apps/ui/src/SiteChrome.tsx` | Footer "FAQ" link (`/#faq`) |
| `apps/ui/src/styles.css` | `.faq-section` / `.faq-item` / `.faq-question` / `.faq-answer` / `.faq-chevron` / `.faq-code` |
| `apps/ui/src/locales/{en,fr,de,es,ja}.json` | `home.faq.*` keys + `chrome.footer.faq` |

## Already deployed

This PR codifies what is already running in production: it was rolled out as Heroku release **v20** for `workbench2` (image `6878a66fb0d0`, served from `dist/ui/ui-assets/index-BNdmk4oh.js`). The PR exists primarily for code review, history, and so the work survives the next clean rebuild.

## Test plan

- [ ] `npm run docker:prebuild` succeeds locally
- [ ] Visit `https://www.sf-workbench.com/` → FAQ section renders below platforms
- [ ] Click each of the 4 questions → answer expands, chevron rotates 180°
- [ ] Inline `<code>` chips render in monospace with soft border (LLM Gateway entry)
- [ ] Footer "FAQ" link scrolls to `#faq` from `/` and navigates to `/#faq` from `/welcome`
- [ ] Keyboard: Tab to question, press Enter or Space → expands; Esc has no special handling (browser default)
- [ ] Switch language to fr / de / es / ja → all four answers translate
- [ ] Mobile (≤740px) → FAQ items stack cleanly, no horizontal overflow from inline `<code>` chips (`white-space: nowrap` on `.faq-code` may need follow-up if a path is too long, but current strings fit)