### PR TITLE
docs(ci): note required status checks for master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
 name: test
+# Required status checks on master: unit, build, e2e-smoke, e2e-extension.
 on:
   pull_request:
     branches: [master]


### PR DESCRIPTION
## Summary
- Tiny doc-only comment at the top of \`.github/workflows/test.yml\`.
- Purpose: validate that branch protection on \`master\` actually gates merges on \`unit\`, \`build\`, \`e2e-smoke\`, \`e2e-extension\` passing.

## Test plan
- [ ] All four required checks run on this PR.
- [ ] Attempt to merge while checks are pending → blocked.
- [ ] Once all green → merge works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)