### PR TITLE
Close loading overlay after successful org connection

### DIFF
--- a/packages/lwc/main/core/store/modules/application.ts
+++ b/packages/lwc/main/core/store/modules/application.ts
@@ -105,6 +105,8 @@ const applicationSlice = createSlice({
             const { connector } = action.payload;
             state.connector = connector;
             state.isLoggedIn = true;
+            state.isLoading = false;
+            state.isLoadingMessage = null;
             state.sessionHasExpired = false;
             // Save Session
             const { instanceUrl, accessToken, version, refreshToken } = connector.conn;


### PR DESCRIPTION
### Summary
Fixes a bug where the full-page loading overlay gets stuck indefinitely after clicking "Connect" on an OAuth-authorized org from the connections page. The connection succeeds (confirmed on page refresh) but the loading spinner never clears.

### Root Cause
The login() method in connection/app/app.ts dispatches startLoading before connecting, but the Redux login action in the application slice never clears isLoading. The stopLoading dispatch only exists in the error paths — the success path is missing it entirely.

This is particularly visible when switching between orgs (already logged in to org A, connecting to org B), because the skeleton app's storeChange handler only calls handleLogin (which dispatches stopLoading) when isLoggedIn transitions from false to true — not when it stays true.

### Fix
Clear isLoading and isLoadingMessage directly in the login reducer, since login inherently means the loading process is complete. This is safe across all 12 callers of the login action — setting isLoading = false when it's already false is a no-op, and when it was stuck as true, this correctly clears it.

Closes https://github.com/grebmann1/workbench/issues/21