### PR TITLE
test: expand unit coverage for server + desktop modules

### DIFF
--- a/packages/extension/src/desktop/__tests__/chromeEnrich.test.js
+++ b/packages/extension/src/desktop/__tests__/chromeEnrich.test.js
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { before, test } from 'node:test';
+
+/**
+ * chromeEnrich.js is a side-effect module with a single top-level guard:
+ *   if (window && window.desktop && chrome) { patch chrome.* }
+ *
+ * Node caches ESM modules by URL, so we can only evaluate the module once
+ * in a test file. We install the "desktop + chrome present" env up front
+ * and cover the patch surface. The negative-path branches (no window,
+ * no chrome, pre-existing storage) aren't reachable from here without a
+ * fresh Node worker — not worth the complexity for a guard this small.
+ */
+
+function makeWebStorage() {
+    const backing = {};
+    const storage = {
+        getItem: k => (k in backing ? backing[k] : null),
+        setItem: (k, v) => {
+            backing[k] = String(v);
+        },
+        removeItem: k => {
+            delete backing[k];
+        },
+        get length() {
+            return Object.keys(backing).length;
+        },
+        _backing: backing,
+    };
+    return storage;
+}
+
+before(async () => {
+    const localStorage = makeWebStorage();
+    const sessionStorage = makeWebStorage();
+    globalThis.localStorage = localStorage;
+    globalThis.sessionStorage = sessionStorage;
+    // chromeEnrich uses Object.keys(webStorage) to enumerate. Patch Object.keys
+    // to look into the _backing map for our storage stubs.
+    const origKeys = Object.keys.bind(Object);
+    Object.keys = obj => {
+        if (obj === localStorage || obj === sessionStorage) {
+            return origKeys(obj._backing);
+        }
+        return origKeys(obj);
+    };
+    globalThis.window = { desktop: {}, location: { origin: 'http://localhost:3000' } };
+    globalThis.chrome = { runtime: {} };
+    await import('../chromeEnrich.js');
+});
+
+test('chromeEnrich: chrome.runtime.getURL resolves relative to window.location.origin', () => {
+    assert.equal(
+        globalThis.chrome.runtime.getURL('/views/app.html'),
+        'http://localhost:3000/views/app.html'
+    );
+});
+
+test('chromeEnrich: chrome.runtime.getURL normalises leading slash', () => {
+    assert.equal(
+        globalThis.chrome.runtime.getURL('views/app.html'),
+        'http://localhost:3000/views/app.html'
+    );
+});
+
+test('chromeEnrich: installs chrome.storage with local/sync/session areas', () => {
+    assert.ok(globalThis.chrome.storage.local);
+    assert.ok(globalThis.chrome.storage.sync);
+    assert.ok(globalThis.chrome.storage.session);
+});
+
+test('chromeEnrich: storage.local set + get round-trips JSON values', async () => {
+    await globalThis.chrome.storage.local.set({ foo: { n: 1, s: 'x' } });
+    const got = await globalThis.chrome.storage.local.get('foo');
+    assert.deepEqual(got, { foo: { n: 1, s: 'x' } });
+});
+
+test('chromeEnrich: storage.local.get returns defaults for missing keys (object arg)', async () => {
+    const got = await globalThis.chrome.storage.local.get({ missing: 'fallback' });
+    assert.deepEqual(got, { missing: 'fallback' });
+});
+
+test('chromeEnrich: storage.local.get with callback', async () => {
+    await globalThis.chrome.storage.local.set({ cb: 42 });
+    await new Promise(resolve => {
+        globalThis.chrome.storage.local.get('cb', result => {
+            assert.deepEqual(result, { cb: 42 });
+            resolve();
+        });
+    });
+});
+
+test('chromeEnrich: storage.local.remove deletes a single key', async () => {
+    await globalThis.chrome.storage.local.set({ del1: 1, del2: 2 });
+    await globalThis.chrome.storage.local.remove('del1');
+    const after = await globalThis.chrome.storage.local.get(['del1', 'del2']);
+    assert.deepEqual(after, { del2: 2 });
+});
+
+test('chromeEnrich: storage.local.remove deletes an array of keys', async () => {
+    await globalThis.chrome.storage.local.set({ r1: 1, r2: 2, r3: 3 });
+    await globalThis.chrome.storage.local.remove(['r1', 'r2']);
+    const after = await globalThis.chrome.storage.local.get(['r1', 'r2', 'r3']);
+    assert.deepEqual(after, { r3: 3 });
+});
+
+test('chromeEnrich: session storage is backed separately from local', async () => {
+    await globalThis.chrome.storage.local.set({ shared: 'L' });
+    await globalThis.chrome.storage.session.set({ shared: 'S' });
+    const l = await globalThis.chrome.storage.local.get('shared');
+    const s = await globalThis.chrome.storage.session.get('shared');
+    assert.equal(l.shared, 'L');
+    assert.equal(s.shared, 'S');
+});
+
+test('chromeEnrich: get with string key returns value under that key', async () => {
+    await globalThis.chrome.storage.local.set({ strKey: 'hello' });
+    const got = await globalThis.chrome.storage.local.get('strKey');
+    assert.equal(got.strKey, 'hello');
+});
+
+test('chromeEnrich: non-JSON value falls back to raw string', async () => {
+    // Inject a raw string bypassing set (simulates pre-existing localStorage data).
+    globalThis.localStorage.setItem('raw', 'not-json-at-all');
+    const got = await globalThis.chrome.storage.local.get('raw');
+    assert.equal(got.raw, 'not-json-at-all');
+});
+
+test('chromeEnrich: set accepts callback', async () => {
+    await new Promise(resolve => {
+        globalThis.chrome.storage.local.set({ cb2: 'ok' }, () => resolve());
+    });
+    const got = await globalThis.chrome.storage.local.get('cb2');
+    assert.equal(got.cb2, 'ok');
+});

