### PR TITLE
ci: add build job gating PRs on full production build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,26 @@ jobs:
       - run: npm run lint
       - run: npm test
 
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.14'
+          cache: 'npm'
+      - run: npm ci --no-audit --no-fund
+      - name: Install apps/ui + apps/docs deps
+        run: |
+          npm --prefix apps/ui ci --no-audit --no-fund
+          npm --prefix apps/docs ci --no-audit --no-fund
+      - run: npm run build:shared
+      - run: npm run build:workers
+      - run: npm run build:extension:main
+      - run: npm run build:server
+      - run: npm run site:build
+
   e2e-smoke:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- New \`build\` job in \`.github/workflows/test.yml\` runs on every PR and push to master.
- Executes \`build:shared + build:workers + build:extension:main + build:server + site:build\`.
- Desktop (Electron) intentionally omitted — rarely regresses from shared code, and doubles CI wall clock.

Once merged, branch protection on \`master\` will be set to require \`unit\`, \`build\`, \`e2e-smoke\`, \`e2e-extension\` as passing status checks before merge.

## Test plan
- [ ] PR CI shows the new \`build\` job running alongside existing \`unit\`, \`e2e-smoke\`, \`e2e-extension\`.
- [ ] All four jobs pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)