--- a/packages/server/modules/__tests__/documentationSearch.test.ts
+++ b/packages/server/modules/__tests__/documentationSearch.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+/**
+ * documentationSearch wraps a flexsearch Document index. flexsearch's
+ * `worker: true` mode spawns a Web Worker that isn't available under
+ * `node --test` — so we cover the one branch that doesn't need the index:
+ * `searchDocumentation` must return [] when the index is uninitialised.
+ *
+ * The sorting / enrichment logic is exercised end-to-end by the dev server
+ * integration tests; testing it here would require bringing up a worker
+ * runtime that the unit suite doesn't have.
+ */
+test('searchDocumentation: returns [] when index is uninitialised', async () => {
+    const { searchDocumentation } = await import('../documentationSearch.ts');
+    // Fresh module = no init call yet.
+    const result = await searchDocumentation({ keywords: 'anything' });
+    assert.deepEqual(result, []);
+});
+
+test('searchDocumentation: returns [] without keywords when uninitialised', async () => {
+    const { searchDocumentation } = await import('../documentationSearch.ts');
+    const result = await searchDocumentation({});
+    assert.deepEqual(result, []);
+});
+
+test('searchDocumentation: returns [] with filters but no init', async () => {
+    const { searchDocumentation } = await import('../documentationSearch.ts');
+    const result = await searchDocumentation({ filters: ['x', 'y'] });
+    assert.deepEqual(result, []);
+});

--- a/packages/server/modules/__tests__/openaiProxy.test.ts
+++ b/packages/server/modules/__tests__/openaiProxy.test.ts
@@ -1,0 +1,264 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import openaiProxy from '../openaiProxy.ts';
+
+/**
+ * openaiProxy wires CORS + auth middleware and four route handlers onto an
+ * Express app. We don't need a real Express — a fake that captures the
+ * registered middlewares and handlers is enough to exercise the behaviours
+ * that matter (auth rejection, model validation, CORS headers).
+ */
+type RouteSlot = {
+    path: string;
+    handlers: Function[];
+};
+
+function makeFakeApp() {
+    const uses: RouteSlot[] = [];
+    const gets: RouteSlot[] = [];
+    const posts: RouteSlot[] = [];
+    const optionss: RouteSlot[] = [];
+    return {
+        uses,
+        gets,
+        posts,
+        optionss,
+        use(path: string, ...handlers: Function[]) {
+            uses.push({ path, handlers });
+        },
+        get(path: string, ...handlers: Function[]) {
+            gets.push({ path, handlers });
+        },
+        post(path: string, ...handlers: Function[]) {
+            posts.push({ path, handlers });
+        },
+        options(path: string, ...handlers: Function[]) {
+            optionss.push({ path, handlers });
+        },
+    };
+}
+
+function makeRes() {
+    const state: any = { status: 200, headers: {}, body: undefined, ended: false, chunks: [] };
+    const res: any = {
+        state,
+        status(code: number) {
+            state.status = code;
+            return res;
+        },
+        set(h: Record<string, string>) {
+            Object.assign(state.headers, h);
+            return res;
+        },
+        json(body: unknown) {
+            state.body = body;
+            return res;
+        },
+        write(chunk: unknown) {
+            state.chunks.push(chunk);
+            return true;
+        },
+        end() {
+            state.ended = true;
+            return res;
+        },
+        flushHeaders() {},
+    };
+    return res;
+}
+
+function makeReq(overrides: Record<string, unknown> = {}) {
+    return {
+        headers: {},
+        body: undefined,
+        ...overrides,
+    };
+}
+
+test('openaiProxy: registers CORS+auth middleware on base path', () => {
+    const app = makeFakeApp();
+    openaiProxy(app as any);
+    // Default path is /openai/v1 → .use('/openai/v1/', corsMw, authMw)
+    const use = app.uses.find(u => u.path === '/openai/v1/');
+    assert.ok(use, 'expected use() on /openai/v1/');
+    assert.equal(use.handlers.length, 2);
+});
+
+test('openaiProxy: registers expected routes', () => {
+    const app = makeFakeApp();
+    openaiProxy(app as any);
+    const postPaths = app.posts.map(p => p.path);
+    assert.ok(postPaths.includes('/openai/v1/chat/completions'));
+    assert.ok(postPaths.includes('/openai/v1/responses'));
+    const getPaths = app.gets.map(g => g.path);
+    assert.ok(getPaths.includes('/openai/v1/models'));
+});
+
+test('openaiProxy: honours custom path option', () => {
+    const app = makeFakeApp();
+    openaiProxy(app as any, { path: '/custom/v2' });
+    assert.ok(app.uses.some(u => u.path === '/custom/v2/'));
+    assert.ok(app.posts.some(p => p.path === '/custom/v2/chat/completions'));
+});
+
+test('openaiProxy: CORS middleware sets permissive headers', () => {
+    const app = makeFakeApp();
+    openaiProxy(app as any);
+    const [corsMw] = app.uses[0].handlers;
+    const res = makeRes();
+    let called = false;
+    corsMw(makeReq(), res, () => (called = true));
+    assert.equal(res.state.headers['Access-Control-Allow-Origin'], '*');
+    assert.ok(res.state.headers['Access-Control-Allow-Methods'].includes('POST'));
+    assert.ok(res.state.headers['Access-Control-Allow-Headers'].includes('Authorization'));
+    assert.equal(called, true);
+});
+
+test('openaiProxy: auth middleware allows request when no static keys configured', () => {
+    const saved = {
+        k0: process.env.SALESFORCE_KEY,
+        k1: process.env.SALESFORCE_KEY1,
+        k2: process.env.SALESFORCE_KEY2,
+        k3: process.env.SALESFORCE_KEY3,
+        k4: process.env.SALESFORCE_KEY4,
+        k5: process.env.SALESFORCE_KEY5,
+    };
+    delete process.env.SALESFORCE_KEY;
+    delete process.env.SALESFORCE_KEY1;
+    delete process.env.SALESFORCE_KEY2;
+    delete process.env.SALESFORCE_KEY3;
+    delete process.env.SALESFORCE_KEY4;
+    delete process.env.SALESFORCE_KEY5;
+    try {
+        const app = makeFakeApp();
+        openaiProxy(app as any);
+        const [, authMw] = app.uses[0].handlers;
+        const res = makeRes();
+        let called = false;
+        authMw(makeReq(), res, () => (called = true));
+        assert.equal(called, true);
+    } finally {
+        Object.entries(saved).forEach(([k, v]) => {
+            const key = k === 'k0' ? 'SALESFORCE_KEY' : `SALESFORCE_KEY${k.slice(1)}`;
+            if (v !== undefined) process.env[key] = v;
+        });
+    }
+});
+
+test('openaiProxy: auth middleware rejects missing bearer when keys configured', () => {
+    const saved = process.env.SALESFORCE_KEY;
+    process.env.SALESFORCE_KEY = 'secret-123';
+    try {
+        const app = makeFakeApp();
+        openaiProxy(app as any);
+        const [, authMw] = app.uses[0].handlers;
+        const res = makeRes();
+        let called = false;
+        authMw(makeReq(), res, () => (called = true));
+        assert.equal(called, false);
+        assert.equal(res.state.status, 401);
+        assert.deepEqual(res.state.body, { error: 'Unauthorized' });
+    } finally {
+        if (saved === undefined) delete process.env.SALESFORCE_KEY;
+        else process.env.SALESFORCE_KEY = saved;
+    }
+});
+
+test('openaiProxy: auth middleware accepts matching bearer token', () => {
+    const saved = process.env.SALESFORCE_KEY;
+    process.env.SALESFORCE_KEY = 'secret-123';
+    try {
+        const app = makeFakeApp();
+        openaiProxy(app as any);
+        const [, authMw] = app.uses[0].handlers;
+        const res = makeRes();
+        let called = false;
+        authMw(
+            makeReq({ headers: { authorization: 'Bearer secret-123' } }),
+            res,
+            () => (called = true)
+        );
+        assert.equal(called, true);
+    } finally {
+        if (saved === undefined) delete process.env.SALESFORCE_KEY;
+        else process.env.SALESFORCE_KEY = saved;
+    }
+});
+
+test('openaiProxy: auth middleware rejects wrong bearer token', () => {
+    const saved = process.env.SALESFORCE_KEY;
+    process.env.SALESFORCE_KEY = 'secret-123';
+    try {
+        const app = makeFakeApp();
+        openaiProxy(app as any);
+        const [, authMw] = app.uses[0].handlers;
+        const res = makeRes();
+        let called = false;
+        authMw(
+            makeReq({ headers: { authorization: 'Bearer wrong-key' } }),
+            res,
+            () => (called = true)
+        );
+        assert.equal(called, false);
+        assert.equal(res.state.status, 401);
+    } finally {
+        if (saved === undefined) delete process.env.SALESFORCE_KEY;
+        else process.env.SALESFORCE_KEY = saved;
+    }
+});
+
+test('openaiProxy: chat/completions returns 400 when body missing', async () => {
+    const app = makeFakeApp();
+    openaiProxy(app as any);
+    const handler = app.posts.find(p => p.path === '/openai/v1/chat/completions')!.handlers[0];
+    const res = makeRes();
+    await handler(makeReq({ body: undefined }), res, () => {});
+    assert.equal(res.state.status, 400);
+    assert.deepEqual(res.state.body, { error: 'Invalid JSON' });
+});
+
+test('openaiProxy: chat/completions returns 400 for unsupported model', async () => {
+    const app = makeFakeApp();
+    openaiProxy(app as any);
+    const handler = app.posts.find(p => p.path === '/openai/v1/chat/completions')!.handlers[0];
+    const res = makeRes();
+    await handler(makeReq({ body: { model: 'not-a-real-model' } }), res, () => {});
+    assert.equal(res.state.status, 400);
+    assert.match((res.state.body as any).error, /not supported/);
+});
+
+test('openaiProxy: responses endpoint returns 400 for missing body', async () => {
+    const app = makeFakeApp();
+    openaiProxy(app as any);
+    const handler = app.posts.find(p => p.path === '/openai/v1/responses')!.handlers[0];
+    const res = makeRes();
+    await handler(makeReq({ body: undefined }), res, () => {});
+    assert.equal(res.state.status, 400);
+});
+
+test('openaiProxy: GET /models lists supportModels as OpenAI-shaped entries', () => {
+    const app = makeFakeApp();
+    openaiProxy(app as any);
+    const handler = app.gets.find(g => g.path === '/openai/v1/models')!.handlers[0];
+    const res = makeRes();
+    handler(makeReq(), res, () => {});
+    const body: any = res.state.body;
+    assert.equal(body.object, 'list');
+    assert.ok(Array.isArray(body.data));
+    assert.ok(body.data.length > 0);
+    assert.equal(body.data[0].object, 'model');
+    assert.equal(body.data[0].owned_by, 'openai');
+    assert.equal(typeof body.data[0].id, 'string');
+});
+
+test('openaiProxy: OPTIONS handler returns 200 ok', () => {
+    const app = makeFakeApp();
+    openaiProxy(app as any);
+    const optRoute = app.optionss.find(o => o.path === '/openai/v1{/*splat}');
+    assert.ok(optRoute, 'expected options() on splat path');
+    const res = makeRes();
+    optRoute!.handlers[0](makeReq(), res);
+    assert.equal(res.state.status, 200);
+    assert.deepEqual(res.state.body, { body: 'ok' });
+});

--- a/packages/server/modules/__tests__/openaiProxy.test.ts
+++ b/packages/server/modules/__tests__/openaiProxy.test.ts
@@ -9,9 +9,10 @@ import openaiProxy from '../openaiProxy.ts';
  * registered middlewares and handlers is enough to exercise the behaviours
  * that matter (auth rejection, model validation, CORS headers).
  */
+type Handler = (...args: any[]) => any;
 type RouteSlot = {
     path: string;
-    handlers: Function[];
+    handlers: Handler[];
 };
 
 function makeFakeApp() {
@@ -24,16 +25,16 @@ function makeFakeApp() {
         gets,
         posts,
         optionss,
-        use(path: string, ...handlers: Function[]) {
+        use(path: string, ...handlers: Handler[]) {
             uses.push({ path, handlers });
         },
-        get(path: string, ...handlers: Function[]) {
+        get(path: string, ...handlers: Handler[]) {
             gets.push({ path, handlers });
         },
-        post(path: string, ...handlers: Function[]) {
+        post(path: string, ...handlers: Handler[]) {
             posts.push({ path, handlers });
         },
-        options(path: string, ...handlers: Function[]) {
+        options(path: string, ...handlers: Handler[]) {
             optionss.push({ path, handlers });
         },
     };


### PR DESCRIPTION
## Summary
- Add 13-test suite for `packages/server/modules/openaiProxy.ts` covering CORS + auth middleware and the 4 route handlers (chat/completions, responses, models, OPTIONS splat).
- Add 12-test suite for `packages/extension/src/desktop/chromeEnrich.js` covering the chrome.* polyfill (getURL, storage.local/sync/session, JSON round-trip, callbacks, raw-string fallback).
- Add 3-test suite for `packages/server/modules/documentationSearch.ts` covering the uninitialised-index guard (flexsearch worker mode is out of reach of node --test).

Test count: 1288 → 1316 (+28).

## Test plan
- [x] \`npm test\` — 1316 pass, 0 fail
- [x] Each new file runs in isolation via \`node --experimental-strip-types --test <file>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)