### PR TITLE
feat(ai): subscription OAuth for AI providers — Codex + xAI

### DIFF
--- a/packages/extension/manifest.template.json
+++ b/packages/extension/manifest.template.json
@@ -76,7 +76,8 @@
         "unlimitedStorage",
         "activeTab",
         "scripting",
-        "debugger"
+        "debugger",
+        "webNavigation"
     ],
     "incognito": "spanning",
     "externally_connectable": {

--- a/packages/extension/src/views/oauth-success.html
+++ b/packages/extension/src/views/oauth-success.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Workbench — Signed in</title>
+        <style>
+            :root {
+                color-scheme: light dark;
+            }
+            body {
+                margin: 0;
+                min-height: 100vh;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-family:
+                    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+                    sans-serif;
+                background: #f3f3f3;
+                color: #181818;
+            }
+            @media (prefers-color-scheme: dark) {
+                body {
+                    background: #1b1b1b;
+                    color: #f3f3f3;
+                }
+                .card {
+                    background: #2a2a2a;
+                }
+            }
+            .card {
+                background: #fff;
+                border-radius: 12px;
+                padding: 40px 48px;
+                box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
+                text-align: center;
+                max-width: 380px;
+            }
+            .check {
+                width: 56px;
+                height: 56px;
+                border-radius: 50%;
+                background: #2e844a;
+                color: #fff;
+                font-size: 32px;
+                line-height: 56px;
+                margin: 0 auto 20px;
+            }
+            h1 {
+                font-size: 18px;
+                margin: 0 0 8px;
+            }
+            p {
+                font-size: 14px;
+                margin: 0;
+                opacity: 0.75;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="card">
+            <div class="check">✓</div>
+            <h1>Signed in to Workbench</h1>
+            <p>You can close this tab and return to Workbench.</p>
+        </div>
+    </body>
+</html>

--- a/packages/extension/src/views/oauth-success.html
+++ b/packages/extension/src/views/oauth-success.html
@@ -5,56 +5,50 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Workbench — Signed in</title>
         <style>
-            :root {
-                color-scheme: light dark;
+            html,
+            body {
+                height: 100%;
+                margin: 0;
             }
             body {
-                margin: 0;
-                min-height: 100vh;
                 display: flex;
                 align-items: center;
                 justify-content: center;
+                background: #f4f6f9;
                 font-family:
                     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
                     sans-serif;
-                background: #f3f3f3;
-                color: #181818;
-            }
-            @media (prefers-color-scheme: dark) {
-                body {
-                    background: #1b1b1b;
-                    color: #f3f3f3;
-                }
-                .card {
-                    background: #2a2a2a;
-                }
             }
             .card {
-                background: #fff;
+                background: #ffffff;
+                border: 1px solid #e5e5e5;
                 border-radius: 12px;
                 padding: 40px 48px;
-                box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
                 text-align: center;
                 max-width: 380px;
+                box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
             }
             .check {
                 width: 56px;
                 height: 56px;
-                border-radius: 50%;
-                background: #2e844a;
-                color: #fff;
-                font-size: 32px;
                 line-height: 56px;
                 margin: 0 auto 20px;
+                border-radius: 50%;
+                background: #2e844a;
+                color: #ffffff;
+                font-size: 30px;
             }
             h1 {
-                font-size: 18px;
                 margin: 0 0 8px;
+                font-size: 18px;
+                font-weight: 600;
+                color: #181818;
             }
             p {
-                font-size: 14px;
                 margin: 0;
-                opacity: 0.75;
+                font-size: 14px;
+                line-height: 1.5;
+                color: #444444;
             }
         </style>
     </head>

--- a/packages/extension/src/workers/background.js
+++ b/packages/extension/src/workers/background.js
@@ -906,16 +906,24 @@ chrome.webNavigation.onBeforeNavigate.addListener(
         handleOAuthRedirect(details)
             .then(result => {
                 if (!result) return;
-                broadcastMessageToAllSidePanelInstances({
-                    action: 'broadcastMessageToSidePanel',
-                    payload: { type: 'oauth_signed_in', provider: result.provider },
-                });
+                // Universal message so any extension surface (side panel or options page)
+                // with a runtime.onMessage listener hears it; ignore "no receiver".
+                chrome.runtime
+                    .sendMessage({
+                        action: 'workbench_oauth_result',
+                        ok: true,
+                        provider: result.provider,
+                    })
+                    .catch(() => {});
             })
             .catch(error => {
-                broadcastMessageToAllSidePanelInstances({
-                    action: 'broadcastMessageToSidePanel',
-                    payload: { type: 'oauth_error', message: error?.message || 'Sign-in failed.' },
-                });
+                chrome.runtime
+                    .sendMessage({
+                        action: 'workbench_oauth_result',
+                        ok: false,
+                        message: error?.message || 'Sign-in failed.',
+                    })
+                    .catch(() => {});
             });
     },
     { url: [{ hostEquals: 'localhost' }, { hostEquals: '127.0.0.1' }] }

--- a/packages/extension/src/workers/background.js
+++ b/packages/extension/src/workers/background.js
@@ -31,7 +31,11 @@ import {
 import { handleVscodeBackgroundMessage, isVscodeBackgroundAction } from './vscode.js';
 import { handleMcpHttpRequest } from './shared/mcpProxy.js';
 import { handleLaunchWebAuthFlow } from './shared/oauth.js';
-import { startProviderOAuth, handleOAuthRedirect } from './shared/providerOAuth.js';
+import {
+    startProviderOAuth,
+    handleOAuthRedirect,
+    submitProviderOAuthCode,
+} from './shared/providerOAuth.js';
 
 /** Command and menu ids */
 const OVERLAY_ENABLE = 'overlay_enable';
@@ -820,6 +824,24 @@ async function handleRuntimeMessage(message, sender) {
     }
     if (message.action === 'providerOAuthStart') {
         return await startProviderOAuth({ provider: message.provider });
+    }
+    if (message.action === 'providerOAuthSubmitCode') {
+        try {
+            const result = await submitProviderOAuthCode({
+                provider: message.provider,
+                code: message.code,
+            });
+            chrome.runtime
+                .sendMessage({
+                    action: 'workbench_oauth_result',
+                    ok: true,
+                    provider: result.provider,
+                })
+                .catch(() => {});
+            return { ok: true };
+        } catch (error) {
+            return { error: error?.message || 'Sign-in failed.' };
+        }
     }
     if (isVscodeBackgroundAction(message.action)) {
         return await handleVscodeBackgroundMessage(message, {

--- a/packages/extension/src/workers/background.js
+++ b/packages/extension/src/workers/background.js
@@ -31,6 +31,7 @@ import {
 import { handleVscodeBackgroundMessage, isVscodeBackgroundAction } from './vscode.js';
 import { handleMcpHttpRequest } from './shared/mcpProxy.js';
 import { handleLaunchWebAuthFlow } from './shared/oauth.js';
+import { startProviderOAuth, handleOAuthRedirect } from './shared/providerOAuth.js';
 
 /** Command and menu ids */
 const OVERLAY_ENABLE = 'overlay_enable';
@@ -817,6 +818,9 @@ async function handleRuntimeMessage(message, sender) {
     if (message.action === 'launchWebAuthFlow') {
         return await handleLaunchWebAuthFlowMessage(message);
     }
+    if (message.action === 'providerOAuthStart') {
+        return await startProviderOAuth({ provider: message.provider });
+    }
     if (isVscodeBackgroundAction(message.action)) {
         return await handleVscodeBackgroundMessage(message, {
             getSidCookieForTabId,
@@ -892,6 +896,30 @@ chrome.tabs.onRemoved.addListener(tabId => {
 });
 chrome.tabs.onUpdated.addListener(handleTabUpdated);
 chrome.runtime.onMessage.addListener(wrapAsyncFunction(handleRuntimeMessage));
+
+// Capture the LLM-provider OAuth loopback redirect. Top-level + storage.session-backed so it
+// survives service-worker suspension during a long user login. Filtered to the loopback host
+// so it doesn't run on ordinary navigation.
+chrome.webNavigation.onBeforeNavigate.addListener(
+    details => {
+        if (details.frameId !== 0) return;
+        handleOAuthRedirect(details)
+            .then(result => {
+                if (!result) return;
+                broadcastMessageToAllSidePanelInstances({
+                    action: 'broadcastMessageToSidePanel',
+                    payload: { type: 'oauth_signed_in', provider: result.provider },
+                });
+            })
+            .catch(error => {
+                broadcastMessageToAllSidePanelInstances({
+                    action: 'broadcastMessageToSidePanel',
+                    payload: { type: 'oauth_error', message: error?.message || 'Sign-in failed.' },
+                });
+            });
+    },
+    { url: [{ hostEquals: 'localhost' }, { hostEquals: '127.0.0.1' }] }
+);
 
 /** Extension lifecycle hooks. */
 chrome.runtime.onStartup.addListener(() => {

--- a/packages/extension/src/workers/shared/__tests__/providerOAuth.test.js
+++ b/packages/extension/src/workers/shared/__tests__/providerOAuth.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { PROVIDER_BINDINGS, isLoopbackRedirect, buildAuthorizeRequest } from '../providerOAuth.js';
+
+test('PROVIDER_BINDINGS: codex maps to openai, xai maps to grok', () => {
+    assert.equal(PROVIDER_BINDINGS.codex.llmProvider, 'openai');
+    assert.equal(PROVIDER_BINDINGS.xai.llmProvider, 'grok');
+});
+
+test('isLoopbackRedirect: matches origin + path, ignores the query', () => {
+    const redirect = 'http://localhost:1455/auth/callback';
+    assert.equal(isLoopbackRedirect('http://localhost:1455/auth/callback?code=a&state=b', redirect), true);
+    assert.equal(isLoopbackRedirect('http://localhost:1455/auth/callback', redirect), true);
+    assert.equal(isLoopbackRedirect('http://localhost:1456/auth/callback', redirect), false);
+    assert.equal(isLoopbackRedirect('http://localhost:1455/other', redirect), false);
+    assert.equal(isLoopbackRedirect('not a url', redirect), false);
+});
+
+test('buildAuthorizeRequest: Codex authorize URL + pending flow (no discovery)', async () => {
+    const now = 1_700_000_000_000;
+    const { authorizeUrl, pending } = await buildAuthorizeRequest('codex', now);
+
+    const url = new URL(authorizeUrl);
+    assert.equal(`${url.origin}${url.pathname}`, 'https://auth.openai.com/oauth/authorize');
+    assert.equal(url.searchParams.get('client_id'), 'app_EMoamEEZ73f0CkXaXp7hrann');
+    assert.equal(url.searchParams.get('code_challenge_method'), 'S256');
+    assert.equal(url.searchParams.get('originator'), 'codex_cli_rs');
+    assert.equal(url.searchParams.get('redirect_uri'), 'http://localhost:1455/auth/callback');
+    assert.equal(url.searchParams.get('state'), pending.state);
+
+    assert.equal(pending.provider, 'codex');
+    assert.ok(pending.verifier);
+    assert.equal(pending.redirectUri, 'http://localhost:1455/auth/callback');
+    assert.equal(pending.tokenEndpoint, 'https://auth.openai.com/oauth/token');
+    assert.equal(pending.createdAt, now);
+});
+
+test('buildAuthorizeRequest: rejects an unknown provider', async () => {
+    await assert.rejects(buildAuthorizeRequest('nope', 0));
+});

--- a/packages/extension/src/workers/shared/providerOAuth.js
+++ b/packages/extension/src/workers/shared/providerOAuth.js
@@ -175,3 +175,46 @@ export async function handleOAuthRedirect(details) {
     }
     return { provider: binding.llmProvider, credentials };
 }
+
+/**
+ * Manual-paste fallback: exchange a user-pasted authorization code against the in-flight
+ * pending flow. Required for xAI, which delivers the code via a CORS fetch to the loopback
+ * (no browser navigation to capture) and shows the code for manual entry when that fails.
+ * Accepts a bare code, a full redirect URL, or a `?code=…&state=…` query.
+ */
+export async function submitProviderOAuthCode({ provider, code }) {
+    const stored = (await chrome.storage.session.get(PENDING_KEY))[PENDING_KEY];
+    if (!stored || stored.provider !== provider) {
+        throw new Error('No sign-in is in progress. Click Sign in again, then paste the code.');
+    }
+    const parsed = parseCallback(String(code || ''), { host: '127.0.0.1', path: '/callback' });
+    if (parsed.error) {
+        throw new Error(parsed.errorDescription || parsed.error);
+    }
+    if (!parsed.code) {
+        throw new Error("That doesn't look like an authorization code.");
+    }
+    // A pasted full URL/query carries state to validate; a bare code skips it (single-use is
+    // still enforced by consuming the pending flow on success).
+    if (parsed.state && parsed.state !== stored.state) {
+        throw new Error('Sign-in failed: state mismatch.');
+    }
+
+    const binding = PROVIDER_BINDINGS[stored.provider];
+    const cfg = binding.oauth;
+    const payload = await exchangeAuthCode({
+        tokenEndpoint: stored.tokenEndpoint,
+        clientId: cfg.clientId,
+        code: parsed.code,
+        redirectUri: stored.redirectUri,
+        verifier: stored.verifier,
+    });
+    const credentials = credentialsFromTokenPayload(payload, {
+        now: Date.now(),
+        refreshSkewMs: cfg.refreshSkewMs,
+        tokenEndpoint: stored.tokenEndpoint,
+    });
+    await persistCredentials(binding.llmProvider, credentials);
+    await chrome.storage.session.remove(PENDING_KEY);
+    return { provider: binding.llmProvider, credentials };
+}

--- a/packages/extension/src/workers/shared/providerOAuth.js
+++ b/packages/extension/src/workers/shared/providerOAuth.js
@@ -1,0 +1,177 @@
+// Chrome MV3 extension OAuth transport for LLM provider sign-in (Codex / xAI).
+//
+// Flow (event-driven so it survives service-worker suspension):
+//   1. startProviderOAuth: PKCE + authorize URL, store the pending flow in
+//      chrome.storage.session (NOT in-memory — the worker can be killed while the user logs
+//      in), open the consent popup.
+//   2. A top-level chrome.webNavigation listener (registered in background.js, filtered to the
+//      loopback host) wakes the worker on the redirect and calls handleOAuthRedirect, which
+//      validates state single-use, exchanges the code, persists credentials, and swaps the
+//      popup to a branded success page.
+//
+// The pure helpers (PROVIDER_BINDINGS, isLoopbackRedirect, buildAuthorizeRequest) are exported
+// for unit testing; the chrome.* orchestration is kept thin.
+
+import {
+    buildAuthorizeUrl,
+    credentialsFromTokenPayload,
+    exchangeAuthCode,
+    parseCallback,
+    pkcePair,
+    randomToken,
+    xaiDiscovery,
+    CODEX_OAUTH,
+    XAI_OAUTH,
+} from 'shared/oauth';
+import {
+    buildProviderConfigCacheRecord,
+    cacheManager,
+    getLlmProviderConfigCacheKeys,
+    resolveLlmProviderConfigMap,
+} from 'shared/cacheManager';
+import { normalizeProviderConfigMap } from 'shared/llm';
+
+/** Maps a sign-in provider id to its OAuth config + the LLM provider whose config stores the
+ *  resulting credentials (Codex is an auth-mode on `openai`, xAI on `grok`). */
+export const PROVIDER_BINDINGS = {
+    codex: { oauth: CODEX_OAUTH, llmProvider: 'openai' },
+    xai: { oauth: XAI_OAUTH, llmProvider: 'grok' },
+};
+
+const PENDING_KEY = 'oauth_pending_flow';
+const PENDING_TTL_MS = 10 * 60 * 1000;
+
+/** True when `url` is the OAuth loopback redirect for the given pending flow (origin + path
+ *  match, ignoring the query that carries the code/state). */
+export function isLoopbackRedirect(url, redirectUri) {
+    try {
+        const target = new URL(url);
+        const expected = new URL(redirectUri);
+        return target.origin === expected.origin && target.pathname === expected.pathname;
+    } catch {
+        return false;
+    }
+}
+
+async function resolveEndpoints(cfg) {
+    if (cfg.usesDiscovery) {
+        const discovery = await xaiDiscovery();
+        return {
+            authorizeEndpoint: discovery.authorization_endpoint,
+            tokenEndpoint: discovery.token_endpoint,
+        };
+    }
+    return { authorizeEndpoint: cfg.authorizeUrl, tokenEndpoint: cfg.tokenUrl };
+}
+
+/** Build the authorize URL + the pending-flow record for a provider (pure aside from PKCE
+ *  randomness and the xAI discovery fetch). Exported for testing. */
+export async function buildAuthorizeRequest(providerId, now) {
+    const binding = PROVIDER_BINDINGS[providerId];
+    if (!binding) throw new Error(`Unknown OAuth provider: ${providerId}`);
+    const cfg = binding.oauth;
+    const { authorizeEndpoint, tokenEndpoint } = await resolveEndpoints(cfg);
+    const { verifier, challenge } = await pkcePair();
+    const state = randomToken();
+    const nonce = randomToken();
+    const authorizeUrl = buildAuthorizeUrl({
+        authorizeEndpoint,
+        clientId: cfg.clientId,
+        redirectUri: cfg.redirectUri,
+        scope: cfg.scope,
+        challenge,
+        state,
+        nonce,
+        extraParams: cfg.extraAuthParams,
+    });
+    const pending = {
+        provider: providerId,
+        state,
+        verifier,
+        nonce,
+        redirectUri: cfg.redirectUri,
+        tokenEndpoint,
+        createdAt: now,
+    };
+    return { authorizeUrl, pending };
+}
+
+/** Persist refreshed/initial OAuth credentials onto the LLM provider config in the cache. */
+async function persistCredentials(llmProvider, credentials) {
+    const cached = await cacheManager.loadConfig(getLlmProviderConfigCacheKeys());
+    const currentMap = resolveLlmProviderConfigMap(cached);
+    const nextMap = normalizeProviderConfigMap({
+        ...currentMap,
+        [llmProvider]: { ...currentMap[llmProvider], authMode: 'oauth', oauth: credentials },
+    });
+    await cacheManager.saveConfig(buildProviderConfigCacheRecord(nextMap));
+}
+
+/** Begin a provider sign-in: store the pending flow and open the consent popup. */
+export async function startProviderOAuth({ provider }) {
+    const { authorizeUrl, pending } = await buildAuthorizeRequest(provider, Date.now());
+    await chrome.storage.session.set({ [PENDING_KEY]: pending });
+    const win = await chrome.windows.create({
+        url: authorizeUrl,
+        type: 'popup',
+        width: 600,
+        height: 760,
+    });
+    return { started: true, windowId: win?.id, authorizeUrl };
+}
+
+/**
+ * Handle a loopback redirect captured by webNavigation. Returns the signed-in
+ * { provider, credentials } on success, or null when the navigation isn't our callback.
+ * Throws (after clearing the pending flow) on state mismatch, OAuth error, or expiry.
+ */
+export async function handleOAuthRedirect(details) {
+    const stored = (await chrome.storage.session.get(PENDING_KEY))[PENDING_KEY];
+    if (!stored || !isLoopbackRedirect(details.url, stored.redirectUri)) {
+        return null;
+    }
+    // Single-use: consume the pending flow before doing anything else.
+    await chrome.storage.session.remove(PENDING_KEY);
+
+    if (Date.now() - stored.createdAt > PENDING_TTL_MS) {
+        throw new Error('Sign-in timed out. Please try again.');
+    }
+
+    const callback = parseCallback(details.url, { host: '127.0.0.1', path: '/callback' });
+    if (callback.error) {
+        throw new Error(callback.errorDescription || callback.error);
+    }
+    if (callback.state !== stored.state) {
+        throw new Error('Sign-in failed: state mismatch.');
+    }
+    if (!callback.code) {
+        throw new Error('Sign-in failed: no authorization code returned.');
+    }
+
+    const binding = PROVIDER_BINDINGS[stored.provider];
+    const cfg = binding.oauth;
+    const payload = await exchangeAuthCode({
+        tokenEndpoint: stored.tokenEndpoint,
+        clientId: cfg.clientId,
+        code: callback.code,
+        redirectUri: stored.redirectUri,
+        verifier: stored.verifier,
+    });
+    const credentials = credentialsFromTokenPayload(payload, {
+        now: Date.now(),
+        refreshSkewMs: cfg.refreshSkewMs,
+        tokenEndpoint: stored.tokenEndpoint,
+    });
+    await persistCredentials(binding.llmProvider, credentials);
+
+    if (typeof details.tabId === 'number') {
+        try {
+            await chrome.tabs.update(details.tabId, {
+                url: chrome.runtime.getURL('views/oauth-success.html'),
+            });
+        } catch {
+            // Popup may already be gone — the sign-in still succeeded.
+        }
+    }
+    return { provider: binding.llmProvider, credentials };
+}

--- a/packages/lwc/main/agent/Agent/Agent.ts
+++ b/packages/lwc/main/agent/Agent/Agent.ts
@@ -37,13 +37,19 @@ import {
     formatSkillsForPrompt,
     resolveProviderModelInstance,
     resolveProviderOptions,
+    persistRefreshedOAuthCredentials,
     type ProviderInstance,
 } from 'agent/utils';
 import { stepCountIs, streamText, tool as createAiSdkTool } from 'ai';
 import type { ModelMessage, ToolModelMessage, ToolResultPart, ToolSet } from 'ai';
 import { getIndexedDbFileSystem } from 'core/fs';
 import { store, AGENT } from 'core/store';
-import { DEFAULT_LLM_PROVIDER, normalizeLlmProvider, getMaxOutputTokensForModel } from 'shared/llm';
+import {
+    DEFAULT_LLM_PROVIDER,
+    normalizeLlmProvider,
+    getMaxOutputTokensForModel,
+    type OAuthCredentials,
+} from 'shared/llm';
 import LOGGER from 'shared/logger';
 import { guid } from 'shared/utils';
 import { z } from 'zod';
@@ -133,6 +139,8 @@ type AgentSettings = {
     isStoreEnabled?: boolean;
     isInternal?: boolean;
     useResponsesApi?: boolean;
+    authMode?: 'apiKey' | 'oauth';
+    oauth?: OAuthCredentials | null;
     extraTools?: Array<{
         name: string;
         description?: string;
@@ -242,6 +250,7 @@ export class Agent {
     private planContext: string | null = null;
     private isInternal: boolean;
     private useResponsesApi: boolean;
+    private authMode?: 'apiKey' | 'oauth';
     private mcpToolset: McpToolset | null;
     private subagentStatusListeners = new Set<(status: SubagentStatus | null) => void>();
     private _lastContextStats: {
@@ -269,6 +278,7 @@ export class Agent {
         isStoreEnabled,
         isInternal,
         useResponsesApi,
+        authMode,
         mcpToolset,
         store,
     }: {
@@ -287,6 +297,7 @@ export class Agent {
         isStoreEnabled: boolean;
         isInternal?: boolean;
         useResponsesApi?: boolean;
+        authMode?: 'apiKey' | 'oauth';
         mcpToolset?: McpToolset | null;
         store: Store;
     }) {
@@ -305,6 +316,7 @@ export class Agent {
         this.isStoreEnabled = isStoreEnabled;
         this.isInternal = !!isInternal;
         this.useResponsesApi = !!useResponsesApi;
+        this.authMode = authMode;
         this.mcpToolset = mcpToolset || null;
         this.store = store;
     }
@@ -357,6 +369,21 @@ export class Agent {
             apiKey: settings.apiKey,
             baseUrl: settings.baseUrl,
             isInternal: !!settings.isInternal,
+            authMode: settings.authMode,
+            oauth: settings.oauth,
+            onTokenRefresh:
+                settings.authMode === 'oauth'
+                    ? credentials => {
+                          // Fire-and-forget: the in-memory token already keeps this run going;
+                          // persistence just keeps the next run + a rotated refresh token fresh.
+                          persistRefreshedOAuthCredentials(provider, credentials).catch(error => {
+                              LOGGER.warn(
+                                  '[agent:oauth] failed to persist refreshed credentials',
+                                  { error }
+                              );
+                          });
+                      }
+                    : undefined,
         });
         const summaryModel = getSummaryModelForAgentProvider(
             provider,
@@ -380,6 +407,7 @@ export class Agent {
             isStoreEnabled: settings.isStoreEnabled || false,
             isInternal: settings.isInternal,
             useResponsesApi: settings.useResponsesApi,
+            authMode: settings.authMode,
             mcpToolset,
             store: store,
         });
@@ -639,6 +667,7 @@ export class Agent {
                             modelId: this.model,
                             isInternal: this.isInternal,
                             useResponsesApi: this.useResponsesApi,
+                            authMode: this.authMode,
                         }),
                         system: systemText,
                         messages: this.messages,

--- a/packages/lwc/main/agent/aiSettings/aiSettings.html
+++ b/packages/lwc/main/agent/aiSettings/aiSettings.html
@@ -110,7 +110,14 @@
                                     label="Sign out"
                                     variant="destructive-text"
                                     data-provider="codex"
-                                    onclick={handleProviderDisconnect}></lightning-button>
+                                    onclick={handleProviderDisconnect}
+                                    class="slds-m-right_small"></lightning-button>
+                                <lightning-button
+                                    label="Refresh models"
+                                    icon-name="utility:refresh"
+                                    variant="neutral"
+                                    disabled={isRefreshingModels}
+                                    onclick={handleRefreshModels}></lightning-button>
                             </template>
                             <template lwc:else>
                                 <lightning-button
@@ -139,36 +146,20 @@
                                     class="slds-m-top_x-small"></lightning-button>
                             </div>
                         </template>
-                        <template lwc:if={codexConnected}>
-                            <template lwc:if={codexNeedsManualModel}>
-                                <lightning-input
-                                    data-provider="codex"
-                                    label="Model"
-                                    placeholder="e.g. gpt-5.1-codex-mini"
-                                    value={codexCustomModel}
-                                    onchange={handleCustomModelChange}
-                                    variant="label-stacked"
-                                    class="slds-full-width slds-m-top_x-small"></lightning-input>
-                                <p
-                                    class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
-                                    No models returned from your ChatGPT subscription — type a
-                                    model name to use.
-                                </p>
-                            </template>
-                            <template lwc:else>
-                                <p
-                                    class="slds-text-body_small slds-text-color_weak slds-m-top_x-small">
-                                    Models loaded from your ChatGPT subscription — pick one in the
-                                    model selector.
-                                </p>
-                            </template>
-                            <lightning-button
-                                label="Refresh models"
-                                icon-name="utility:refresh"
-                                variant="neutral"
-                                disabled={isRefreshingModels}
-                                onclick={handleRefreshModels}
-                                class="slds-m-top_x-small"></lightning-button>
+                        <template lwc:if={codexNeedsManualModel}>
+                            <lightning-input
+                                data-provider="codex"
+                                label="Model"
+                                placeholder="e.g. gpt-5.1-codex-mini"
+                                value={codexCustomModel}
+                                onchange={handleCustomModelChange}
+                                variant="label-stacked"
+                                class="slds-full-width slds-m-top_x-small"></lightning-input>
+                            <p
+                                class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
+                                No models returned from your ChatGPT subscription — type a model
+                                name to use.
+                            </p>
                         </template>
                     </div>
                 </slds-tab>
@@ -325,7 +316,14 @@
                                     label="Sign out"
                                     variant="destructive-text"
                                     data-provider="xai"
-                                    onclick={handleProviderDisconnect}></lightning-button>
+                                    onclick={handleProviderDisconnect}
+                                    class="slds-m-right_small"></lightning-button>
+                                <lightning-button
+                                    label="Refresh models"
+                                    icon-name="utility:refresh"
+                                    variant="neutral"
+                                    disabled={isRefreshingModels}
+                                    onclick={handleRefreshModels}></lightning-button>
                             </template>
                             <template lwc:else>
                                 <lightning-button
@@ -358,36 +356,20 @@
                                     class="slds-m-top_x-small"></lightning-button>
                             </div>
                         </template>
-                        <template lwc:if={xaiConnected}>
-                            <template lwc:if={xaiNeedsManualModel}>
-                                <lightning-input
-                                    data-provider="xai"
-                                    label="Model"
-                                    placeholder="e.g. grok-4.1-fast-reasoning"
-                                    value={xaiCustomModel}
-                                    onchange={handleCustomModelChange}
-                                    variant="label-stacked"
-                                    class="slds-full-width slds-m-top_x-small"></lightning-input>
-                                <p
-                                    class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
-                                    No models returned from your SuperGrok subscription — type a
-                                    model name to use.
-                                </p>
-                            </template>
-                            <template lwc:else>
-                                <p
-                                    class="slds-text-body_small slds-text-color_weak slds-m-top_x-small">
-                                    Models loaded from your SuperGrok subscription — pick one in the
-                                    model selector.
-                                </p>
-                            </template>
-                            <lightning-button
-                                label="Refresh models"
-                                icon-name="utility:refresh"
-                                variant="neutral"
-                                disabled={isRefreshingModels}
-                                onclick={handleRefreshModels}
-                                class="slds-m-top_x-small"></lightning-button>
+                        <template lwc:if={xaiNeedsManualModel}>
+                            <lightning-input
+                                data-provider="xai"
+                                label="Model"
+                                placeholder="e.g. grok-4.1-fast-reasoning"
+                                value={xaiCustomModel}
+                                onchange={handleCustomModelChange}
+                                variant="label-stacked"
+                                class="slds-full-width slds-m-top_x-small"></lightning-input>
+                            <p
+                                class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
+                                No models returned from your SuperGrok subscription — type a model
+                                name to use.
+                            </p>
                         </template>
                     </div>
                 </slds-tab>

--- a/packages/lwc/main/agent/aiSettings/aiSettings.html
+++ b/packages/lwc/main/agent/aiSettings/aiSettings.html
@@ -121,6 +121,21 @@
                                     onclick={handleProviderSignIn}></lightning-button>
                             </template>
                         </div>
+                        <template lwc:if={codexConnected}>
+                            <lightning-input
+                                data-provider="codex"
+                                label="Model"
+                                placeholder="e.g. gpt-5.1-codex-mini"
+                                value={codexCustomModel}
+                                onchange={handleCustomModelChange}
+                                variant="label-stacked"
+                                class="slds-full-width slds-m-top_x-small"></lightning-input>
+                            <p
+                                class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
+                                Models load from your ChatGPT subscription. Type a model name if
+                                it isn't listed.
+                            </p>
+                        </template>
                     </div>
                 </slds-tab>
                 <slds-tab label="Anthropic" value="anthropic">
@@ -287,6 +302,20 @@
                                     onclick={handleProviderSignIn}></lightning-button>
                             </template>
                         </div>
+                        <template lwc:if={xaiConnected}>
+                            <lightning-input
+                                data-provider="xai"
+                                label="Model"
+                                placeholder="e.g. grok-4.1-fast-reasoning"
+                                value={xaiCustomModel}
+                                onchange={handleCustomModelChange}
+                                variant="label-stacked"
+                                class="slds-full-width slds-m-top_x-small"></lightning-input>
+                            <p
+                                class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
+                                Type a model name if it isn't listed.
+                            </p>
+                        </template>
                     </div>
                 </slds-tab>
             </slds-tabset>

--- a/packages/lwc/main/agent/aiSettings/aiSettings.html
+++ b/packages/lwc/main/agent/aiSettings/aiSettings.html
@@ -135,6 +135,13 @@
                                 Models load from your ChatGPT subscription. Type a model name if
                                 it isn't listed.
                             </p>
+                            <lightning-button
+                                label="Refresh models"
+                                icon-name="utility:refresh"
+                                variant="neutral"
+                                disabled={isRefreshingModels}
+                                onclick={handleRefreshModels}
+                                class="slds-m-top_x-small"></lightning-button>
                         </template>
                     </div>
                 </slds-tab>
@@ -315,6 +322,13 @@
                                 class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
                                 Type a model name if it isn't listed.
                             </p>
+                            <lightning-button
+                                label="Refresh models"
+                                icon-name="utility:refresh"
+                                variant="neutral"
+                                disabled={isRefreshingModels}
+                                onclick={handleRefreshModels}
+                                class="slds-m-top_x-small"></lightning-button>
                         </template>
                     </div>
                 </slds-tab>

--- a/packages/lwc/main/agent/aiSettings/aiSettings.html
+++ b/packages/lwc/main/agent/aiSettings/aiSettings.html
@@ -95,6 +95,33 @@
                                 class="slds-full-width"></lightning-input>
                         </div>
                     </div>
+                    <div class="slds-p-horizontal_small slds-p-bottom_small">
+                        <p
+                            class="slds-text-body_small slds-text-color_weak slds-m-bottom_x-small">
+                            Or sign in with your ChatGPT subscription (Codex) instead of an API
+                            key.
+                        </p>
+                        <div class="slds-grid slds-grid_vertical-align-center">
+                            <template lwc:if={codexConnected}>
+                                <lightning-badge
+                                    label="Connected"
+                                    class="slds-m-right_small"></lightning-badge>
+                                <lightning-button
+                                    label="Sign out"
+                                    variant="destructive-text"
+                                    data-provider="codex"
+                                    onclick={handleProviderDisconnect}></lightning-button>
+                            </template>
+                            <template lwc:else>
+                                <lightning-button
+                                    label="Sign in with ChatGPT (Codex)"
+                                    variant="brand"
+                                    data-provider="codex"
+                                    disabled={isSigningIn}
+                                    onclick={handleProviderSignIn}></lightning-button>
+                            </template>
+                        </div>
+                    </div>
                 </slds-tab>
                 <slds-tab label="Anthropic" value="anthropic">
                     <div class="slds-grid slds-wrap slds-p-around_small">
@@ -233,6 +260,32 @@
                                 value={config.grok_url}
                                 variant="label-stacked"
                                 class="slds-full-width"></lightning-input>
+                        </div>
+                    </div>
+                    <div class="slds-p-horizontal_small slds-p-bottom_small">
+                        <p
+                            class="slds-text-body_small slds-text-color_weak slds-m-bottom_x-small">
+                            Or sign in with your SuperGrok subscription instead of an API key.
+                        </p>
+                        <div class="slds-grid slds-grid_vertical-align-center">
+                            <template lwc:if={xaiConnected}>
+                                <lightning-badge
+                                    label="Connected"
+                                    class="slds-m-right_small"></lightning-badge>
+                                <lightning-button
+                                    label="Sign out"
+                                    variant="destructive-text"
+                                    data-provider="xai"
+                                    onclick={handleProviderDisconnect}></lightning-button>
+                            </template>
+                            <template lwc:else>
+                                <lightning-button
+                                    label="Sign in with xAI"
+                                    variant="brand"
+                                    data-provider="xai"
+                                    disabled={isSigningIn}
+                                    onclick={handleProviderSignIn}></lightning-button>
+                            </template>
                         </div>
                     </div>
                 </slds-tab>

--- a/packages/lwc/main/agent/aiSettings/aiSettings.html
+++ b/packages/lwc/main/agent/aiSettings/aiSettings.html
@@ -121,6 +121,24 @@
                                     onclick={handleProviderSignIn}></lightning-button>
                             </template>
                         </div>
+                        <template lwc:if={showCodexCodeInput}>
+                            <div class="slds-m-top_x-small">
+                                <lightning-input
+                                    label="Authorization code"
+                                    placeholder="Paste the code if the page shows one"
+                                    value={pastedCode}
+                                    onchange={handlePastedCodeChange}
+                                    variant="label-stacked"
+                                    class="slds-full-width"></lightning-input>
+                                <lightning-button
+                                    label="Submit code"
+                                    variant="brand"
+                                    data-provider="codex"
+                                    disabled={isSigningIn}
+                                    onclick={handleSubmitCode}
+                                    class="slds-m-top_x-small"></lightning-button>
+                            </div>
+                        </template>
                         <template lwc:if={codexConnected}>
                             <lightning-input
                                 data-provider="codex"
@@ -309,6 +327,28 @@
                                     onclick={handleProviderSignIn}></lightning-button>
                             </template>
                         </div>
+                        <template lwc:if={showXaiCodeInput}>
+                            <div class="slds-m-top_x-small">
+                                <p
+                                    class="slds-text-body_small slds-text-color_weak slds-m-bottom_xx-small">
+                                    xAI shows a code instead of returning automatically — copy it
+                                    and paste it here.
+                                </p>
+                                <lightning-input
+                                    label="Authorization code"
+                                    value={pastedCode}
+                                    onchange={handlePastedCodeChange}
+                                    variant="label-stacked"
+                                    class="slds-full-width"></lightning-input>
+                                <lightning-button
+                                    label="Submit code"
+                                    variant="brand"
+                                    data-provider="xai"
+                                    disabled={isSigningIn}
+                                    onclick={handleSubmitCode}
+                                    class="slds-m-top_x-small"></lightning-button>
+                            </div>
+                        </template>
                         <template lwc:if={xaiConnected}>
                             <lightning-input
                                 data-provider="xai"

--- a/packages/lwc/main/agent/aiSettings/aiSettings.html
+++ b/packages/lwc/main/agent/aiSettings/aiSettings.html
@@ -140,19 +140,28 @@
                             </div>
                         </template>
                         <template lwc:if={codexConnected}>
-                            <lightning-input
-                                data-provider="codex"
-                                label="Model"
-                                placeholder="e.g. gpt-5.1-codex-mini"
-                                value={codexCustomModel}
-                                onchange={handleCustomModelChange}
-                                variant="label-stacked"
-                                class="slds-full-width slds-m-top_x-small"></lightning-input>
-                            <p
-                                class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
-                                Models load from your ChatGPT subscription. Type a model name if
-                                it isn't listed.
-                            </p>
+                            <template lwc:if={codexNeedsManualModel}>
+                                <lightning-input
+                                    data-provider="codex"
+                                    label="Model"
+                                    placeholder="e.g. gpt-5.1-codex-mini"
+                                    value={codexCustomModel}
+                                    onchange={handleCustomModelChange}
+                                    variant="label-stacked"
+                                    class="slds-full-width slds-m-top_x-small"></lightning-input>
+                                <p
+                                    class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
+                                    No models returned from your ChatGPT subscription — type a
+                                    model name to use.
+                                </p>
+                            </template>
+                            <template lwc:else>
+                                <p
+                                    class="slds-text-body_small slds-text-color_weak slds-m-top_x-small">
+                                    Models loaded from your ChatGPT subscription — pick one in the
+                                    model selector.
+                                </p>
+                            </template>
                             <lightning-button
                                 label="Refresh models"
                                 icon-name="utility:refresh"
@@ -350,18 +359,28 @@
                             </div>
                         </template>
                         <template lwc:if={xaiConnected}>
-                            <lightning-input
-                                data-provider="xai"
-                                label="Model"
-                                placeholder="e.g. grok-4.1-fast-reasoning"
-                                value={xaiCustomModel}
-                                onchange={handleCustomModelChange}
-                                variant="label-stacked"
-                                class="slds-full-width slds-m-top_x-small"></lightning-input>
-                            <p
-                                class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
-                                Type a model name if it isn't listed.
-                            </p>
+                            <template lwc:if={xaiNeedsManualModel}>
+                                <lightning-input
+                                    data-provider="xai"
+                                    label="Model"
+                                    placeholder="e.g. grok-4.1-fast-reasoning"
+                                    value={xaiCustomModel}
+                                    onchange={handleCustomModelChange}
+                                    variant="label-stacked"
+                                    class="slds-full-width slds-m-top_x-small"></lightning-input>
+                                <p
+                                    class="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
+                                    No models returned from your SuperGrok subscription — type a
+                                    model name to use.
+                                </p>
+                            </template>
+                            <template lwc:else>
+                                <p
+                                    class="slds-text-body_small slds-text-color_weak slds-m-top_x-small">
+                                    Models loaded from your SuperGrok subscription — pick one in the
+                                    model selector.
+                                </p>
+                            </template>
                             <lightning-button
                                 label="Refresh models"
                                 icon-name="utility:refresh"

--- a/packages/lwc/main/agent/aiSettings/aiSettings.ts
+++ b/packages/lwc/main/agent/aiSettings/aiSettings.ts
@@ -20,7 +20,6 @@ import LOGGER from 'shared/logger';
 // Subscription sign-in maps a UI provider id to the LLM provider whose config stores the
 // OAuth credentials (Codex is an auth-mode on `openai`, xAI on `grok`).
 const OAUTH_PROVIDER_TO_LLM = { codex: 'openai', xai: 'grok' };
-const OAUTH_PROVIDER_LABELS = { codex: 'ChatGPT (Codex)', xai: 'xAI' };
 
 const INTERNAL_PROVIDER_DOCS_URL = 'https://doc.sf-workbench.com/ai-agent/llm-provider-runtime';
 
@@ -100,12 +99,8 @@ export default class AiSettings extends LightningElement {
                     }
                 });
             });
-            // Success arrives asynchronously via handleOAuthResultMessage once the user
-            // completes consent; keep a gentle hint here.
-            Toast.show({
-                label: `Complete sign-in to ${OAUTH_PROVIDER_LABELS[provider] || provider} in the opened window.`,
-                variant: 'info',
-            });
+            // The popup is the user's cue; completion arrives asynchronously via
+            // handleOAuthResultMessage (which shows the "Signed in" toast + connected state).
         } catch (err) {
             LOGGER.error('Provider OAuth start failed', err);
             Toast.show({ label: `Sign-in failed: ${err.message}`, variant: 'error' });

--- a/packages/lwc/main/agent/aiSettings/aiSettings.ts
+++ b/packages/lwc/main/agent/aiSettings/aiSettings.ts
@@ -35,6 +35,7 @@ export default class AiSettings extends LightningElement {
     @track googleDriveConnected = false;
     @track showOnboardAiProvider = false;
     @track providerConfigs: Partial<LlmProviderConfigMap> = {};
+    @track availableModelsByProvider: Partial<Record<string, unknown[]>> = {};
     @track isSigningIn = false;
     @track isRefreshingModels = false;
     @track signingInProvider: string | null = null;
@@ -48,6 +49,7 @@ export default class AiSettings extends LightningElement {
         this.googleDriveConnected =
             !!session?.token && !!settings[CACHE_CONFIG.GOOGLE_DRIVE_CONNECTED.key];
         this.providerConfigs = application?.providerConfigs || {};
+        this.availableModelsByProvider = application?.availableModelsByProvider || {};
     }
 
     connectedCallback() {
@@ -252,6 +254,24 @@ export default class AiSettings extends LightningElement {
     get xaiConnected() {
         const config = this.providerConfigs?.grok;
         return config?.authMode === 'oauth' && !!config?.oauth?.access;
+    }
+
+    // The live `/models` fetch populated the catalog → the normal model selector covers it, so the
+    // manual Model input is only shown when the fetch returned nothing (the customModel fallback).
+    get codexHasModels() {
+        return (this.availableModelsByProvider?.openai?.length ?? 0) > 0;
+    }
+
+    get xaiHasModels() {
+        return (this.availableModelsByProvider?.grok?.length ?? 0) > 0;
+    }
+
+    get codexNeedsManualModel() {
+        return this.codexConnected && !this.codexHasModels;
+    }
+
+    get xaiNeedsManualModel() {
+        return this.xaiConnected && !this.xaiHasModels;
     }
 
     emitInputChange(key, value) {

--- a/packages/lwc/main/agent/aiSettings/aiSettings.ts
+++ b/packages/lwc/main/agent/aiSettings/aiSettings.ts
@@ -6,11 +6,13 @@ import {
     CACHE_CONFIG,
     buildProviderConfigCacheRecord,
     cacheManager,
+    getAiProviderFromConfig,
     getLlmProviderConfigCacheKeys,
     resolveLlmProviderConfigMap,
     saveSingleExtensionConfigToCache,
 } from 'shared/cacheManager';
 import {
+    fetchLlmModelsEndpoint,
     isInternalProviderBaseUrl,
     normalizeProviderConfigMap,
     type LlmProviderConfigMap,
@@ -74,6 +76,47 @@ export default class AiSettings extends LightningElement {
         const cached = await cacheManager.loadConfig(getLlmProviderConfigCacheKeys());
         const providerConfigs = resolveLlmProviderConfigMap(cached);
         store.dispatch(APPLICATION.reduxSlice.actions.updateProviderConfigs({ providerConfigs }));
+        // Refresh the model catalog so the live Codex/xAI models appear without a reload.
+        try {
+            const response = await fetchLlmModelsEndpoint({
+                provider: getAiProviderFromConfig(cached),
+                providerConfigs,
+            });
+            store.dispatch(
+                APPLICATION.reduxSlice.actions.updateProviderCatalogs({ catalogs: response.catalogs })
+            );
+        } catch (err) {
+            LOGGER.warn('Failed to refresh model catalog after sign-in', err);
+        }
+    }
+
+    handleCustomModelChange = async e => {
+        const provider = e.currentTarget?.dataset?.provider;
+        const llmProvider = OAUTH_PROVIDER_TO_LLM[provider];
+        if (!llmProvider) return;
+        const value = (e.detail?.value ?? '').trim();
+        try {
+            const cached = await cacheManager.loadConfig(getLlmProviderConfigCacheKeys());
+            const currentMap = resolveLlmProviderConfigMap(cached);
+            const nextMap = normalizeProviderConfigMap({
+                ...currentMap,
+                [llmProvider]: { ...currentMap[llmProvider], customModel: value },
+            });
+            await cacheManager.saveConfig(buildProviderConfigCacheRecord(nextMap));
+            store.dispatch(
+                APPLICATION.reduxSlice.actions.updateProviderConfigs({ providerConfigs: nextMap })
+            );
+        } catch (err) {
+            LOGGER.error('Failed to save custom model', err);
+        }
+    };
+
+    get codexCustomModel() {
+        return this.providerConfigs?.openai?.customModel ?? '';
+    }
+
+    get xaiCustomModel() {
+        return this.providerConfigs?.grok?.customModel ?? '';
     }
 
     handleProviderSignIn = async e => {

--- a/packages/lwc/main/agent/aiSettings/aiSettings.ts
+++ b/packages/lwc/main/agent/aiSettings/aiSettings.ts
@@ -36,6 +36,7 @@ export default class AiSettings extends LightningElement {
     @track showOnboardAiProvider = false;
     @track providerConfigs: Partial<LlmProviderConfigMap> = {};
     @track isSigningIn = false;
+    @track isRefreshingModels = false;
 
     @wire(connectStore, { store })
     storeChange({ application }) {
@@ -72,23 +73,44 @@ export default class AiSettings extends LightningElement {
         }
     };
 
+    /** Re-fetch the live model catalog (Codex/xAI included) and push it into the store, so the
+     *  picker reflects provider-side model changes (deprecations / additions) on demand. */
+    async refreshModelCatalog() {
+        const cached = await cacheManager.loadConfig(getLlmProviderConfigCacheKeys());
+        const providerConfigs = resolveLlmProviderConfigMap(cached);
+        const response = await fetchLlmModelsEndpoint({
+            provider: getAiProviderFromConfig(cached),
+            providerConfigs,
+        });
+        store.dispatch(
+            APPLICATION.reduxSlice.actions.updateProviderCatalogs({ catalogs: response.catalogs })
+        );
+    }
+
     async reloadProviderConfigs() {
         const cached = await cacheManager.loadConfig(getLlmProviderConfigCacheKeys());
         const providerConfigs = resolveLlmProviderConfigMap(cached);
         store.dispatch(APPLICATION.reduxSlice.actions.updateProviderConfigs({ providerConfigs }));
         // Refresh the model catalog so the live Codex/xAI models appear without a reload.
         try {
-            const response = await fetchLlmModelsEndpoint({
-                provider: getAiProviderFromConfig(cached),
-                providerConfigs,
-            });
-            store.dispatch(
-                APPLICATION.reduxSlice.actions.updateProviderCatalogs({ catalogs: response.catalogs })
-            );
+            await this.refreshModelCatalog();
         } catch (err) {
             LOGGER.warn('Failed to refresh model catalog after sign-in', err);
         }
     }
+
+    handleRefreshModels = async () => {
+        this.isRefreshingModels = true;
+        try {
+            await this.refreshModelCatalog();
+            Toast.show({ label: 'Models refreshed.', variant: 'success' });
+        } catch (err) {
+            LOGGER.error('Failed to refresh models', err);
+            Toast.show({ label: `Couldn't refresh models: ${err.message}`, variant: 'error' });
+        } finally {
+            this.isRefreshingModels = false;
+        }
+    };
 
     handleCustomModelChange = async e => {
         const provider = e.currentTarget?.dataset?.provider;

--- a/packages/lwc/main/agent/aiSettings/aiSettings.ts
+++ b/packages/lwc/main/agent/aiSettings/aiSettings.ts
@@ -2,9 +2,25 @@ import { GOOGLE_DRIVE_SCOPES } from 'agent/googleAuth';
 import { store, APPLICATION, connectStore } from 'core/store';
 import Toast from 'lightning/toast';
 import { api, LightningElement, track, wire } from 'lwc';
-import { CACHE_CONFIG, saveSingleExtensionConfigToCache } from 'shared/cacheManager';
-import { isInternalProviderBaseUrl } from 'shared/llm';
+import {
+    CACHE_CONFIG,
+    buildProviderConfigCacheRecord,
+    cacheManager,
+    getLlmProviderConfigCacheKeys,
+    resolveLlmProviderConfigMap,
+    saveSingleExtensionConfigToCache,
+} from 'shared/cacheManager';
+import {
+    isInternalProviderBaseUrl,
+    normalizeProviderConfigMap,
+    type LlmProviderConfigMap,
+} from 'shared/llm';
 import LOGGER from 'shared/logger';
+
+// Subscription sign-in maps a UI provider id to the LLM provider whose config stores the
+// OAuth credentials (Codex is an auth-mode on `openai`, xAI on `grok`).
+const OAUTH_PROVIDER_TO_LLM = { codex: 'openai', xai: 'grok' };
+const OAUTH_PROVIDER_LABELS = { codex: 'ChatGPT (Codex)', xai: 'xAI' };
 
 const INTERNAL_PROVIDER_DOCS_URL = 'https://doc.sf-workbench.com/ai-agent/llm-provider-runtime';
 
@@ -17,6 +33,8 @@ export default class AiSettings extends LightningElement {
     @track googleUser = null;
     @track googleDriveConnected = false;
     @track showOnboardAiProvider = false;
+    @track providerConfigs: Partial<LlmProviderConfigMap> = {};
+    @track isSigningIn = false;
 
     @wire(connectStore, { store })
     storeChange({ application }) {
@@ -25,6 +43,107 @@ export default class AiSettings extends LightningElement {
         this.googleUser = session;
         this.googleDriveConnected =
             !!session?.token && !!settings[CACHE_CONFIG.GOOGLE_DRIVE_CONNECTED.key];
+        this.providerConfigs = application?.providerConfigs || {};
+    }
+
+    connectedCallback() {
+        if (typeof chrome !== 'undefined' && chrome?.runtime?.onMessage) {
+            chrome.runtime.onMessage.addListener(this.handleOAuthResultMessage);
+        }
+    }
+
+    disconnectedCallback() {
+        if (typeof chrome !== 'undefined' && chrome?.runtime?.onMessage) {
+            chrome.runtime.onMessage.removeListener(this.handleOAuthResultMessage);
+        }
+    }
+
+    // Completion of an extension OAuth sign-in is delivered by the background worker.
+    handleOAuthResultMessage = message => {
+        if (message?.action !== 'workbench_oauth_result') return;
+        this.isSigningIn = false;
+        if (message.ok) {
+            this.reloadProviderConfigs()
+                .then(() => Toast.show({ label: 'Signed in.', variant: 'success' }))
+                .catch(err => LOGGER.error('Failed to reload provider configs', err));
+        } else {
+            Toast.show({ label: message.message || 'Sign-in failed.', variant: 'error' });
+        }
+    };
+
+    async reloadProviderConfigs() {
+        const cached = await cacheManager.loadConfig(getLlmProviderConfigCacheKeys());
+        const providerConfigs = resolveLlmProviderConfigMap(cached);
+        store.dispatch(APPLICATION.reduxSlice.actions.updateProviderConfigs({ providerConfigs }));
+    }
+
+    handleProviderSignIn = async e => {
+        const provider = e.currentTarget?.dataset?.provider;
+        if (!provider) return;
+        if (typeof chrome === 'undefined' || typeof chrome?.runtime?.sendMessage !== 'function') {
+            Toast.show({
+                label: 'Subscription sign-in is only available in the Chrome extension.',
+                variant: 'error',
+            });
+            return;
+        }
+        this.isSigningIn = true;
+        try {
+            await new Promise((resolve, reject) => {
+                chrome.runtime.sendMessage({ action: 'providerOAuthStart', provider }, response => {
+                    if (chrome.runtime.lastError) {
+                        reject(new Error(chrome.runtime.lastError.message));
+                    } else if (response?.error) {
+                        reject(new Error(response.error));
+                    } else {
+                        resolve(response);
+                    }
+                });
+            });
+            // Success arrives asynchronously via handleOAuthResultMessage once the user
+            // completes consent; keep a gentle hint here.
+            Toast.show({
+                label: `Complete sign-in to ${OAUTH_PROVIDER_LABELS[provider] || provider} in the opened window.`,
+                variant: 'info',
+            });
+        } catch (err) {
+            LOGGER.error('Provider OAuth start failed', err);
+            Toast.show({ label: `Sign-in failed: ${err.message}`, variant: 'error' });
+        } finally {
+            this.isSigningIn = false;
+        }
+    };
+
+    handleProviderDisconnect = async e => {
+        const provider = e.currentTarget?.dataset?.provider;
+        const llmProvider = OAUTH_PROVIDER_TO_LLM[provider];
+        if (!llmProvider) return;
+        try {
+            const cached = await cacheManager.loadConfig(getLlmProviderConfigCacheKeys());
+            const currentMap = resolveLlmProviderConfigMap(cached);
+            const nextMap = normalizeProviderConfigMap({
+                ...currentMap,
+                [llmProvider]: { ...currentMap[llmProvider], authMode: 'apiKey', oauth: null },
+            });
+            await cacheManager.saveConfig(buildProviderConfigCacheRecord(nextMap));
+            store.dispatch(
+                APPLICATION.reduxSlice.actions.updateProviderConfigs({ providerConfigs: nextMap })
+            );
+            Toast.show({ label: 'Signed out.', variant: 'success' });
+        } catch (err) {
+            LOGGER.error('Provider OAuth disconnect failed', err);
+            Toast.show({ label: `Sign-out failed: ${err.message}`, variant: 'error' });
+        }
+    };
+
+    get codexConnected() {
+        const config = this.providerConfigs?.openai;
+        return config?.authMode === 'oauth' && !!config?.oauth?.access;
+    }
+
+    get xaiConnected() {
+        const config = this.providerConfigs?.grok;
+        return config?.authMode === 'oauth' && !!config?.oauth?.access;
     }
 
     emitInputChange(key, value) {

--- a/packages/lwc/main/agent/aiSettings/aiSettings.ts
+++ b/packages/lwc/main/agent/aiSettings/aiSettings.ts
@@ -37,6 +37,8 @@ export default class AiSettings extends LightningElement {
     @track providerConfigs: Partial<LlmProviderConfigMap> = {};
     @track isSigningIn = false;
     @track isRefreshingModels = false;
+    @track signingInProvider: string | null = null;
+    @track pastedCode = '';
 
     @wire(connectStore, { store })
     storeChange({ application }) {
@@ -65,6 +67,8 @@ export default class AiSettings extends LightningElement {
         if (message?.action !== 'workbench_oauth_result') return;
         this.isSigningIn = false;
         if (message.ok) {
+            this.signingInProvider = null;
+            this.pastedCode = '';
             this.reloadProviderConfigs()
                 .then(() => Toast.show({ label: 'Signed in.', variant: 'success' }))
                 .catch(err => LOGGER.error('Failed to reload provider configs', err));
@@ -72,6 +76,47 @@ export default class AiSettings extends LightningElement {
             Toast.show({ label: message.message || 'Sign-in failed.', variant: 'error' });
         }
     };
+
+    handlePastedCodeChange = e => {
+        this.pastedCode = e.detail?.value ?? '';
+    };
+
+    // Manual-paste fallback: some providers (xAI) show the authorization code instead of
+    // returning to the loopback, so the user pastes it here.
+    handleSubmitCode = async e => {
+        const provider = e.currentTarget?.dataset?.provider;
+        const code = (this.pastedCode || '').trim();
+        if (!provider || !code) {
+            Toast.show({ label: 'Paste the authorization code first.', variant: 'error' });
+            return;
+        }
+        this.isSigningIn = true;
+        try {
+            const response = (await new Promise(resolve => {
+                chrome.runtime.sendMessage(
+                    { action: 'providerOAuthSubmitCode', provider, code },
+                    resolve
+                );
+            })) as { error?: string } | undefined;
+            if (response?.error) {
+                Toast.show({ label: `Sign-in failed: ${response.error}`, variant: 'error' });
+            }
+            // Success arrives via handleOAuthResultMessage (broadcast).
+        } catch (err) {
+            LOGGER.error('Provider OAuth code submit failed', err);
+            Toast.show({ label: `Sign-in failed: ${err.message}`, variant: 'error' });
+        } finally {
+            this.isSigningIn = false;
+        }
+    };
+
+    get showCodexCodeInput() {
+        return this.signingInProvider === 'codex';
+    }
+
+    get showXaiCodeInput() {
+        return this.signingInProvider === 'xai';
+    }
 
     /** Re-fetch the live model catalog (Codex/xAI included) and push it into the store, so the
      *  picker reflects provider-side model changes (deprecations / additions) on demand. */
@@ -152,6 +197,8 @@ export default class AiSettings extends LightningElement {
             return;
         }
         this.isSigningIn = true;
+        this.pastedCode = '';
+        this.signingInProvider = provider; // reveal the manual-paste fallback
         try {
             await new Promise((resolve, reject) => {
                 chrome.runtime.sendMessage({ action: 'providerOAuthStart', provider }, response => {
@@ -167,6 +214,7 @@ export default class AiSettings extends LightningElement {
             // The popup is the user's cue; completion arrives asynchronously via
             // handleOAuthResultMessage (which shows the "Signed in" toast + connected state).
         } catch (err) {
+            this.signingInProvider = null;
             LOGGER.error('Provider OAuth start failed', err);
             Toast.show({ label: `Sign-in failed: ${err.message}`, variant: 'error' });
         } finally {

--- a/packages/lwc/main/agent/app/app.ts
+++ b/packages/lwc/main/agent/app/app.ts
@@ -33,6 +33,7 @@ import {
     buildAvailableAgentModelOptions,
     getProviderForModel,
     getProviderLabel,
+    hasUsableProviderCredentials,
     isOpenAiCompatibleGateway,
     normalizeLlmProvider,
 } from 'shared/llm';
@@ -413,6 +414,8 @@ You have full access to the toolkit UI. All navigation and display tools work no
                 apiKey: activeProviderConfig?.apiKey ?? '',
                 baseUrl: activeProviderConfig?.baseUrl,
                 isInternal,
+                authMode: activeProviderConfig?.authMode,
+                oauth: activeProviderConfig?.oauth ?? null,
                 useResponsesApi: activeProviderConfig?.useResponsesApi ?? false,
                 selectedModel:
                     model ||
@@ -590,7 +593,13 @@ You have full access to the toolkit UI. All navigation and display tools work no
         const { settings } = await this.buildAgentExecutionContext(model);
         const activeProvider = normalizeLlmProvider(settings.provider);
         const activeProviderLabel = getProviderLabel(activeProvider);
-        const isProviderConfigured = !isEmpty(settings.apiKey);
+        // OAuth-mode providers are configured via an access token, not an API key.
+        const isProviderConfigured = hasUsableProviderCredentials({
+            apiKey: settings.apiKey || null,
+            baseUrl: settings.baseUrl ?? '',
+            authMode: settings.authMode,
+            oauth: settings.oauth,
+        });
         store.dispatch(AGENT.reduxSlice.actions.updateSelectedModel({ model }));
         store.dispatch(AGENT.reduxSlice.actions.setSelectedReasoning({ reasoning }));
         if (!isProviderConfigured) {

--- a/packages/lwc/main/agent/compaction/compaction.ts
+++ b/packages/lwc/main/agent/compaction/compaction.ts
@@ -1,4 +1,4 @@
-import { generateText, type ModelMessage } from 'ai';
+import { streamText, type ModelMessage } from 'ai';
 
 import { resolveProviderModelInstance, type ProviderInstance } from '../utils/providerRuntime.ts';
 
@@ -575,9 +575,9 @@ async function summarizeConversation(
         request.temperature = 0.2;
     }
 
-    const { text } = await generateText(request);
-
-    return text.trim();
+    // streamText (not generateText): WHAM (Codex) only supports streaming.
+    const result = streamText(request);
+    return (await result.text).trim();
 }
 
 /**

--- a/packages/lwc/main/agent/utils/__tests__/oauthFetch.test.ts
+++ b/packages/lwc/main/agent/utils/__tests__/oauthFetch.test.ts
@@ -96,6 +96,33 @@ test('createOAuthFetch: returns the 401 unchanged when there is no refresh token
     );
 });
 
+test('createOAuthFetch: replaces a pre-existing auth header instead of duplicating it', async () => {
+    // The SDK sets its own Authorization (often lowercased) from apiKey; we must emit exactly
+    // one, else fetch combines them into "Bearer a, Bearer b" and the backend can't parse it.
+    const original = globalThis.fetch;
+    let capturedHeaders: Record<string, string> = {};
+    globalThis.fetch = (async (_url: RequestInfo | URL, options?: RequestInit) => {
+        capturedHeaders = (options?.headers ?? {}) as Record<string, string>;
+        return new Response('', { status: 200 });
+    }) as typeof fetch;
+    try {
+        const fetchImpl = createOAuthFetch({
+            provider: CODEX_OAUTH,
+            credentials: { access: 'the-token', refresh: 'rt', expires: FAR_FUTURE },
+        });
+        await fetchImpl(wham(), {
+            method: 'POST',
+            body: '{}',
+            headers: { authorization: 'Bearer stale-sdk-token' },
+        });
+        const authKeys = Object.keys(capturedHeaders).filter(k => k.toLowerCase() === 'authorization');
+        assert.deepEqual(authKeys, ['Authorization']);
+        assert.equal(capturedHeaders.Authorization, 'Bearer the-token');
+    } finally {
+        globalThis.fetch = original;
+    }
+});
+
 test('createOAuthFetch: concurrent 401s share a single refresh (single-flight)', async () => {
     let apiHits = 0;
     let tokenHits = 0;

--- a/packages/lwc/main/agent/utils/__tests__/oauthFetch.test.ts
+++ b/packages/lwc/main/agent/utils/__tests__/oauthFetch.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { CODEX_OAUTH } from 'shared/oauth';
+
+import { createOAuthFetch } from '../provider/shared/oauthFetch.ts';
+
+const FAR_FUTURE = 4_102_444_800_000; // year 2100 — never proactively expired
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+    });
+}
+
+/** Install a global fetch stub, run `fn`, and restore. Records {url, auth} per call. */
+async function withFetch(
+    handler: (url: string) => Response,
+    fn: (calls: Array<{ url: string; auth?: string }>) => Promise<void>
+): Promise<void> {
+    const original = globalThis.fetch;
+    const calls: Array<{ url: string; auth?: string }> = [];
+    globalThis.fetch = (async (url: RequestInfo | URL, options?: RequestInit) => {
+        const headers = (options?.headers ?? {}) as Record<string, string>;
+        calls.push({ url: String(url), auth: headers.Authorization });
+        return handler(String(url));
+    }) as typeof fetch;
+    try {
+        await fn(calls);
+    } finally {
+        globalThis.fetch = original;
+    }
+}
+
+const wham = (path = '/responses') => `https://chatgpt.com/backend-api/wham${path}`;
+
+test('createOAuthFetch: refreshes once on 401 and retries with the new token', async () => {
+    let apiHits = 0;
+    let tokenHits = 0;
+    await withFetch(
+        url => {
+            if (url === CODEX_OAUTH.tokenUrl) {
+                tokenHits++;
+                return jsonResponse({ access_token: 'fresh', expires_in: 3600 });
+            }
+            apiHits++;
+            return new Response('', { status: apiHits === 1 ? 401 : 200 });
+        },
+        async calls => {
+            const fetchImpl = createOAuthFetch({
+                provider: CODEX_OAUTH,
+                credentials: { access: 'stale', refresh: 'rt', expires: FAR_FUTURE },
+            });
+            const res = await fetchImpl(wham(), { method: 'POST', body: '{}' });
+            assert.equal(res.status, 200);
+            assert.equal(tokenHits, 1);
+            const apiCalls = calls.filter(c => c.url.startsWith(wham()));
+            assert.equal(apiCalls[0].auth, 'Bearer stale');
+            assert.equal(apiCalls[1].auth, 'Bearer fresh');
+        }
+    );
+});
+
+test('createOAuthFetch: proactively refreshes a stale token before the first request', async () => {
+    await withFetch(
+        url =>
+            url === CODEX_OAUTH.tokenUrl
+                ? jsonResponse({ access_token: 'fresh', expires_in: 3600 })
+                : new Response('', { status: 200 }),
+        async calls => {
+            const fetchImpl = createOAuthFetch({
+                provider: CODEX_OAUTH,
+                credentials: { access: 'stale', refresh: 'rt', expires: 0 }, // already expired
+            });
+            await fetchImpl(wham(), { method: 'POST', body: '{}' });
+            const apiCalls = calls.filter(c => c.url.startsWith(wham()));
+            assert.equal(apiCalls[0].auth, 'Bearer fresh');
+        }
+    );
+});
+
+test('createOAuthFetch: returns the 401 unchanged when there is no refresh token', async () => {
+    await withFetch(
+        () => new Response('', { status: 401 }),
+        async calls => {
+            const fetchImpl = createOAuthFetch({
+                provider: CODEX_OAUTH,
+                credentials: { access: 'tok', refresh: '', expires: FAR_FUTURE },
+            });
+            const res = await fetchImpl(wham(), { method: 'POST', body: '{}' });
+            assert.equal(res.status, 401);
+            assert.equal(calls.filter(c => c.url === CODEX_OAUTH.tokenUrl).length, 0);
+            assert.equal(calls.filter(c => c.url.startsWith(wham())).length, 1); // no retry
+        }
+    );
+});
+
+test('createOAuthFetch: concurrent 401s share a single refresh (single-flight)', async () => {
+    let apiHits = 0;
+    let tokenHits = 0;
+    await withFetch(
+        url => {
+            if (url === CODEX_OAUTH.tokenUrl) {
+                tokenHits++;
+                return jsonResponse({ access_token: 'fresh', expires_in: 3600 });
+            }
+            apiHits++;
+            return new Response('', { status: apiHits <= 2 ? 401 : 200 });
+        },
+        async () => {
+            const fetchImpl = createOAuthFetch({
+                provider: CODEX_OAUTH,
+                credentials: { access: 'stale', refresh: 'rt', expires: FAR_FUTURE },
+            });
+            const [a, b] = await Promise.all([
+                fetchImpl(wham(), { method: 'POST', body: '{}' }),
+                fetchImpl(wham(), { method: 'POST', body: '{}' }),
+            ]);
+            assert.equal(a.status, 200);
+            assert.equal(b.status, 200);
+            assert.equal(tokenHits, 1);
+        }
+    );
+});

--- a/packages/lwc/main/agent/utils/__tests__/providerRuntime.test.ts
+++ b/packages/lwc/main/agent/utils/__tests__/providerRuntime.test.ts
@@ -174,6 +174,7 @@ test('codexFormatRequest: injects store:false and lifts the system message into 
         method: 'POST',
         body: JSON.stringify({
             model: 'gpt-5.1-codex',
+            max_output_tokens: 16000,
             input: [
                 { role: 'system', content: [{ type: 'input_text', text: 'You are Codex.' }] },
                 { role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
@@ -183,6 +184,7 @@ test('codexFormatRequest: injects store:false and lifts the system message into 
     const body = JSON.parse(out.options?.body as string);
     assert.equal(body.store, false);
     assert.equal(body.instructions, 'You are Codex.');
+    assert.equal(body.max_output_tokens, undefined); // WHAM rejects it
     assert.equal(body.input.length, 1);
     assert.equal(body.input[0].role, 'user');
 

--- a/packages/lwc/main/agent/utils/__tests__/providerRuntime.test.ts
+++ b/packages/lwc/main/agent/utils/__tests__/providerRuntime.test.ts
@@ -144,6 +144,21 @@ test('resolveProviderModelInstance: openai + oauth resolves a Responses-API mode
     assert.equal(model.provider, 'openai.responses');
 });
 
+test('resolveProviderModelInstance: codex default callable resolves Responses without authMode', () => {
+    // Mirrors the context-compaction path, which resolves the summary model without passing
+    // authMode — the codex instance's default callable must still route to the Responses API.
+    const instance = createProviderInstance({
+        provider: 'openai',
+        authMode: 'oauth',
+        oauth: OAUTH_CREDS,
+    });
+    const model = resolveProviderModelInstance(instance, {
+        provider: 'openai',
+        modelId: 'gpt-5.1-codex',
+    }) as any;
+    assert.equal(model.provider, 'openai.responses');
+});
+
 test('createProviderInstance: grok + oauth returns a callable (bearer = access token)', () => {
     const instance = createProviderInstance({
         provider: 'grok',

--- a/packages/lwc/main/agent/utils/__tests__/providerRuntime.test.ts
+++ b/packages/lwc/main/agent/utils/__tests__/providerRuntime.test.ts
@@ -7,6 +7,14 @@ import {
     createProviderInstance,
     resolveProviderModelInstance,
 } from '../providerRuntime.ts';
+import { codexFormatRequest } from '../provider/codex/runtime.ts';
+
+const OAUTH_CREDS = {
+    access: 'tok',
+    refresh: 'ref',
+    expires: 4_102_444_800_000, // year 2100, comfortably unexpired
+    accountId: 'acct-123',
+};
 
 test('supportsReasoningProvider: true for openai, false for others', () => {
     assert.equal(supportsReasoningProvider('openai'), true);
@@ -111,6 +119,54 @@ test('createProviderInstance: internal Anthropic Bedrock uses Anthropic message 
     }) as any;
 
     assert.equal(model.provider, 'anthropic.messages');
+});
+
+test('createProviderInstance: openai + oauth selects the Codex (WHAM) runtime', () => {
+    const instance = createProviderInstance({
+        provider: 'openai',
+        authMode: 'oauth',
+        oauth: OAUTH_CREDS,
+    });
+    assert.equal(typeof instance, 'function');
+});
+
+test('resolveProviderModelInstance: openai + oauth resolves a Responses-API model', () => {
+    const instance = createProviderInstance({
+        provider: 'openai',
+        authMode: 'oauth',
+        oauth: OAUTH_CREDS,
+    });
+    const model = resolveProviderModelInstance(instance, {
+        provider: 'openai',
+        modelId: 'gpt-5.1-codex',
+        authMode: 'oauth',
+    }) as any;
+    assert.equal(model.provider, 'openai.responses');
+});
+
+test('createProviderInstance: grok + oauth returns a callable (bearer = access token)', () => {
+    const instance = createProviderInstance({
+        provider: 'grok',
+        authMode: 'oauth',
+        oauth: OAUTH_CREDS,
+    });
+    assert.equal(typeof instance, 'function');
+});
+
+test('codexFormatRequest: injects store:false into JSON bodies, leaves others untouched', () => {
+    const out = codexFormatRequest('https://chatgpt.com/backend-api/wham/responses', {
+        method: 'POST',
+        body: JSON.stringify({ model: 'gpt-5.1-codex', input: [] }),
+    });
+    assert.equal(JSON.parse(out.options?.body as string).store, false);
+
+    // An explicit store value is preserved (not overwritten).
+    const kept = codexFormatRequest('x', { body: JSON.stringify({ store: true }) });
+    assert.equal(JSON.parse(kept.options?.body as string).store, true);
+
+    // No body / non-JSON body pass through unchanged.
+    assert.equal(codexFormatRequest('x', { method: 'GET' }).options?.body, undefined);
+    assert.equal(codexFormatRequest('x', { body: 'not-json' }).options?.body, 'not-json');
 });
 
 test('createProviderInstance: internal Anthropic Bedrock targets /invoke-with-response-stream on streaming requests', async () => {

--- a/packages/lwc/main/agent/utils/__tests__/providerRuntime.test.ts
+++ b/packages/lwc/main/agent/utils/__tests__/providerRuntime.test.ts
@@ -168,18 +168,39 @@ test('createProviderInstance: grok + oauth returns a callable (bearer = access t
     assert.equal(typeof instance, 'function');
 });
 
-test('codexFormatRequest: injects store:false into JSON bodies, leaves others untouched', () => {
+test('codexFormatRequest: injects store:false and lifts the system message into instructions', () => {
+    // WHAM requires top-level `instructions`; the SDK puts the system prompt in `input`.
     const out = codexFormatRequest('https://chatgpt.com/backend-api/wham/responses', {
         method: 'POST',
-        body: JSON.stringify({ model: 'gpt-5.1-codex', input: [] }),
+        body: JSON.stringify({
+            model: 'gpt-5.1-codex',
+            input: [
+                { role: 'system', content: [{ type: 'input_text', text: 'You are Codex.' }] },
+                { role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
+            ],
+        }),
     });
-    assert.equal(JSON.parse(out.options?.body as string).store, false);
+    const body = JSON.parse(out.options?.body as string);
+    assert.equal(body.store, false);
+    assert.equal(body.instructions, 'You are Codex.');
+    assert.equal(body.input.length, 1);
+    assert.equal(body.input[0].role, 'user');
 
-    // An explicit store value is preserved (not overwritten).
-    const kept = codexFormatRequest('x', { body: JSON.stringify({ store: true }) });
-    assert.equal(JSON.parse(kept.options?.body as string).store, true);
+    // No system message → instructions defaulted so WHAM doesn't reject the request.
+    const noSystem = JSON.parse(
+        codexFormatRequest('x', {
+            body: JSON.stringify({ input: [{ role: 'user', content: 'hi' }] }),
+        }).options?.body as string
+    );
+    assert.ok(noSystem.instructions);
 
-    // No body / non-JSON body pass through unchanged.
+    // Existing store/instructions preserved; non-JSON / no body pass through.
+    const kept = JSON.parse(
+        codexFormatRequest('x', { body: JSON.stringify({ store: true, instructions: 'keep' }) })
+            .options?.body as string
+    );
+    assert.equal(kept.store, true);
+    assert.equal(kept.instructions, 'keep');
     assert.equal(codexFormatRequest('x', { method: 'GET' }).options?.body, undefined);
     assert.equal(codexFormatRequest('x', { body: 'not-json' }).options?.body, 'not-json');
 });

--- a/packages/lwc/main/agent/utils/generateTitle.ts
+++ b/packages/lwc/main/agent/utils/generateTitle.ts
@@ -1,4 +1,5 @@
 import { generateText } from 'ai';
+import type { OAuthCredentials } from 'shared/llm';
 import LOGGER from 'shared/logger';
 
 import { getSummaryModelForAgentProvider } from './models';
@@ -18,17 +19,32 @@ export async function generateConversationTitle(
         baseUrl?: string;
         isInternal?: boolean;
         selectedModel?: string;
+        authMode?: 'apiKey' | 'oauth';
+        oauth?: OAuthCredentials | null;
     },
     firstMessage: string
 ): Promise<string> {
-    const { provider, apiKey, baseUrl, isInternal = false, selectedModel } = settings;
+    const { provider, apiKey, baseUrl, isInternal = false, selectedModel, authMode, oauth } =
+        settings;
     const modelId = getSummaryModelForAgentProvider(provider, selectedModel, isInternal);
-    const providerInstance = createProviderInstance({ provider, apiKey, baseUrl, isInternal });
+    const providerInstance = createProviderInstance({
+        provider,
+        apiKey,
+        baseUrl,
+        isInternal,
+        authMode,
+        oauth,
+    });
 
     LOGGER.debug('[generateTitle] Generating title with model:', modelId);
 
     const request = {
-        model: resolveProviderModelInstance(providerInstance, { provider, modelId, isInternal }),
+        model: resolveProviderModelInstance(providerInstance, {
+            provider,
+            modelId,
+            isInternal,
+            authMode,
+        }),
         prompt: `${TITLE_PROMPT}${firstMessage}`,
         maxRetries: 0,
         maxOutputTokens: 20,

--- a/packages/lwc/main/agent/utils/generateTitle.ts
+++ b/packages/lwc/main/agent/utils/generateTitle.ts
@@ -1,4 +1,4 @@
-import { generateText } from 'ai';
+import { streamText } from 'ai';
 import type { OAuthCredentials } from 'shared/llm';
 import LOGGER from 'shared/logger';
 
@@ -60,9 +60,10 @@ export async function generateConversationTitle(
         request.temperature = 0.5;
     }
 
-    const { text } = await generateText(request);
-
-    const title = text.trim();
+    // streamText (not generateText): WHAM only supports streaming ("Stream must be set to
+    // true"). For non-streaming providers this still resolves the full text.
+    const result = streamText(request);
+    const title = (await result.text).trim();
     LOGGER.debug('[generateTitle] Generated title:', title);
     return title;
 }

--- a/packages/lwc/main/agent/utils/oauthPersist.ts
+++ b/packages/lwc/main/agent/utils/oauthPersist.ts
@@ -1,0 +1,34 @@
+import { store, APPLICATION } from 'core/store';
+import { buildProviderConfigCacheRecord, cacheManager } from 'shared/cacheManager';
+import {
+    createDefaultProviderConfigMap,
+    normalizeProviderConfigMap,
+    type LlmProvider,
+    type LlmProviderConfigMap,
+    type OAuthCredentials,
+} from 'shared/llm';
+
+/**
+ * Persist OAuth credentials that were refreshed mid-run back into the provider config — both
+ * Redux (so the live session sees the new token) and the cache (so the next run starts fresh
+ * and a rotated refresh token isn't lost). Best-effort: callers fire-and-forget and log on
+ * failure, since the in-memory token already keeps the current run working.
+ */
+export async function persistRefreshedOAuthCredentials(
+    provider: LlmProvider,
+    oauth: OAuthCredentials
+): Promise<void> {
+    const state = store.getState() as {
+        application?: { providerConfigs?: LlmProviderConfigMap };
+    };
+    const currentMap = state.application?.providerConfigs ?? createDefaultProviderConfigMap();
+    const currentConfig = currentMap[provider] ?? createDefaultProviderConfigMap()[provider];
+    const nextMap = normalizeProviderConfigMap({
+        ...currentMap,
+        [provider]: { ...currentConfig, authMode: 'oauth', oauth },
+    });
+    store.dispatch(
+        APPLICATION.reduxSlice.actions.updateProviderConfigs({ providerConfigs: nextMap })
+    );
+    await cacheManager.saveConfig(buildProviderConfigCacheRecord(nextMap));
+}

--- a/packages/lwc/main/agent/utils/provider/codex/runtime.ts
+++ b/packages/lwc/main/agent/utils/provider/codex/runtime.ts
@@ -1,0 +1,66 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import type { LanguageModelV3 } from '@ai-sdk/provider';
+import { CODEX_WHAM_BASE_URL } from 'shared/llm';
+import type {
+    CreateInstanceArgs,
+    ProviderInstance,
+    ProviderRuntime,
+    ResolveModelArgs,
+    ResolveOptionsArgs,
+} from '../types';
+import { createSanitizedFetch, type FormattedRequest } from '../shared/fetch';
+
+// Codex (ChatGPT subscription) runtime. Selected when the `openai` provider is in OAuth
+// mode; targets the WHAM backend, which is Responses-API only and requires `store:false`.
+// Codex is an auth-mode on `openai`, not a separate provider — keeping it as its own runtime
+// (like the internal/bedrock runtimes) isolates the WHAM specifics from the standard openai
+// API path.
+
+/** WHAM is stateless and rejects requests unless `store:false` is sent — inject it into
+ *  every JSON request body that doesn't already set it. Non-JSON bodies (e.g. the GET
+ *  /models request) pass through untouched. Exported for unit testing. */
+export function codexFormatRequest(url: RequestInfo | URL, options?: RequestInit): FormattedRequest {
+    const body = options?.body;
+    if (typeof body === 'string') {
+        try {
+            const payload = JSON.parse(body);
+            if (payload && typeof payload === 'object' && payload.store === undefined) {
+                payload.store = false;
+                return { url, options: { ...options, body: JSON.stringify(payload) } };
+            }
+        } catch {
+            // Leave the body untouched when it isn't JSON.
+        }
+    }
+    return { url, options };
+}
+
+export const codexRuntime: ProviderRuntime = {
+    createInstance({ oauth }: CreateInstanceArgs): ProviderInstance {
+        const headers: Record<string, string> = {};
+        // ChatGPT-Account-Id selects the subscription account; decoded from the JWT at login.
+        if (oauth?.accountId) {
+            headers['ChatGPT-Account-Id'] = oauth.accountId;
+        }
+        return createOpenAI({
+            // The access token is the bearer; the SDK formats `Authorization: Bearer <token>`.
+            apiKey: oauth?.access || '',
+            baseURL: CODEX_WHAM_BASE_URL,
+            headers,
+            fetch: createSanitizedFetch({ formatRequest: codexFormatRequest }),
+        });
+    },
+
+    // WHAM only speaks the Responses API.
+    resolveModel(instance: ProviderInstance, { modelId }: ResolveModelArgs): LanguageModelV3 {
+        return (instance.responses ?? instance)(modelId);
+    },
+
+    resolveOptions({ reasoningConfig }: ResolveOptionsArgs) {
+        return reasoningConfig == null ? undefined : { openai: reasoningConfig };
+    },
+
+    supportsReasoning() {
+        return true;
+    },
+};

--- a/packages/lwc/main/agent/utils/provider/codex/runtime.ts
+++ b/packages/lwc/main/agent/utils/provider/codex/runtime.ts
@@ -1,6 +1,7 @@
 import { createOpenAI } from '@ai-sdk/openai';
 import type { LanguageModelV3 } from '@ai-sdk/provider';
 import { CODEX_WHAM_BASE_URL } from 'shared/llm';
+import { CODEX_OAUTH } from 'shared/oauth';
 import type {
     CreateInstanceArgs,
     ProviderInstance,
@@ -9,6 +10,7 @@ import type {
     ResolveOptionsArgs,
 } from '../types';
 import { createSanitizedFetch, type FormattedRequest } from '../shared/fetch';
+import { createOAuthFetch } from '../shared/oauthFetch';
 
 // Codex (ChatGPT subscription) runtime. Selected when the `openai` provider is in OAuth
 // mode; targets the WHAM backend, which is Responses-API only and requires `store:false`.
@@ -36,22 +38,36 @@ export function codexFormatRequest(url: RequestInfo | URL, options?: RequestInit
 }
 
 export const codexRuntime: ProviderRuntime = {
-    createInstance({ oauth }: CreateInstanceArgs): ProviderInstance {
+    createInstance({ oauth, onTokenRefresh }: CreateInstanceArgs): ProviderInstance {
         const headers: Record<string, string> = {};
         // ChatGPT-Account-Id selects the subscription account; decoded from the JWT at login.
         if (oauth?.accountId) {
             headers['ChatGPT-Account-Id'] = oauth.accountId;
         }
-        return createOpenAI({
-            // The access token is the bearer; the SDK formats `Authorization: Bearer <token>`.
+        const provider = createOpenAI({
+            // The access token seeds the bearer; createOAuthFetch keeps it fresh + injects
+            // the current token on every request and on a 401.
             apiKey: oauth?.access || '',
             baseURL: CODEX_WHAM_BASE_URL,
             headers,
-            fetch: createSanitizedFetch({ formatRequest: codexFormatRequest }),
+            fetch: oauth
+                ? createOAuthFetch({
+                      provider: CODEX_OAUTH,
+                      credentials: oauth,
+                      onTokenRefresh,
+                      formatRequest: codexFormatRequest,
+                  })
+                : createSanitizedFetch({ formatRequest: codexFormatRequest }),
         });
+        // WHAM is Responses-API only — make the *default* callable resolve Responses models so
+        // every consumer routes correctly even when it doesn't pass authMode (e.g. context
+        // compaction resolves the summary model without it).
+        const instance = ((modelId: string) => provider.responses(modelId)) as ProviderInstance;
+        instance.responses = (modelId: string) => provider.responses(modelId);
+        instance.chat = (modelId: string) => provider.chat(modelId);
+        return instance;
     },
 
-    // WHAM only speaks the Responses API.
     resolveModel(instance: ProviderInstance, { modelId }: ResolveModelArgs): LanguageModelV3 {
         return (instance.responses ?? instance)(modelId);
     },

--- a/packages/lwc/main/agent/utils/provider/codex/runtime.ts
+++ b/packages/lwc/main/agent/utils/provider/codex/runtime.ts
@@ -73,6 +73,11 @@ export function codexFormatRequest(url: RequestInfo | URL, options?: RequestInit
         if (instructions) payload.input = rest;
         changed = true;
     }
+    // WHAM rejects `max_output_tokens` ("Unsupported parameter") — the model uses its own cap.
+    if (payload.max_output_tokens !== undefined) {
+        delete payload.max_output_tokens;
+        changed = true;
+    }
     return changed ? { url, options: { ...options, body: JSON.stringify(payload) } } : { url, options };
 }
 

--- a/packages/lwc/main/agent/utils/provider/codex/runtime.ts
+++ b/packages/lwc/main/agent/utils/provider/codex/runtime.ts
@@ -18,23 +18,62 @@ import { createOAuthFetch } from '../shared/oauthFetch';
 // (like the internal/bedrock runtimes) isolates the WHAM specifics from the standard openai
 // API path.
 
-/** WHAM is stateless and rejects requests unless `store:false` is sent — inject it into
- *  every JSON request body that doesn't already set it. Non-JSON bodies (e.g. the GET
- *  /models request) pass through untouched. Exported for unit testing. */
-export function codexFormatRequest(url: RequestInfo | URL, options?: RequestInit): FormattedRequest {
-    const body = options?.body;
-    if (typeof body === 'string') {
-        try {
-            const payload = JSON.parse(body);
-            if (payload && typeof payload === 'object' && payload.store === undefined) {
-                payload.store = false;
-                return { url, options: { ...options, body: JSON.stringify(payload) } };
+/** Pull the system prompt out of the Responses `input` array (the AI SDK puts it there as a
+ *  system/developer item) so it can be sent as WHAM's required top-level `instructions`. */
+function extractInstructionsFromInput(input: unknown): { instructions: string; rest: unknown } {
+    if (!Array.isArray(input)) return { instructions: '', rest: input };
+    const parts: string[] = [];
+    const rest: unknown[] = [];
+    for (const item of input) {
+        const role =
+            item && typeof item === 'object' ? (item as { role?: unknown }).role : undefined;
+        if (role === 'system' || role === 'developer') {
+            const content = (item as { content?: unknown }).content;
+            if (typeof content === 'string') {
+                parts.push(content);
+            } else if (Array.isArray(content)) {
+                for (const part of content) {
+                    const text =
+                        part && typeof part === 'object'
+                            ? (part as { text?: unknown }).text
+                            : undefined;
+                    if (typeof text === 'string') parts.push(text);
+                }
             }
-        } catch {
-            // Leave the body untouched when it isn't JSON.
+        } else {
+            rest.push(item);
         }
     }
-    return { url, options };
+    return { instructions: parts.join('\n\n'), rest };
+}
+
+/** WHAM (a) is stateless and requires `store:false`, and (b) requires a top-level
+ *  `instructions` (system prompt) — but the AI SDK puts the system message inside `input` as a
+ *  system/developer item. Inject `store:false` and lift the system message into `instructions`.
+ *  Non-JSON bodies (e.g. the GET /models request) pass through untouched. Exported for tests. */
+export function codexFormatRequest(url: RequestInfo | URL, options?: RequestInit): FormattedRequest {
+    const body = options?.body;
+    if (typeof body !== 'string') return { url, options };
+    let payload: Record<string, unknown>;
+    try {
+        const parsed = JSON.parse(body);
+        if (!parsed || typeof parsed !== 'object') return { url, options };
+        payload = parsed as Record<string, unknown>;
+    } catch {
+        return { url, options };
+    }
+    let changed = false;
+    if (payload.store === undefined) {
+        payload.store = false;
+        changed = true;
+    }
+    if (!payload.instructions) {
+        const { instructions, rest } = extractInstructionsFromInput(payload.input);
+        payload.instructions = instructions || 'You are a helpful assistant.';
+        if (instructions) payload.input = rest;
+        changed = true;
+    }
+    return changed ? { url, options: { ...options, body: JSON.stringify(payload) } } : { url, options };
 }
 
 export const codexRuntime: ProviderRuntime = {

--- a/packages/lwc/main/agent/utils/provider/grok/runtime.ts
+++ b/packages/lwc/main/agent/utils/provider/grok/runtime.ts
@@ -11,9 +11,12 @@ import { createSanitizedFetch } from '../shared/fetch';
 import { resolveProviderRuntimeBaseUrl } from '../shared/urls';
 
 export const grokRuntime: ProviderRuntime = {
-    createInstance({ apiKey, baseUrl }: CreateInstanceArgs): ProviderInstance {
+    createInstance({ apiKey, baseUrl, authMode, oauth }: CreateInstanceArgs): ProviderInstance {
+        // OAuth (SuperGrok subscription) reuses the same endpoint; the access token simply
+        // replaces the API key as the bearer.
+        const bearer = authMode === 'oauth' ? oauth?.access || '' : apiKey || '';
         return createXai({
-            apiKey: apiKey || '',
+            apiKey: bearer,
             baseURL: resolveProviderRuntimeBaseUrl('grok', baseUrl),
             fetch: createSanitizedFetch(),
         });

--- a/packages/lwc/main/agent/utils/provider/grok/runtime.ts
+++ b/packages/lwc/main/agent/utils/provider/grok/runtime.ts
@@ -7,18 +7,23 @@ import type {
     ResolveModelArgs,
     ResolveOptionsArgs,
 } from '../types';
+import { XAI_OAUTH } from 'shared/oauth';
 import { createSanitizedFetch } from '../shared/fetch';
+import { createOAuthFetch } from '../shared/oauthFetch';
 import { resolveProviderRuntimeBaseUrl } from '../shared/urls';
 
 export const grokRuntime: ProviderRuntime = {
-    createInstance({ apiKey, baseUrl, authMode, oauth }: CreateInstanceArgs): ProviderInstance {
-        // OAuth (SuperGrok subscription) reuses the same endpoint; the access token simply
-        // replaces the API key as the bearer.
-        const bearer = authMode === 'oauth' ? oauth?.access || '' : apiKey || '';
+    createInstance({ apiKey, baseUrl, authMode, oauth, onTokenRefresh }: CreateInstanceArgs): ProviderInstance {
+        // OAuth (SuperGrok subscription) reuses the same endpoint; the access token replaces
+        // the API key as the bearer, and createOAuthFetch keeps it fresh.
+        const isOAuth = authMode === 'oauth' && !!oauth;
         return createXai({
-            apiKey: bearer,
+            apiKey: isOAuth ? oauth?.access || '' : apiKey || '',
             baseURL: resolveProviderRuntimeBaseUrl('grok', baseUrl),
-            fetch: createSanitizedFetch(),
+            fetch:
+                isOAuth && oauth
+                    ? createOAuthFetch({ provider: XAI_OAUTH, credentials: oauth, onTokenRefresh })
+                    : createSanitizedFetch(),
         });
     },
 

--- a/packages/lwc/main/agent/utils/provider/index.ts
+++ b/packages/lwc/main/agent/utils/provider/index.ts
@@ -70,6 +70,7 @@ export function createProviderInstance({
     isInternal = false,
     authMode,
     oauth,
+    onTokenRefresh,
 }: {
     provider: unknown;
     apiKey?: string;
@@ -77,6 +78,7 @@ export function createProviderInstance({
     isInternal?: boolean;
     authMode?: 'apiKey' | 'oauth';
     oauth?: OAuthCredentials | null;
+    onTokenRefresh?: (credentials: OAuthCredentials) => void;
 }): ProviderInstance {
     const normalizedProvider = normalizeLlmProvider(provider);
     const runtime = selectInstanceRuntime({
@@ -85,7 +87,7 @@ export function createProviderInstance({
         isInternal,
         authMode,
     });
-    return runtime.createInstance({ apiKey, baseUrl, isInternal, authMode, oauth });
+    return runtime.createInstance({ apiKey, baseUrl, isInternal, authMode, oauth, onTokenRefresh });
 }
 
 export function resolveProviderModelInstance(

--- a/packages/lwc/main/agent/utils/provider/index.ts
+++ b/packages/lwc/main/agent/utils/provider/index.ts
@@ -1,4 +1,4 @@
-import { normalizeLlmProvider, type LlmProvider } from 'shared/llm';
+import { normalizeLlmProvider, type LlmProvider, type OAuthCredentials } from 'shared/llm';
 import type {
     ProviderInstance,
     ProviderReasoningConfig,
@@ -14,6 +14,7 @@ import { grokRuntime } from './grok/runtime';
 import { mistralRuntime } from './mistral/runtime';
 import { workbenchRuntime } from './workbench/runtime';
 import { internalRuntime } from './internal/runtime';
+import { codexRuntime } from './codex/runtime';
 
 export type { ProviderInstance, ProviderReasoningConfig } from './types';
 
@@ -31,21 +32,27 @@ const PROVIDER_RUNTIMES: Record<LlmProvider, ProviderRuntime> = {
  *
  * Precedence mirrors the original monolithic router exactly:
  *   1. Anthropic + baseUrl ending in `/bedrock` → anthropic runtime (bedrock path).
- *   2. isInternal + gemini → gemini runtime (native Google SDK, internal mode).
- *   3. isInternal → internal runtime (OpenAI SDK routed to `/responses`).
- *   4. Otherwise → the provider's native runtime.
+ *   2. openai + oauth → codex runtime (ChatGPT subscription / WHAM backend).
+ *   3. isInternal + gemini → gemini runtime (native Google SDK, internal mode).
+ *   4. isInternal → internal runtime (OpenAI SDK routed to `/responses`).
+ *   5. Otherwise → the provider's native runtime.
  */
 function selectInstanceRuntime({
     provider,
     baseUrl,
     isInternal,
+    authMode,
 }: {
     provider: LlmProvider;
     baseUrl?: string;
     isInternal?: boolean;
+    authMode?: 'apiKey' | 'oauth';
 }): ProviderRuntime {
     if (isAnthropicBedrockGateway(provider, baseUrl)) {
         return anthropicRuntime;
+    }
+    if (provider === 'openai' && authMode === 'oauth') {
+        return codexRuntime;
     }
     if (isInternal && provider === 'gemini') {
         return geminiRuntime;
@@ -61,19 +68,24 @@ export function createProviderInstance({
     apiKey,
     baseUrl,
     isInternal = false,
+    authMode,
+    oauth,
 }: {
     provider: unknown;
     apiKey?: string;
     baseUrl?: string;
     isInternal?: boolean;
+    authMode?: 'apiKey' | 'oauth';
+    oauth?: OAuthCredentials | null;
 }): ProviderInstance {
     const normalizedProvider = normalizeLlmProvider(provider);
     const runtime = selectInstanceRuntime({
         provider: normalizedProvider,
         baseUrl,
         isInternal,
+        authMode,
     });
-    return runtime.createInstance({ apiKey, baseUrl, isInternal });
+    return runtime.createInstance({ apiKey, baseUrl, isInternal, authMode, oauth });
 }
 
 export function resolveProviderModelInstance(
@@ -83,15 +95,18 @@ export function resolveProviderModelInstance(
         modelId,
         isInternal = false,
         useResponsesApi = false,
+        authMode,
     }: ResolveModelArgs & { provider: unknown }
 ) {
     const normalizedProvider = normalizeLlmProvider(provider);
     // Note: runtime selection here doesn't re-check baseUrl, since the caller already
-    // used it to build `providerInstance`. We only need provider + isInternal to pick
-    // the right call shape (.chat() vs direct call vs .responses()).
+    // used it to build `providerInstance`. We need provider + isInternal + authMode to pick
+    // the right call shape (.chat() vs direct call vs .responses()) — openai + oauth (Codex)
+    // is Responses-only, so authMode must be threaded through here too.
     const runtime = selectInstanceRuntime({
         provider: normalizedProvider,
         isInternal,
+        authMode,
     });
     return runtime.resolveModel(providerInstance, { modelId, isInternal, useResponsesApi });
 }

--- a/packages/lwc/main/agent/utils/provider/shared/oauthFetch.ts
+++ b/packages/lwc/main/agent/utils/provider/shared/oauthFetch.ts
@@ -1,0 +1,91 @@
+import type { OAuthCredentials } from 'shared/llm';
+import { isExpired, refreshCredentials, type OAuthProviderConfig } from 'shared/oauth';
+
+import { createSanitizedFetch, type FormattedRequest } from './fetch';
+
+type FormatRequestFn = (url: RequestInfo | URL, options?: RequestInit) => FormattedRequest;
+
+/** Normalize any HeadersInit to a plain object so `createSanitizedFetch` (which iterates with
+ *  Object.entries) keeps our Authorization override. */
+function toHeaderObject(headers: HeadersInit | undefined): Record<string, string> {
+    if (!headers) return {};
+    if (headers instanceof Headers) {
+        const result: Record<string, string> = {};
+        headers.forEach((value, key) => {
+            result[key] = value;
+        });
+        return result;
+    }
+    if (Array.isArray(headers)) return Object.fromEntries(headers);
+    return { ...(headers as Record<string, string>) };
+}
+
+/**
+ * Build a fetch that keeps an OAuth access token fresh for the life of a provider instance:
+ *
+ *  - Overrides the `Authorization` header with the *current* access token on every request,
+ *    so requests after a refresh use the new token (the SDK only knows the token from
+ *    instance-creation time).
+ *  - Proactively refreshes when the stored token is at/after its (skew-adjusted) expiry.
+ *  - Reactively refreshes once and retries on a `401`.
+ *  - De-duplicates concurrent refreshes via a single in-flight promise (parallel tool calls
+ *    don't stampede the token endpoint).
+ *  - Calls `onTokenRefresh` with the new credentials so the caller can persist them (refresh
+ *    tokens may rotate, so the new one must be stored).
+ *
+ * Refresh failures are swallowed and the original/last response is returned, so the caller
+ * surfaces a normal auth error and can prompt re-authentication.
+ */
+export function createOAuthFetch(opts: {
+    provider: OAuthProviderConfig;
+    credentials: OAuthCredentials;
+    onTokenRefresh?: (credentials: OAuthCredentials) => void;
+    formatRequest?: FormatRequestFn;
+}) {
+    let credentials = opts.credentials;
+    let inflight: Promise<OAuthCredentials> | null = null;
+    const sanitizedFetch = createSanitizedFetch(
+        opts.formatRequest ? { formatRequest: opts.formatRequest } : {}
+    );
+
+    function refresh(): Promise<OAuthCredentials> {
+        if (!inflight) {
+            inflight = refreshCredentials(credentials, opts.provider, { now: Date.now() })
+                .then(next => {
+                    credentials = next;
+                    opts.onTokenRefresh?.(next);
+                    return next;
+                })
+                .finally(() => {
+                    inflight = null;
+                });
+        }
+        return inflight;
+    }
+
+    function withAuth(options: RequestInit | undefined): RequestInit {
+        const headers = toHeaderObject(options?.headers);
+        headers.Authorization = `Bearer ${credentials.access}`;
+        return { ...options, headers };
+    }
+
+    return async (url: RequestInfo | URL, options?: RequestInit): Promise<Response> => {
+        if (credentials.refresh && isExpired(credentials, Date.now())) {
+            try {
+                await refresh();
+            } catch {
+                // Fall through; the request will 401 and surface a re-auth error.
+            }
+        }
+        let response = await sanitizedFetch(url, withAuth(options));
+        if (response.status === 401 && credentials.refresh) {
+            try {
+                await refresh();
+                response = await sanitizedFetch(url, withAuth(options));
+            } catch {
+                // Refresh failed — return the 401 so the caller surfaces re-authentication.
+            }
+        }
+        return response;
+    };
+}

--- a/packages/lwc/main/agent/utils/provider/shared/oauthFetch.ts
+++ b/packages/lwc/main/agent/utils/provider/shared/oauthFetch.ts
@@ -65,6 +65,15 @@ export function createOAuthFetch(opts: {
 
     function withAuth(options: RequestInit | undefined): RequestInit {
         const headers = toHeaderObject(options?.headers);
+        // Drop any existing auth header first. The SDK sets one from `apiKey` (often
+        // lowercased as `authorization`); if we then add `Authorization` too, the request
+        // carries two auth headers that fetch combines into an unparseable
+        // "Bearer x, Bearer y" value — which WHAM rejects with "could not parse your
+        // authentication token". We emit exactly one, with the current (possibly refreshed)
+        // token.
+        for (const key of Object.keys(headers)) {
+            if (key.toLowerCase() === 'authorization') delete headers[key];
+        }
         headers.Authorization = `Bearer ${credentials.access}`;
         return { ...options, headers };
     }

--- a/packages/lwc/main/agent/utils/provider/types.ts
+++ b/packages/lwc/main/agent/utils/provider/types.ts
@@ -23,6 +23,9 @@ export type CreateInstanceArgs = {
     authMode?: 'apiKey' | 'oauth';
     /** Subscription OAuth credentials, used when `authMode === 'oauth'`. */
     oauth?: OAuthCredentials | null;
+    /** Called with the new credentials whenever the runtime refreshes an OAuth token, so the
+     *  caller can persist them (refresh tokens may rotate). */
+    onTokenRefresh?: (credentials: OAuthCredentials) => void;
 };
 
 export type ResolveModelArgs = {

--- a/packages/lwc/main/agent/utils/provider/types.ts
+++ b/packages/lwc/main/agent/utils/provider/types.ts
@@ -1,4 +1,5 @@
 import type { LanguageModelV3 } from '@ai-sdk/provider';
+import type { OAuthCredentials } from 'shared/llm';
 import type { FormattedRequest } from './shared/fetch';
 
 type ModelResolver = (modelId: string) => LanguageModelV3;
@@ -18,12 +19,19 @@ export type CreateInstanceArgs = {
     apiKey?: string;
     baseUrl?: string;
     isInternal?: boolean;
+    /** When 'oauth', the runtime authenticates with `oauth` instead of `apiKey`. */
+    authMode?: 'apiKey' | 'oauth';
+    /** Subscription OAuth credentials, used when `authMode === 'oauth'`. */
+    oauth?: OAuthCredentials | null;
 };
 
 export type ResolveModelArgs = {
     modelId: string;
     isInternal?: boolean;
     useResponsesApi?: boolean;
+    /** Mirrors CreateInstanceArgs so model resolution can pick the same runtime
+     *  (e.g. openai + oauth → the Codex/WHAM runtime, which is Responses-only). */
+    authMode?: 'apiKey' | 'oauth';
 };
 
 export type ResolveOptionsArgs = {

--- a/packages/lwc/main/agent/utils/utils.ts
+++ b/packages/lwc/main/agent/utils/utils.ts
@@ -4,6 +4,7 @@ export * from './generateTitle';
 export * from './models';
 export * from './message';
 export * from './providerRuntime';
+export * from './oauthPersist';
 export * from './skills';
 export * from './runnerHelpers';
 

--- a/packages/lwc/main/tsconfig.json
+++ b/packages/lwc/main/tsconfig.json
@@ -150,6 +150,7 @@
             "illustration/illustration": ["component/illustration/illustration/illustration"],
             "shared/analytics": ["../shared/modules/analytics/analytics"],
             "shared/llm": ["../shared/modules/llm/llm"],
+            "shared/oauth": ["../shared/modules/oauth/oauth"],
             "shared/loader": ["../shared/modules/loader/loader"],
             "shared/markdown": ["../shared/modules/markdown/markdown"],
             "shared/sf": ["../shared/modules/sf/sf"],

--- a/packages/lwc/main/vscode/fullApp/bridge/iframeAiBridgeRuntime.ts
+++ b/packages/lwc/main/vscode/fullApp/bridge/iframeAiBridgeRuntime.ts
@@ -2,6 +2,7 @@
 import {
     createProviderInstance,
     getReasoningConfigFromSelection,
+    persistRefreshedOAuthCredentials,
     resolveProviderModelInstance,
     resolveProviderOptions,
 } from 'agent/utils';
@@ -18,8 +19,10 @@ import {
     getDefaultModelForProvider,
     getProviderModelOptions,
     buildAvailableAgentModelOptions,
+    hasUsableProviderCredentials,
     resolveAgentProviderBaseUrl,
     isOpenAiCompatibleGateway,
+    type OAuthCredentials,
 } from 'shared/llm';
 
 import type {
@@ -39,6 +42,8 @@ type RuntimeConfig = {
     baseUrl?: string;
     systemPrompt?: string;
     reasoning?: string;
+    authMode?: 'apiKey' | 'oauth';
+    oauth?: OAuthCredentials | null;
 };
 
 type FullRuntimeConfig = RuntimeConfig & {
@@ -55,6 +60,8 @@ async function readRuntimeConfig(): Promise<FullRuntimeConfig> {
             provider,
             apiKey: providerConfig?.apiKey || undefined,
             baseUrl: providerConfig?.baseUrl || undefined,
+            authMode: providerConfig?.authMode,
+            oauth: providerConfig?.oauth ?? null,
             providerConfigs,
         };
     } catch {
@@ -88,13 +95,22 @@ async function* streamCompletionViaProvider(
         getDefaultModelForProvider(provider) || 'gpt-4o'
     );
     const reasoning = String(modelConfig.reasoning || storedConfig.reasoning || 'none');
+    const authMode = storedConfig.authMode;
+    const oauth = storedConfig.oauth ?? null;
 
-    if (!apiKey) {
+    if (
+        !hasUsableProviderCredentials({
+            apiKey: apiKey || null,
+            baseUrl: baseUrl ?? '',
+            authMode,
+            oauth,
+        })
+    ) {
         yield {
             type: 'error',
             code: 'ENOCONFIG',
             message:
-                'AI bridge runtime is not configured. Set an API key to enable AI completions.',
+                'AI bridge runtime is not configured. Set an API key or sign in to enable AI completions.',
         };
         yield { type: 'done' };
         return;
@@ -102,7 +118,20 @@ async function* streamCompletionViaProvider(
 
     const isInternal = isOpenAiCompatibleGateway(provider, baseUrl);
     const reasoningConfig = getReasoningConfigFromSelection(reasoning);
-    const providerInstance = createProviderInstance({ provider, apiKey, baseUrl, isInternal });
+    const providerInstance = createProviderInstance({
+        provider,
+        apiKey,
+        baseUrl,
+        isInternal,
+        authMode,
+        oauth,
+        onTokenRefresh:
+            authMode === 'oauth'
+                ? credentials => {
+                      persistRefreshedOAuthCredentials(provider, credentials).catch(() => {});
+                  }
+                : undefined,
+    });
     const systemPrompt = buildSystemPrompt(
         String(modelConfig.systemPrompt || storedConfig.systemPrompt || '')
     );
@@ -239,7 +268,13 @@ async function* buildConfigStream(): AsyncGenerator<IframeAiBridgeChunk> {
                   isDefault: m.value === defaultModel,
               }));
 
-    yield { type: 'ai_config', provider, models, isConfigured: !!storedConfig.apiKey };
+    const isConfigured = hasUsableProviderCredentials({
+        apiKey: storedConfig.apiKey ?? null,
+        baseUrl: storedConfig.baseUrl ?? '',
+        authMode: storedConfig.authMode,
+        oauth: storedConfig.oauth ?? null,
+    });
+    yield { type: 'ai_config', provider, models, isConfigured };
     yield { type: 'done' };
 }
 

--- a/packages/lwc/shared/modules/cacheManager/__tests__/cacheManager.test.ts
+++ b/packages/lwc/shared/modules/cacheManager/__tests__/cacheManager.test.ts
@@ -151,6 +151,31 @@ test('buildProviderConfigCacheRecord: emits canonical + legacy flat keys', () =>
     assert.deepEqual(canonical.openai, { apiKey: 'sk-a', baseUrl: 'https://proxy/v1' });
 });
 
+test('build → resolve round-trip preserves authMode + oauth (data-loss regression)', () => {
+    // Exercises the REAL save (buildProviderConfigCacheRecord) → load
+    // (resolveLlmProviderConfigMap) path, not just normalize, so a regression
+    // in either function that drops the OAuth blob is caught.
+    const map = getDefaultLlmProviderConfigMap();
+    map.openai = {
+        apiKey: null,
+        baseUrl: DEFAULT_PROVIDER_BASE_URLS.openai,
+        authMode: 'oauth',
+        oauth: {
+            access: 'tok',
+            refresh: 'ref',
+            expires: 999,
+            accountId: 'acct',
+            tokenEndpoint: 'https://auth.x.ai/oauth2/token',
+        },
+    };
+    const restored = resolveLlmProviderConfigMap(buildProviderConfigCacheRecord(map));
+    assert.equal(restored.openai.authMode, 'oauth');
+    assert.equal(restored.openai.oauth?.access, 'tok');
+    assert.equal(restored.openai.oauth?.refresh, 'ref');
+    assert.equal(restored.openai.oauth?.accountId, 'acct');
+    assert.equal(restored.openai.oauth?.tokenEndpoint, 'https://auth.x.ai/oauth2/token');
+});
+
 test('getAiProviderFromConfig: picks stored provider if valid, else default', () => {
     assert.equal(getAiProviderFromConfig({ ai_provider: 'anthropic' }), 'anthropic');
     assert.equal(getAiProviderFromConfig({ ai_provider: 'nonsense' }), DEFAULT_LLM_PROVIDER);

--- a/packages/lwc/shared/modules/llm/__tests__/llm.test.ts
+++ b/packages/lwc/shared/modules/llm/__tests__/llm.test.ts
@@ -18,6 +18,8 @@ import {
     getProviderForModel,
     buildAvailableAgentModelOptions,
     fetchCodexModels,
+    resolveCodexClientVersion,
+    CODEX_MODELS_CLIENT_VERSION,
     hasUsableProviderCredentials,
     normalizeOAuthCredentials,
     resolveAgentProviderBaseUrl,
@@ -149,10 +151,7 @@ test('normalizeOAuthCredentials: requires an access token', () => {
 
 test('hasUsableProviderCredentials: oauth mode needs an access token, apiKey mode needs a key', () => {
     assert.equal(hasUsableProviderCredentials(undefined), false);
-    assert.equal(
-        hasUsableProviderCredentials({ apiKey: 'sk', baseUrl: 'x' }),
-        true
-    );
+    assert.equal(hasUsableProviderCredentials({ apiKey: 'sk', baseUrl: 'x' }), true);
     assert.equal(
         hasUsableProviderCredentials({ apiKey: null, baseUrl: 'x', authMode: 'oauth' }),
         false
@@ -305,7 +304,6 @@ test('getMaxOutputTokensForModel: unknown model returns default 8192', () => {
     assert.equal(getMaxOutputTokensForModel(''), 8192);
     assert.equal(getMaxOutputTokensForModel(null), 8192);
 });
-
 
 test('getProviderForModel: exact value match returns provider', () => {
     assert.equal(getProviderForModel('claude-opus-4-6'), 'anthropic');
@@ -473,14 +471,20 @@ test('buildAvailableAgentModelOptions: Codex OAuth uses the live WHAM catalog wh
 test('fetchCodexModels: maps WHAM models[].slug to options with auth headers', async () => {
     const calls: Array<{ url: string; headers: Record<string, string> }> = [];
     const mockFetch = (async (url: string | URL, options?: RequestInit) => {
-        calls.push({ url: String(url), headers: (options?.headers ?? {}) as Record<string, string> });
+        calls.push({
+            url: String(url),
+            headers: (options?.headers ?? {}) as Record<string, string>,
+        });
         return {
             ok: true,
-            json: async () => ({ models: [{ slug: 'gpt-5.1-codex' }, { slug: 'gpt-5.1-codex-mini' }] }),
+            json: async () => ({
+                models: [{ slug: 'gpt-5.1-codex' }, { slug: 'gpt-5.1-codex-mini' }],
+            }),
         } as Response;
     }) as unknown as typeof fetch;
     const models = await fetchCodexModels(
         { access: 'tok', refresh: 'r', expires: 1, accountId: 'acct' },
+        '0.137.0',
         mockFetch
     );
     assert.deepEqual(
@@ -488,20 +492,43 @@ test('fetchCodexModels: maps WHAM models[].slug to options with auth headers', a
         ['gpt-5.1-codex', 'gpt-5.1-codex-mini']
     );
     assert.equal(models[0].provider, 'openai');
-    assert.match(calls[0].url, /backend-api\/wham\/models\?client_version=/);
+    assert.match(calls[0].url, /backend-api\/wham\/models\?client_version=0\.137\.0/);
     assert.equal(calls[0].headers.Authorization, 'Bearer tok');
     assert.equal(calls[0].headers['ChatGPT-Account-Id'], 'acct');
 });
 
 test('fetchCodexModels: falls back to data[].id and is empty without an access token', async () => {
     const mockFetch = (async () =>
-        ({ ok: true, json: async () => ({ data: [{ id: 'm1' }] }) }) as Response) as unknown as typeof fetch;
-    const fromData = await fetchCodexModels({ access: 'tok', refresh: 'r', expires: 1 }, mockFetch);
+        ({
+            ok: true,
+            json: async () => ({ data: [{ id: 'm1' }] }),
+        }) as Response) as unknown as typeof fetch;
+    const fromData = await fetchCodexModels(
+        { access: 'tok', refresh: 'r', expires: 1 },
+        '1.0.0',
+        mockFetch
+    );
     assert.deepEqual(
         fromData.map(m => m.value),
         ['m1']
     );
-    assert.deepEqual(await fetchCodexModels({ access: '', refresh: '', expires: 0 }, mockFetch), []);
+    assert.deepEqual(
+        await fetchCodexModels({ access: '', refresh: '', expires: 0 }, '1.0.0', mockFetch),
+        []
+    );
+});
+
+test('resolveCodexClientVersion: uses latest npm version, falls back to the pinned default', async () => {
+    const ok = (async (url: string | URL) => {
+        assert.match(String(url), /registry\.npmjs\.org\/@openai\/codex\/latest/);
+        return { ok: true, json: async () => ({ version: '0.140.0' }) } as Response;
+    }) as unknown as typeof fetch;
+    assert.equal(await resolveCodexClientVersion(ok), '0.140.0');
+
+    const offline = (async () => {
+        throw new Error('offline');
+    }) as unknown as typeof fetch;
+    assert.equal(await resolveCodexClientVersion(offline), CODEX_MODELS_CLIENT_VERSION);
 });
 
 test('buildAvailableAgentModelOptions: accepts { models } catalog shape', () => {

--- a/packages/lwc/shared/modules/llm/__tests__/llm.test.ts
+++ b/packages/lwc/shared/modules/llm/__tests__/llm.test.ts
@@ -121,7 +121,7 @@ test('normalizeProviderConfig: drops invalid authMode and access-less oauth', ()
     assert.equal(config.oauth, undefined);
 });
 
-test('normalizeProviderConfigMap: round-trips oauth credentials (data-loss regression)', () => {
+test('normalizeProviderConfigMap: is idempotent on oauth credentials', () => {
     const input = {
         openai: {
             apiKey: null,
@@ -130,8 +130,9 @@ test('normalizeProviderConfigMap: round-trips oauth credentials (data-loss regre
             oauth: { access: 'a', refresh: 'b', expires: 999, accountId: 'acct' },
         },
     };
-    // Two passes simulate save (buildProviderConfigCacheRecord) → load
-    // (resolveLlmProviderConfigMap), both of which normalize.
+    // Normalizing an already-normalized map must not drop the oauth blob. The
+    // full save→load round-trip through buildProviderConfigCacheRecord /
+    // resolveLlmProviderConfigMap is covered in cacheManager.test.ts.
     const twice = normalizeProviderConfigMap(normalizeProviderConfigMap(input));
     assert.equal(twice.openai.authMode, 'oauth');
     assert.equal(twice.openai.oauth?.access, 'a');
@@ -303,6 +304,16 @@ test('getMaxOutputTokensForModel: unknown model returns default 8192', () => {
     assert.equal(getMaxOutputTokensForModel('no-such-model'), 8192);
     assert.equal(getMaxOutputTokensForModel(''), 8192);
     assert.equal(getMaxOutputTokensForModel(null), 8192);
+});
+
+test('getMaxOutputTokensForModel: Codex-only slugs resolve their declared limit', () => {
+    // CODEX_MODEL_OPTIONS must be in the default lookup table, otherwise the
+    // codex-only slugs (absent from PROVIDER_MODEL_OPTIONS/INTERNAL) silently
+    // fall back to the 8192 default instead of 16000.
+    for (const model of CODEX_MODEL_OPTIONS) {
+        assert.equal(getMaxOutputTokensForModel(model.value), model.maxOutputTokens);
+    }
+    assert.equal(getMaxOutputTokensForModel('gpt-5.1-codex-mini'), 16000);
 });
 
 test('getProviderForModel: exact value match returns provider', () => {

--- a/packages/lwc/shared/modules/llm/__tests__/llm.test.ts
+++ b/packages/lwc/shared/modules/llm/__tests__/llm.test.ts
@@ -455,6 +455,28 @@ test('buildAvailableAgentModelOptions: openai OAuth (Codex) surfaces Codex slugs
     }
 });
 
+test('buildAvailableAgentModelOptions: Codex OAuth ignores a non-Codex server catalog', () => {
+    const configs = createDefaultProviderConfigMap();
+    configs.openai = {
+        apiKey: null,
+        baseUrl: DEFAULT_PROVIDER_BASE_URLS.openai,
+        authMode: 'oauth',
+        oauth: { access: 'tok', refresh: 'r', expires: 1 },
+    };
+    // The background /api/llm/models refresh supplies the standard OpenAI catalog for the
+    // 'openai' provider; the Codex (WHAM) runtime can't serve those, so they must NOT win.
+    const options = buildAvailableAgentModelOptions({
+        providerConfigs: configs,
+        availableModelsByProvider: {
+            openai: [{ label: 'gpt-4o', value: 'gpt-4o', provider: 'openai' }],
+        },
+    });
+    assert.deepEqual(
+        options.map(o => o.value),
+        CODEX_MODEL_OPTIONS.map(m => m.value)
+    );
+});
+
 test('buildAvailableAgentModelOptions: accepts { models } catalog shape', () => {
     const configs = createDefaultProviderConfigMap();
     configs.openai = { apiKey: 'sk-a', baseUrl: DEFAULT_PROVIDER_BASE_URLS.openai };

--- a/packages/lwc/shared/modules/llm/__tests__/llm.test.ts
+++ b/packages/lwc/shared/modules/llm/__tests__/llm.test.ts
@@ -17,6 +17,8 @@ import {
     getMaxOutputTokensForModel,
     getProviderForModel,
     buildAvailableAgentModelOptions,
+    hasUsableProviderCredentials,
+    normalizeOAuthCredentials,
     resolveAgentProviderBaseUrl,
     DEFAULT_LLM_PROVIDER,
     DEFAULT_PROVIDER_BASE_URLS,
@@ -24,6 +26,7 @@ import {
     LLM_PROVIDERS,
     OPENAI_MODEL_OPTIONS,
     ANTHROPIC_MODEL_OPTIONS,
+    CODEX_MODEL_OPTIONS,
 } from '../llm.ts';
 
 test('isLlmProvider: accepts known providers, rejects anything else', () => {
@@ -81,6 +84,87 @@ test('normalizeProviderConfig: non-object input yields defaults', () => {
     const config = normalizeProviderConfig('gemini', null);
     assert.equal(config.apiKey, null);
     assert.equal(config.baseUrl, DEFAULT_PROVIDER_BASE_URLS.gemini);
+});
+
+test('normalizeProviderConfig: preserves useResponsesApi, authMode and oauth', () => {
+    const config = normalizeProviderConfig('openai', {
+        apiKey: '',
+        baseUrl: '',
+        useResponsesApi: true,
+        authMode: 'oauth',
+        oauth: {
+            access: 'tok',
+            refresh: 'ref',
+            expires: 123,
+            accountId: 'acct',
+            tokenEndpoint: 'https://auth.x.ai/oauth2/token',
+        },
+    });
+    assert.equal(config.apiKey, null);
+    assert.equal(config.useResponsesApi, true);
+    assert.equal(config.authMode, 'oauth');
+    assert.equal(config.oauth?.access, 'tok');
+    assert.equal(config.oauth?.refresh, 'ref');
+    assert.equal(config.oauth?.expires, 123);
+    assert.equal(config.oauth?.accountId, 'acct');
+    assert.equal(config.oauth?.tokenEndpoint, 'https://auth.x.ai/oauth2/token');
+});
+
+test('normalizeProviderConfig: drops invalid authMode and access-less oauth', () => {
+    const config = normalizeProviderConfig('openai', {
+        apiKey: 'sk',
+        baseUrl: 'https://x/v1',
+        authMode: 'bogus',
+        oauth: { refresh: 'ref', expires: 1 },
+    });
+    assert.equal(config.authMode, undefined);
+    assert.equal(config.oauth, undefined);
+});
+
+test('normalizeProviderConfigMap: round-trips oauth credentials (data-loss regression)', () => {
+    const input = {
+        openai: {
+            apiKey: null,
+            baseUrl: DEFAULT_PROVIDER_BASE_URLS.openai,
+            authMode: 'oauth' as const,
+            oauth: { access: 'a', refresh: 'b', expires: 999, accountId: 'acct' },
+        },
+    };
+    // Two passes simulate save (buildProviderConfigCacheRecord) → load
+    // (resolveLlmProviderConfigMap), both of which normalize.
+    const twice = normalizeProviderConfigMap(normalizeProviderConfigMap(input));
+    assert.equal(twice.openai.authMode, 'oauth');
+    assert.equal(twice.openai.oauth?.access, 'a');
+    assert.equal(twice.openai.oauth?.accountId, 'acct');
+});
+
+test('normalizeOAuthCredentials: requires an access token', () => {
+    assert.equal(normalizeOAuthCredentials({ refresh: 'r', expires: 1 }), null);
+    assert.equal(normalizeOAuthCredentials(null), null);
+    const ok = normalizeOAuthCredentials({ access: '  tok  ', refresh: 'r', expires: 5 });
+    assert.equal(ok?.access, 'tok');
+    assert.equal(ok?.tokenType, undefined);
+});
+
+test('hasUsableProviderCredentials: oauth mode needs an access token, apiKey mode needs a key', () => {
+    assert.equal(hasUsableProviderCredentials(undefined), false);
+    assert.equal(
+        hasUsableProviderCredentials({ apiKey: 'sk', baseUrl: 'x' }),
+        true
+    );
+    assert.equal(
+        hasUsableProviderCredentials({ apiKey: null, baseUrl: 'x', authMode: 'oauth' }),
+        false
+    );
+    assert.equal(
+        hasUsableProviderCredentials({
+            apiKey: null,
+            baseUrl: 'x',
+            authMode: 'oauth',
+            oauth: { access: 'tok', refresh: 'r', expires: 1 },
+        }),
+        true
+    );
 });
 
 test('normalizeProviderConfigMap: fills missing providers with defaults, retains overrides', () => {
@@ -339,6 +423,25 @@ test('buildAvailableAgentModelOptions: server-provided catalog overrides default
     });
     assert.equal(options.length, 1);
     assert.equal(options[0].value, 'custom-model');
+});
+
+test('buildAvailableAgentModelOptions: openai OAuth (Codex) surfaces Codex slugs without an apiKey', () => {
+    const configs = createDefaultProviderConfigMap();
+    configs.openai = {
+        apiKey: null,
+        baseUrl: DEFAULT_PROVIDER_BASE_URLS.openai,
+        authMode: 'oauth',
+        oauth: { access: 'tok', refresh: 'r', expires: 1 },
+    };
+    const options = buildAvailableAgentModelOptions({ providerConfigs: configs });
+    assert.ok(options.length > 0);
+    assert.deepEqual(
+        options.map(o => o.value),
+        CODEX_MODEL_OPTIONS.map(m => m.value)
+    );
+    for (const option of options) {
+        assert.equal(option.provider, 'openai');
+    }
 });
 
 test('buildAvailableAgentModelOptions: accepts { models } catalog shape', () => {

--- a/packages/lwc/shared/modules/llm/__tests__/llm.test.ts
+++ b/packages/lwc/shared/modules/llm/__tests__/llm.test.ts
@@ -17,6 +17,7 @@ import {
     getMaxOutputTokensForModel,
     getProviderForModel,
     buildAvailableAgentModelOptions,
+    fetchCodexModels,
     hasUsableProviderCredentials,
     normalizeOAuthCredentials,
     resolveAgentProviderBaseUrl,
@@ -26,7 +27,6 @@ import {
     LLM_PROVIDERS,
     OPENAI_MODEL_OPTIONS,
     ANTHROPIC_MODEL_OPTIONS,
-    CODEX_MODEL_OPTIONS,
 } from '../llm.ts';
 
 test('isLlmProvider: accepts known providers, rejects anything else', () => {
@@ -306,15 +306,6 @@ test('getMaxOutputTokensForModel: unknown model returns default 8192', () => {
     assert.equal(getMaxOutputTokensForModel(null), 8192);
 });
 
-test('getMaxOutputTokensForModel: Codex-only slugs resolve their declared limit', () => {
-    // CODEX_MODEL_OPTIONS must be in the default lookup table, otherwise the
-    // codex-only slugs (absent from PROVIDER_MODEL_OPTIONS/INTERNAL) silently
-    // fall back to the 8192 default instead of 16000.
-    for (const model of CODEX_MODEL_OPTIONS) {
-        assert.equal(getMaxOutputTokensForModel(model.value), model.maxOutputTokens);
-    }
-    assert.equal(getMaxOutputTokensForModel('gpt-5.1-codex-mini'), 16000);
-});
 
 test('getProviderForModel: exact value match returns provider', () => {
     assert.equal(getProviderForModel('claude-opus-4-6'), 'anthropic');
@@ -436,7 +427,7 @@ test('buildAvailableAgentModelOptions: server-provided catalog overrides default
     assert.equal(options[0].value, 'custom-model');
 });
 
-test('buildAvailableAgentModelOptions: openai OAuth (Codex) surfaces Codex slugs without an apiKey', () => {
+test('buildAvailableAgentModelOptions: Codex OAuth is empty without a catalog, surfaces customModel', () => {
     const configs = createDefaultProviderConfigMap();
     configs.openai = {
         apiKey: null,
@@ -444,18 +435,20 @@ test('buildAvailableAgentModelOptions: openai OAuth (Codex) surfaces Codex slugs
         authMode: 'oauth',
         oauth: { access: 'tok', refresh: 'r', expires: 1 },
     };
-    const options = buildAvailableAgentModelOptions({ providerConfigs: configs });
-    assert.ok(options.length > 0);
+    // No hardcoded Codex models: with no live catalog and no manual model, the picker is empty.
+    assert.deepEqual(buildAvailableAgentModelOptions({ providerConfigs: configs }), []);
+
+    // The user-typed customModel is surfaced as a selectable option.
+    configs.openai = { ...configs.openai, customModel: 'gpt-7-codex' };
+    const withCustom = buildAvailableAgentModelOptions({ providerConfigs: configs });
     assert.deepEqual(
-        options.map(o => o.value),
-        CODEX_MODEL_OPTIONS.map(m => m.value)
+        withCustom.map(o => o.value),
+        ['gpt-7-codex']
     );
-    for (const option of options) {
-        assert.equal(option.provider, 'openai');
-    }
+    assert.equal(withCustom[0].provider, 'openai');
 });
 
-test('buildAvailableAgentModelOptions: Codex OAuth ignores a non-Codex server catalog', () => {
+test('buildAvailableAgentModelOptions: Codex OAuth uses the live WHAM catalog when present', () => {
     const configs = createDefaultProviderConfigMap();
     configs.openai = {
         apiKey: null,
@@ -463,18 +456,52 @@ test('buildAvailableAgentModelOptions: Codex OAuth ignores a non-Codex server ca
         authMode: 'oauth',
         oauth: { access: 'tok', refresh: 'r', expires: 1 },
     };
-    // The background /api/llm/models refresh supplies the standard OpenAI catalog for the
-    // 'openai' provider; the Codex (WHAM) runtime can't serve those, so they must NOT win.
+    // For OAuth, fetchLlmModelsEndpoint overrides the openai catalog with the live WHAM list,
+    // so the picker should surface exactly that (not the static seed) once it's available.
     const options = buildAvailableAgentModelOptions({
         providerConfigs: configs,
         availableModelsByProvider: {
-            openai: [{ label: 'gpt-4o', value: 'gpt-4o', provider: 'openai' }],
+            openai: [{ label: 'gpt-5.9-codex', value: 'gpt-5.9-codex', provider: 'openai' }],
         },
     });
     assert.deepEqual(
         options.map(o => o.value),
-        CODEX_MODEL_OPTIONS.map(m => m.value)
+        ['gpt-5.9-codex']
     );
+});
+
+test('fetchCodexModels: maps WHAM models[].slug to options with auth headers', async () => {
+    const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+    const mockFetch = (async (url: string | URL, options?: RequestInit) => {
+        calls.push({ url: String(url), headers: (options?.headers ?? {}) as Record<string, string> });
+        return {
+            ok: true,
+            json: async () => ({ models: [{ slug: 'gpt-5.1-codex' }, { slug: 'gpt-5.1-codex-mini' }] }),
+        } as Response;
+    }) as unknown as typeof fetch;
+    const models = await fetchCodexModels(
+        { access: 'tok', refresh: 'r', expires: 1, accountId: 'acct' },
+        mockFetch
+    );
+    assert.deepEqual(
+        models.map(m => m.value),
+        ['gpt-5.1-codex', 'gpt-5.1-codex-mini']
+    );
+    assert.equal(models[0].provider, 'openai');
+    assert.match(calls[0].url, /backend-api\/wham\/models\?client_version=/);
+    assert.equal(calls[0].headers.Authorization, 'Bearer tok');
+    assert.equal(calls[0].headers['ChatGPT-Account-Id'], 'acct');
+});
+
+test('fetchCodexModels: falls back to data[].id and is empty without an access token', async () => {
+    const mockFetch = (async () =>
+        ({ ok: true, json: async () => ({ data: [{ id: 'm1' }] }) }) as Response) as unknown as typeof fetch;
+    const fromData = await fetchCodexModels({ access: 'tok', refresh: 'r', expires: 1 }, mockFetch);
+    assert.deepEqual(
+        fromData.map(m => m.value),
+        ['m1']
+    );
+    assert.deepEqual(await fetchCodexModels({ access: '', refresh: '', expires: 0 }, mockFetch), []);
 });
 
 test('buildAvailableAgentModelOptions: accepts { models } catalog shape', () => {

--- a/packages/lwc/shared/modules/llm/__tests__/llm.test.ts
+++ b/packages/lwc/shared/modules/llm/__tests__/llm.test.ts
@@ -18,6 +18,7 @@ import {
     getProviderForModel,
     buildAvailableAgentModelOptions,
     fetchCodexModels,
+    fetchXaiModels,
     resolveCodexClientVersion,
     CODEX_MODELS_CLIENT_VERSION,
     hasUsableProviderCredentials,
@@ -515,6 +516,88 @@ test('fetchCodexModels: falls back to data[].id and is empty without an access t
     assert.deepEqual(
         await fetchCodexModels({ access: '', refresh: '', expires: 0 }, '1.0.0', mockFetch),
         []
+    );
+});
+
+test('fetchXaiModels: maps /v1/language-models models[].id with a bearer, dedupes', async () => {
+    const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+    const mockFetch = (async (url: string | URL, options?: RequestInit) => {
+        calls.push({
+            url: String(url),
+            headers: (options?.headers ?? {}) as Record<string, string>,
+        });
+        return {
+            ok: true,
+            json: async () => ({
+                models: [
+                    { id: 'grok-4.1-fast-reasoning' },
+                    { id: 'grok-code-fast-1' },
+                    { id: 'grok-4.1-fast-reasoning' }, // duplicate id is dropped
+                ],
+            }),
+        } as Response;
+    }) as unknown as typeof fetch;
+    const models = await fetchXaiModels(
+        { access: 'xtok', refresh: 'r', expires: 1 },
+        DEFAULT_PROVIDER_BASE_URLS.grok,
+        mockFetch
+    );
+    assert.deepEqual(
+        models.map(m => m.value),
+        ['grok-4.1-fast-reasoning', 'grok-code-fast-1']
+    );
+    assert.equal(models[0].provider, 'grok');
+    assert.match(calls[0].url, /api\.x\.ai\/v1\/language-models$/);
+    assert.equal(calls[0].headers.Authorization, 'Bearer xtok');
+});
+
+test('fetchXaiModels: falls back to data[].id and is empty without an access token', async () => {
+    const mockFetch = (async () =>
+        ({
+            ok: true,
+            json: async () => ({ data: [{ id: 'grok-x' }] }),
+        }) as Response) as unknown as typeof fetch;
+    const fromData = await fetchXaiModels(
+        { access: 'xtok', refresh: 'r', expires: 1 },
+        DEFAULT_PROVIDER_BASE_URLS.grok,
+        mockFetch
+    );
+    assert.deepEqual(
+        fromData.map(m => m.value),
+        ['grok-x']
+    );
+    assert.deepEqual(
+        await fetchXaiModels({ access: '', refresh: '', expires: 0 }, '', mockFetch),
+        []
+    );
+});
+
+test('buildAvailableAgentModelOptions: xAI OAuth uses the live catalog, no hardcoded fallback', () => {
+    const configs = createDefaultProviderConfigMap();
+    configs.grok = {
+        apiKey: null,
+        baseUrl: DEFAULT_PROVIDER_BASE_URLS.grok,
+        authMode: 'oauth',
+        oauth: { access: 'xtok', refresh: 'r', expires: 1 },
+    };
+    // No live catalog → empty (NOT the static GROK_MODEL_OPTIONS), surfaces customModel instead.
+    assert.deepEqual(buildAvailableAgentModelOptions({ providerConfigs: configs }), []);
+    configs.grok = { ...configs.grok, customModel: 'grok-custom' };
+    assert.deepEqual(
+        buildAvailableAgentModelOptions({ providerConfigs: configs }).map(o => o.value),
+        ['grok-custom']
+    );
+
+    // With a live catalog, the picker surfaces exactly that list.
+    const withCatalog = buildAvailableAgentModelOptions({
+        providerConfigs: configs,
+        availableModelsByProvider: {
+            grok: [{ label: 'grok-4.3-latest', value: 'grok-4.3-latest', provider: 'grok' }],
+        },
+    });
+    assert.deepEqual(
+        withCatalog.map(o => o.value),
+        ['grok-4.3-latest', 'grok-custom']
     );
 });
 

--- a/packages/lwc/shared/modules/llm/constants.ts
+++ b/packages/lwc/shared/modules/llm/constants.ts
@@ -9,6 +9,24 @@ export const LLM_PROVIDERS = [
 
 export type LlmProvider = (typeof LLM_PROVIDERS)[number];
 
+/** Credentials obtained from a provider's subscription OAuth login. Stored on the
+ *  per-provider config alongside (and mutually exclusive with) an API key. The
+ *  storage trust model is identical to the existing `apiKey` field. */
+export type OAuthCredentials = {
+    /** OAuth access token; used as the bearer for provider API calls. */
+    access: string;
+    /** OAuth refresh token; used to mint a fresh access token. */
+    refresh: string;
+    /** Access-token expiry as epoch milliseconds. */
+    expires: number;
+    /** Codex only: the `ChatGPT-Account-Id` header value, decoded from the JWT. */
+    accountId?: string;
+    /** xAI only: the token endpoint resolved from OIDC discovery (for refresh). */
+    tokenEndpoint?: string;
+    /** Token type from the token response; defaults to `Bearer`. */
+    tokenType?: string;
+};
+
 export type LlmProviderConfig = {
     apiKey: string | null;
     baseUrl: string;
@@ -17,6 +35,11 @@ export type LlmProviderConfig = {
      *  (e.g. LiteLLM) routes to OpenAI's Responses API endpoint, which
      *  requires tools with a flat `name` field rather than nested `function.name`. */
     useResponsesApi?: boolean;
+    /** How this provider authenticates. `apiKey` (default) uses `apiKey`;
+     *  `oauth` uses the `oauth` credentials below (subscription sign-in). */
+    authMode?: 'apiKey' | 'oauth';
+    /** Subscription OAuth credentials, when `authMode === 'oauth'`. */
+    oauth?: OAuthCredentials | null;
 };
 
 export type LlmProviderConfigMap = Record<LlmProvider, LlmProviderConfig>;
@@ -60,6 +83,12 @@ export const DEFAULT_PROVIDER_BASE_URLS = {
     workbench: '/openai/v1',
 } satisfies Record<LlmProvider, string>;
 
+/** OpenAI ChatGPT (Codex) subscription backend, used when the `openai` provider is in
+ *  OAuth mode. This is the WHAM endpoint the Codex CLI talks to — Responses-API only,
+ *  with `store:false` and a `ChatGPT-Account-Id` header. Kept as a single constant so a
+ *  future provider-side change is a one-line edit (see roadmap compatibility note). */
+export const CODEX_WHAM_BASE_URL = 'https://chatgpt.com/backend-api/wham';
+
 export const INTERNAL_PROVIDER_BASE_URLS = {
     openai: 'https://eng-ai-model-gateway.sfproxy.devx-preprod.aws-esvc1-useast2.aws.sfdc.cl/v1',
     anthropic:
@@ -90,6 +119,22 @@ export const OPENAI_MODEL_OPTIONS: LlmModelOption[] = [
     { label: 'gpt-5.4', value: 'gpt-5.4', provider: 'openai', maxOutputTokens: 16000 },
     { label: 'gpt-5.4-mini', value: 'gpt-5.4-mini', provider: 'openai', maxOutputTokens: 16000 },
     { label: 'gpt-5.4-nano', value: 'gpt-5.4-nano', provider: 'openai', maxOutputTokens: 16000 },
+];
+
+/** Models surfaced when the `openai` provider is in OAuth (Codex) mode. These are the
+ *  WHAM slugs reachable with a ChatGPT subscription token; the catalog may also be
+ *  refreshed live from WHAM `/models` (slug-based). Provider stays `openai` because Codex
+ *  is an auth-mode on `openai`, not a separate provider. */
+export const CODEX_MODEL_OPTIONS: LlmModelOption[] = [
+    { label: 'gpt-5.1-codex', value: 'gpt-5.1-codex', provider: 'openai', maxOutputTokens: 16000 },
+    {
+        label: 'gpt-5.1-codex-mini',
+        value: 'gpt-5.1-codex-mini',
+        provider: 'openai',
+        maxOutputTokens: 16000,
+    },
+    { label: 'gpt-5.2-codex', value: 'gpt-5.2-codex', provider: 'openai', maxOutputTokens: 16000 },
+    { label: 'gpt-5.3-codex', value: 'gpt-5.3-codex', provider: 'openai', maxOutputTokens: 16000 },
 ];
 
 export const INTERNAL_MODEL_OPTIONS: LlmModelOption[] = [

--- a/packages/lwc/shared/modules/llm/constants.ts
+++ b/packages/lwc/shared/modules/llm/constants.ts
@@ -40,6 +40,10 @@ export type LlmProviderConfig = {
     authMode?: 'apiKey' | 'oauth';
     /** Subscription OAuth credentials, when `authMode === 'oauth'`. */
     oauth?: OAuthCredentials | null;
+    /** A user-typed model slug, surfaced as a selectable option. The escape hatch for
+     *  Codex/OAuth, where the available models change per account/plan and over time — so the
+     *  picker shows the live `/models` list and lets the user type anything it's missing. */
+    customModel?: string;
 };
 
 export type LlmProviderConfigMap = Record<LlmProvider, LlmProviderConfig>;
@@ -89,6 +93,11 @@ export const DEFAULT_PROVIDER_BASE_URLS = {
  *  future provider-side change is a one-line edit (see roadmap compatibility note). */
 export const CODEX_WHAM_BASE_URL = 'https://chatgpt.com/backend-api/wham';
 
+/** `client_version` query param required by the WHAM `/models` endpoint. The available model
+ *  list is per-account/plan and changes over time, so the picker fetches it live rather than
+ *  relying on a hardcoded list. Isolated here so it's a one-line update if WHAM tightens it. */
+export const CODEX_MODELS_CLIENT_VERSION = '0.0.1';
+
 export const INTERNAL_PROVIDER_BASE_URLS = {
     openai: 'https://eng-ai-model-gateway.sfproxy.devx-preprod.aws-esvc1-useast2.aws.sfdc.cl/v1',
     anthropic:
@@ -121,22 +130,9 @@ export const OPENAI_MODEL_OPTIONS: LlmModelOption[] = [
     { label: 'gpt-5.4-nano', value: 'gpt-5.4-nano', provider: 'openai', maxOutputTokens: 16000 },
 ];
 
-/** Default models surfaced when the `openai` provider is in OAuth (Codex) mode. These are
- *  the WHAM slugs a ChatGPT subscription can run today (newer slugs like gpt-5.2/5.3-codex
- *  are rejected for ChatGPT accounts with "model is not supported when using Codex with a
- *  ChatGPT account"). The authoritative list is per-account/plan and comes from a live WHAM
- *  `/models` fetch (a follow-up); this seed keeps the picker usable until then. `gpt-5.1-codex-mini`
- *  is first as the safe default. Provider stays `openai` because Codex is an auth-mode on
- *  `openai`, not a separate provider. */
-export const CODEX_MODEL_OPTIONS: LlmModelOption[] = [
-    {
-        label: 'gpt-5.1-codex-mini',
-        value: 'gpt-5.1-codex-mini',
-        provider: 'openai',
-        maxOutputTokens: 16000,
-    },
-    { label: 'gpt-5.1-codex', value: 'gpt-5.1-codex', provider: 'openai', maxOutputTokens: 16000 },
-];
+// Codex (OAuth) models are NOT hardcoded — the available set is per-account/plan and changes
+// often, so the picker is sourced from the live WHAM `/models` fetch (see fetchCodexModels),
+// with a user-typed `customModel` as the manual fallback.
 
 export const INTERNAL_MODEL_OPTIONS: LlmModelOption[] = [
     { label: 'gpt-4o', value: 'gpt-4o', provider: 'openai', maxOutputTokens: 16000 },

--- a/packages/lwc/shared/modules/llm/constants.ts
+++ b/packages/lwc/shared/modules/llm/constants.ts
@@ -121,20 +121,21 @@ export const OPENAI_MODEL_OPTIONS: LlmModelOption[] = [
     { label: 'gpt-5.4-nano', value: 'gpt-5.4-nano', provider: 'openai', maxOutputTokens: 16000 },
 ];
 
-/** Models surfaced when the `openai` provider is in OAuth (Codex) mode. These are the
- *  WHAM slugs reachable with a ChatGPT subscription token; the catalog may also be
- *  refreshed live from WHAM `/models` (slug-based). Provider stays `openai` because Codex
- *  is an auth-mode on `openai`, not a separate provider. */
+/** Default models surfaced when the `openai` provider is in OAuth (Codex) mode. These are
+ *  the WHAM slugs a ChatGPT subscription can run today (newer slugs like gpt-5.2/5.3-codex
+ *  are rejected for ChatGPT accounts with "model is not supported when using Codex with a
+ *  ChatGPT account"). The authoritative list is per-account/plan and comes from a live WHAM
+ *  `/models` fetch (a follow-up); this seed keeps the picker usable until then. `gpt-5.1-codex-mini`
+ *  is first as the safe default. Provider stays `openai` because Codex is an auth-mode on
+ *  `openai`, not a separate provider. */
 export const CODEX_MODEL_OPTIONS: LlmModelOption[] = [
-    { label: 'gpt-5.1-codex', value: 'gpt-5.1-codex', provider: 'openai', maxOutputTokens: 16000 },
     {
         label: 'gpt-5.1-codex-mini',
         value: 'gpt-5.1-codex-mini',
         provider: 'openai',
         maxOutputTokens: 16000,
     },
-    { label: 'gpt-5.2-codex', value: 'gpt-5.2-codex', provider: 'openai', maxOutputTokens: 16000 },
-    { label: 'gpt-5.3-codex', value: 'gpt-5.3-codex', provider: 'openai', maxOutputTokens: 16000 },
+    { label: 'gpt-5.1-codex', value: 'gpt-5.1-codex', provider: 'openai', maxOutputTokens: 16000 },
 ];
 
 export const INTERNAL_MODEL_OPTIONS: LlmModelOption[] = [

--- a/packages/lwc/shared/modules/llm/constants.ts
+++ b/packages/lwc/shared/modules/llm/constants.ts
@@ -93,10 +93,10 @@ export const DEFAULT_PROVIDER_BASE_URLS = {
  *  future provider-side change is a one-line edit (see roadmap compatibility note). */
 export const CODEX_WHAM_BASE_URL = 'https://chatgpt.com/backend-api/wham';
 
-/** `client_version` query param required by the WHAM `/models` endpoint. The available model
- *  list is per-account/plan and changes over time, so the picker fetches it live rather than
- *  relying on a hardcoded list. Isolated here so it's a one-line update if WHAM tightens it. */
-export const CODEX_MODELS_CLIENT_VERSION = '0.0.1';
+/** `client_version` query param required by the WHAM `/models` endpoint. WHAM gates the model
+ *  list by client version — an old value (e.g. 0.0.1) returns an empty list — so this tracks a
+ *  current Codex CLI version. Isolated here so it's a one-line bump when OpenAI moves forward. */
+export const CODEX_MODELS_CLIENT_VERSION = '0.137.0';
 
 export const INTERNAL_PROVIDER_BASE_URLS = {
     openai: 'https://eng-ai-model-gateway.sfproxy.devx-preprod.aws-esvc1-useast2.aws.sfdc.cl/v1',

--- a/packages/lwc/shared/modules/llm/llm.ts
+++ b/packages/lwc/shared/modules/llm/llm.ts
@@ -281,12 +281,13 @@ export function buildAvailableAgentModelOptions({
         const config = normalizedConfigs[provider];
         const serverModels = extractModels(availableModelsByProvider, provider);
         const isProviderInternal = isInternalProviderBaseUrl(config.baseUrl);
-        // `openai` in OAuth mode is Codex (WHAM): use the live WHAM `/models` catalog
-        // (fetchLlmModelsEndpoint fetches it client-side for OAuth and overrides the openai
-        // catalog) — there is no hardcoded Codex list. Other providers keep their existing
-        // server/internal/static resolution.
-        const isCodexOAuth = provider === 'openai' && config.authMode === 'oauth';
-        let models = isCodexOAuth
+        // Subscription OAuth (openai→Codex/WHAM, grok→SuperGrok): the live `/models` catalog is
+        // fetched client-side by fetchLlmModelsEndpoint and overrides the provider catalog — there
+        // is no hardcoded list, so an empty fetch falls through to the user-typed customModel
+        // rather than a stale static seed. Other providers keep server/internal/static resolution.
+        const isSubscriptionOAuth =
+            config.authMode === 'oauth' && (provider === 'openai' || provider === 'grok');
+        let models = isSubscriptionOAuth
             ? serverModels
             : serverModels.length > 0
               ? serverModels
@@ -365,51 +366,126 @@ export async function resolveCodexClientVersion(fetchImpl: typeof fetch = fetch)
     return CODEX_MODELS_CLIENT_VERSION;
 }
 
-/** Fetch the live Codex (WHAM) model list for an OAuth-authenticated openai config. WHAM's
- *  `/models` returns `{ models: [{ slug }] }` (slug-based, client_version required); falls back
- *  to the standard `{ data: [{ id }] }` shape. Returns [] on any failure so the picker degrades
- *  to the user-typed customModel. Works from the extension (host permissions); the hosted web
- *  app would need a server-side proxy (a documented follow-up). */
-export async function fetchCodexModels(
-    oauth: OAuthCredentials,
-    clientVersion: string,
-    fetchImpl: typeof fetch = fetch
-): Promise<LlmModelOption[]> {
-    if (!oauth?.access) return [];
-    const headers: Record<string, string> = {
-        Authorization: `Bearer ${oauth.access}`,
-        Accept: 'application/json',
-    };
-    if (oauth.accountId) headers['ChatGPT-Account-Id'] = oauth.accountId;
-    const url = `${CODEX_WHAM_BASE_URL}/models?client_version=${encodeURIComponent(clientVersion)}`;
-    const response = await fetchImpl(url, { headers });
-    if (!response.ok) {
-        throw new Error(`Codex /models request failed with status ${response.status}.`);
-    }
-    const data = (await response.json()) as { models?: unknown; data?: unknown };
+const SUBSCRIPTION_MODEL_MAX_OUTPUT_TOKENS = 16000;
+
+/** Parse an OpenAI-compatible model-listing response into picker options. Handles every list
+ *  shape the subscription backends return: `{ data: [{ id }] }` (OpenAI / xAI `/v1/models`),
+ *  `{ models: [{ slug }] }` (Codex WHAM), and `{ models: [{ id }] }` (xAI `/v1/language-models`).
+ *  Dedupes by id so aliased/overlapping lists don't repeat. */
+function parseModelCatalogResponse(data: unknown, provider: LlmProvider): LlmModelOption[] {
+    if (!isRecord(data)) return [];
     const rawList = Array.isArray(data.models)
         ? data.models
         : Array.isArray(data.data)
           ? data.data
           : [];
     const options: LlmModelOption[] = [];
+    const seen = new Set<string>();
     for (const entry of rawList) {
         if (!isRecord(entry)) continue;
-        const slug =
+        const id =
             typeof entry.slug === 'string'
                 ? entry.slug
                 : typeof entry.id === 'string'
                   ? entry.id
                   : '';
-        if (slug) {
-            options.push({ label: slug, value: slug, provider: 'openai', maxOutputTokens: 16000 });
+        if (id && !seen.has(id)) {
+            seen.add(id);
+            options.push({
+                label: id,
+                value: id,
+                provider,
+                maxOutputTokens: SUBSCRIPTION_MODEL_MAX_OUTPUT_TOKENS,
+            });
         }
     }
     return options;
 }
 
+/** Fetch + parse a provider's model catalog from an OpenAI-compatible `/models`-style endpoint.
+ *  Shared by the subscription-OAuth providers (Codex/WHAM, xAI/SuperGrok), where the Workbench
+ *  server can't fetch the list (it never receives the OAuth token). `bearer` + `extraHeaders`
+ *  carry the auth. Throws on a non-OK response so callers can degrade to the user-typed
+ *  customModel. Works from the extension (host permissions); the hosted web app would need a
+ *  server-side proxy (a documented follow-up). */
+async function fetchOAuthModelCatalog({
+    url,
+    bearer,
+    provider,
+    extraHeaders,
+    fetchImpl = fetch,
+}: {
+    url: string;
+    bearer: string;
+    provider: LlmProvider;
+    extraHeaders?: Record<string, string>;
+    fetchImpl?: typeof fetch;
+}): Promise<LlmModelOption[]> {
+    const headers: Record<string, string> = {
+        Authorization: `Bearer ${bearer}`,
+        Accept: 'application/json',
+        ...extraHeaders,
+    };
+    const response = await fetchImpl(url, { headers });
+    if (!response.ok) {
+        throw new Error(`Model catalog request to ${url} failed with status ${response.status}.`);
+    }
+    return parseModelCatalogResponse(await response.json(), provider);
+}
+
+/** Fetch the live Codex (WHAM) model list for an OAuth-authenticated openai config. WHAM gates
+ *  the list by `client_version` (an old value returns an empty list). Returns [] without a
+ *  token; throws on a non-OK response so the picker degrades to the user-typed customModel. */
+export async function fetchCodexModels(
+    oauth: OAuthCredentials,
+    clientVersion: string,
+    fetchImpl: typeof fetch = fetch
+): Promise<LlmModelOption[]> {
+    if (!oauth?.access) return [];
+    const url = `${CODEX_WHAM_BASE_URL}/models?client_version=${encodeURIComponent(clientVersion)}`;
+    return fetchOAuthModelCatalog({
+        url,
+        bearer: oauth.access,
+        provider: 'openai',
+        extraHeaders: oauth.accountId ? { 'ChatGPT-Account-Id': oauth.accountId } : undefined,
+        fetchImpl,
+    });
+}
+
+/** Fetch the live xAI (SuperGrok) model list for an OAuth-authenticated grok config. Uses
+ *  `/v1/language-models` — xAI's chat-model listing, which (unlike `/v1/models`) excludes the
+ *  image/video generation models that would otherwise pollute the chat picker. Returns [] without
+ *  a token; throws on a non-OK response so the picker degrades to the user-typed customModel. */
+export async function fetchXaiModels(
+    oauth: OAuthCredentials,
+    baseUrl: string,
+    fetchImpl: typeof fetch = fetch
+): Promise<LlmModelOption[]> {
+    if (!oauth?.access) return [];
+    const root = (normalizeString(baseUrl) || DEFAULT_PROVIDER_BASE_URLS.grok).replace(/\/+$/, '');
+    return fetchOAuthModelCatalog({
+        url: `${root}/language-models`,
+        bearer: oauth.access,
+        provider: 'grok',
+        fetchImpl,
+    });
+}
+
 function emptyProviderCatalog(provider: LlmProvider): LlmProviderCatalog {
     return { provider, status: 'missing_key', models: [], defaultModel: null, error: null };
+}
+
+/** Build a provider catalog from a client-side OAuth model fetch. `ok` when the fetch returned
+ *  models; `missing_key` (an empty catalog) when it didn't, so the picker falls back to the
+ *  user-typed customModel. */
+function oauthModelCatalog(provider: LlmProvider, models: LlmModelOption[]): LlmProviderCatalog {
+    return {
+        provider,
+        status: models.length > 0 ? 'ok' : 'missing_key',
+        models,
+        defaultModel: models[0]?.value ?? null,
+        error: null,
+    };
 }
 
 function emptyProviderCatalogs(): Record<LlmProvider, LlmProviderCatalog> {
@@ -432,6 +508,8 @@ export async function fetchLlmModelsEndpoint({
     const normalizedConfigs = normalizeProviderConfigMap(providerConfigs);
     const openaiConfig = normalizedConfigs.openai;
     const isCodexOAuth = openaiConfig?.authMode === 'oauth' && !!openaiConfig.oauth?.access;
+    const grokConfig = normalizedConfigs.grok;
+    const isXaiOAuth = grokConfig?.authMode === 'oauth' && !!grokConfig.oauth?.access;
 
     let result: LlmModelsEndpointResponse;
     try {
@@ -452,9 +530,9 @@ export async function fetchLlmModelsEndpoint({
         result = (await response.json()) as LlmModelsEndpointResponse;
     } catch (serverError) {
         // The Workbench server may be unreachable (e.g. an extension user signed in with their
-        // own subscription and has no server). Still serve the Codex catalog client-side;
+        // own subscription and has no server). Still serve the subscription catalog client-side;
         // otherwise propagate so API-key providers report the failure.
-        if (!isCodexOAuth) throw serverError;
+        if (!isCodexOAuth && !isXaiOAuth) throw serverError;
         result = {
             provider,
             catalog: emptyProviderCatalog(provider),
@@ -471,16 +549,24 @@ export async function fetchLlmModelsEndpoint({
             const codexModels = await fetchCodexModels(openaiConfig.oauth, clientVersion);
             result.catalogs = {
                 ...result.catalogs,
-                openai: {
-                    provider: 'openai',
-                    status: codexModels.length > 0 ? 'ok' : 'missing_key',
-                    models: codexModels,
-                    defaultModel: codexModels[0]?.value ?? null,
-                    error: null,
-                },
+                openai: oauthModelCatalog('openai', codexModels),
             };
         } catch {
             // Leave the openai catalog empty; the user can type a model manually.
+        }
+    }
+
+    // grok in OAuth (SuperGrok) mode: same story — the server has no token, so fetch xAI's live
+    // chat-model list client-side and override the grok catalog. Degrade gracefully on failure.
+    if (isXaiOAuth && grokConfig?.oauth) {
+        try {
+            const xaiModels = await fetchXaiModels(grokConfig.oauth, grokConfig.baseUrl);
+            result.catalogs = {
+                ...result.catalogs,
+                grok: oauthModelCatalog('grok', xaiModels),
+            };
+        } catch {
+            // Leave the grok catalog empty; the user can type a model manually.
         }
     }
 

--- a/packages/lwc/shared/modules/llm/llm.ts
+++ b/packages/lwc/shared/modules/llm/llm.ts
@@ -345,13 +345,34 @@ function stripOAuthFromProviderConfigs(configs: LlmProviderConfigMap): LlmProvid
     }, {} as LlmProviderConfigMap);
 }
 
+/** The `client_version` WHAM gates its `/models` list by. Resolved from the latest published
+ *  @openai/codex release (npm) so it tracks OpenAI without manual bumps; falls back to the
+ *  pinned constant when the registry is unreachable. */
+export async function resolveCodexClientVersion(fetchImpl: typeof fetch = fetch): Promise<string> {
+    try {
+        const response = await fetchImpl('https://registry.npmjs.org/@openai/codex/latest', {
+            headers: { Accept: 'application/json' },
+        });
+        if (response.ok) {
+            const data = (await response.json()) as { version?: unknown };
+            if (typeof data.version === 'string' && data.version) {
+                return data.version;
+            }
+        }
+    } catch {
+        // Registry unreachable (e.g. offline) — fall back to the pinned default.
+    }
+    return CODEX_MODELS_CLIENT_VERSION;
+}
+
 /** Fetch the live Codex (WHAM) model list for an OAuth-authenticated openai config. WHAM's
  *  `/models` returns `{ models: [{ slug }] }` (slug-based, client_version required); falls back
- *  to the standard `{ data: [{ id }] }` shape. Returns [] on any failure so callers degrade to
- *  the static seed. Note: works from the extension (host permissions); the hosted web app would
- *  need a server-side proxy (a documented follow-up). */
+ *  to the standard `{ data: [{ id }] }` shape. Returns [] on any failure so the picker degrades
+ *  to the user-typed customModel. Works from the extension (host permissions); the hosted web
+ *  app would need a server-side proxy (a documented follow-up). */
 export async function fetchCodexModels(
     oauth: OAuthCredentials,
+    clientVersion: string,
     fetchImpl: typeof fetch = fetch
 ): Promise<LlmModelOption[]> {
     if (!oauth?.access) return [];
@@ -360,9 +381,7 @@ export async function fetchCodexModels(
         Accept: 'application/json',
     };
     if (oauth.accountId) headers['ChatGPT-Account-Id'] = oauth.accountId;
-    const url = `${CODEX_WHAM_BASE_URL}/models?client_version=${encodeURIComponent(
-        CODEX_MODELS_CLIENT_VERSION
-    )}`;
+    const url = `${CODEX_WHAM_BASE_URL}/models?client_version=${encodeURIComponent(clientVersion)}`;
     const response = await fetchImpl(url, { headers });
     if (!response.ok) {
         throw new Error(`Codex /models request failed with status ${response.status}.`);
@@ -448,7 +467,8 @@ export async function fetchLlmModelsEndpoint({
     // picker then relies on the user-typed customModel).
     if (isCodexOAuth && openaiConfig?.oauth) {
         try {
-            const codexModels = await fetchCodexModels(openaiConfig.oauth);
+            const clientVersion = await resolveCodexClientVersion();
+            const codexModels = await fetchCodexModels(openaiConfig.oauth, clientVersion);
             result.catalogs = {
                 ...result.catalogs,
                 openai: {

--- a/packages/lwc/shared/modules/llm/llm.ts
+++ b/packages/lwc/shared/modules/llm/llm.ts
@@ -1,6 +1,7 @@
 import { isRecord } from 'shared/utils';
 
 import {
+    CODEX_MODEL_OPTIONS,
     DEFAULT_LLM_PROVIDER,
     DEFAULT_PROVIDER_BASE_URLS,
     INTERNAL_MODEL_OPTIONS,
@@ -13,6 +14,7 @@ import {
     type LlmModelsEndpointResponse,
     type LlmProviderConfig,
     type LlmProviderConfigMap,
+    type OAuthCredentials,
 } from './constants';
 
 function getInternalModelsForProvider(provider: LlmProvider) {
@@ -47,15 +49,60 @@ export function createDefaultProviderConfigMap(): LlmProviderConfigMap {
     }, {} as LlmProviderConfigMap);
 }
 
+function normalizeAuthMode(value: unknown): LlmProviderConfig['authMode'] {
+    return value === 'oauth' ? 'oauth' : value === 'apiKey' ? 'apiKey' : undefined;
+}
+
+/** Validates and preserves an OAuth credential blob. Returns null when there is no usable
+ *  access token, so a malformed/partial blob is dropped rather than stored. */
+export function normalizeOAuthCredentials(value: unknown): OAuthCredentials | null {
+    if (!isRecord(value)) return null;
+    const access = normalizeString(value.access);
+    if (!access) return null;
+    const expires =
+        typeof value.expires === 'number' && Number.isFinite(value.expires) ? value.expires : 0;
+    const credentials: OAuthCredentials = {
+        access,
+        refresh: normalizeString(value.refresh),
+        expires,
+    };
+    const accountId = normalizeString(value.accountId);
+    if (accountId) credentials.accountId = accountId;
+    const tokenEndpoint = normalizeString(value.tokenEndpoint);
+    if (tokenEndpoint) credentials.tokenEndpoint = tokenEndpoint;
+    const tokenType = normalizeString(value.tokenType);
+    if (tokenType) credentials.tokenType = tokenType;
+    return credentials;
+}
+
 export function normalizeProviderConfig(provider: LlmProvider, config: unknown): LlmProviderConfig {
     const defaults = getDefaultProviderConfig(provider);
     const record = isRecord(config) ? config : {};
     const apiKey = normalizeString(record.apiKey);
     const baseUrl = normalizeString(record.baseUrl);
-    return {
+    const normalized: LlmProviderConfig = {
         apiKey: apiKey || null,
         baseUrl: baseUrl || defaults.baseUrl,
     };
+    // Preserve the optional fields the previous implementation silently dropped —
+    // including `useResponsesApi` (a latent bug) and the OAuth fields. Every persistence
+    // path funnels through here, so dropping these loses them on the next save/load.
+    if (typeof record.useResponsesApi === 'boolean') {
+        normalized.useResponsesApi = record.useResponsesApi;
+    }
+    const authMode = normalizeAuthMode(record.authMode);
+    if (authMode) normalized.authMode = authMode;
+    const oauth = normalizeOAuthCredentials(record.oauth);
+    if (oauth) normalized.oauth = oauth;
+    return normalized;
+}
+
+/** A provider is usable in the model picker when it has an API key, or — in OAuth mode —
+ *  a stored access token. Mirrors the credential gate used elsewhere. */
+export function hasUsableProviderCredentials(config: LlmProviderConfig | undefined): boolean {
+    if (!config) return false;
+    if (config.authMode === 'oauth') return !!config.oauth?.access;
+    return !!config.apiKey;
 }
 
 export function normalizeProviderConfigMap(configs: unknown): LlmProviderConfigMap {
@@ -221,8 +268,8 @@ export function buildAvailableAgentModelOptions({
     providerConfigs: LlmProviderConfigMap;
 }): LlmModelOption[] {
     const normalizedConfigs = normalizeProviderConfigMap(providerConfigs);
-    const configuredProviders = LLM_PROVIDERS.filter(
-        provider => !!normalizedConfigs[provider]?.apiKey
+    const configuredProviders = LLM_PROVIDERS.filter(provider =>
+        hasUsableProviderCredentials(normalizedConfigs[provider])
     );
     const shouldPrefixProviderLabel = configuredProviders.length > 1;
 
@@ -230,12 +277,17 @@ export function buildAvailableAgentModelOptions({
         const config = normalizedConfigs[provider];
         const serverModels = extractModels(availableModelsByProvider, provider);
         const isProviderInternal = isInternalProviderBaseUrl(config.baseUrl);
+        // `openai` in OAuth mode is Codex (WHAM) — surface the Codex slugs, not the
+        // standard OpenAI catalog.
+        const isCodexOAuth = provider === 'openai' && config.authMode === 'oauth';
         const models =
             serverModels.length > 0
                 ? serverModels
                 : isProviderInternal
                   ? getInternalModelsForProvider(provider)
-                  : getProviderModelOptions(provider);
+                  : isCodexOAuth
+                    ? CODEX_MODEL_OPTIONS
+                    : getProviderModelOptions(provider);
 
         return models.map(model => ({
             ...model,

--- a/packages/lwc/shared/modules/llm/llm.ts
+++ b/packages/lwc/shared/modules/llm/llm.ts
@@ -281,17 +281,18 @@ export function buildAvailableAgentModelOptions({
         const config = normalizedConfigs[provider];
         const serverModels = extractModels(availableModelsByProvider, provider);
         const isProviderInternal = isInternalProviderBaseUrl(config.baseUrl);
-        // `openai` in OAuth mode is Codex (WHAM) — surface the Codex slugs, not the
-        // standard OpenAI catalog.
+        // `openai` in OAuth mode is Codex (WHAM) — surface the Codex slugs and ignore the
+        // server `/api/llm/models` catalog, which returns the standard OpenAI API models the
+        // WHAM runtime can't serve (the server isn't Codex-aware). Codex takes precedence over
+        // serverModels for exactly this reason.
         const isCodexOAuth = provider === 'openai' && config.authMode === 'oauth';
-        const models =
-            serverModels.length > 0
-                ? serverModels
-                : isProviderInternal
-                  ? getInternalModelsForProvider(provider)
-                  : isCodexOAuth
-                    ? CODEX_MODEL_OPTIONS
-                    : getProviderModelOptions(provider);
+        const models = isCodexOAuth
+            ? CODEX_MODEL_OPTIONS
+            : serverModels.length > 0
+              ? serverModels
+              : isProviderInternal
+                ? getInternalModelsForProvider(provider)
+                : getProviderModelOptions(provider);
 
         return models.map(model => ({
             ...model,

--- a/packages/lwc/shared/modules/llm/llm.ts
+++ b/packages/lwc/shared/modules/llm/llm.ts
@@ -227,6 +227,7 @@ export function getMaxOutputTokensForModel(
     options: LlmModelOption[] = [
         ...Object.values(PROVIDER_MODEL_OPTIONS).flat(),
         ...INTERNAL_MODEL_OPTIONS,
+        ...CODEX_MODEL_OPTIONS,
     ]
 ): number {
     const normalized = normalizeString(model);
@@ -237,7 +238,10 @@ export function getMaxOutputTokensForModel(
 
 export function getProviderForModel(
     model: unknown,
-    options: LlmModelOption[] = Object.values(PROVIDER_MODEL_OPTIONS).flat()
+    options: LlmModelOption[] = [
+        ...Object.values(PROVIDER_MODEL_OPTIONS).flat(),
+        ...CODEX_MODEL_OPTIONS,
+    ]
 ): LlmProvider {
     const normalized = normalizeString(model);
     if (!normalized) {

--- a/packages/lwc/shared/modules/llm/llm.ts
+++ b/packages/lwc/shared/modules/llm/llm.ts
@@ -1,7 +1,8 @@
 import { isRecord } from 'shared/utils';
 
 import {
-    CODEX_MODEL_OPTIONS,
+    CODEX_MODELS_CLIENT_VERSION,
+    CODEX_WHAM_BASE_URL,
     DEFAULT_LLM_PROVIDER,
     DEFAULT_PROVIDER_BASE_URLS,
     INTERNAL_MODEL_OPTIONS,
@@ -12,6 +13,7 @@ import {
     type LlmModelOption,
     type LlmProvider,
     type LlmModelsEndpointResponse,
+    type LlmProviderCatalog,
     type LlmProviderConfig,
     type LlmProviderConfigMap,
     type OAuthCredentials,
@@ -94,6 +96,8 @@ export function normalizeProviderConfig(provider: LlmProvider, config: unknown):
     if (authMode) normalized.authMode = authMode;
     const oauth = normalizeOAuthCredentials(record.oauth);
     if (oauth) normalized.oauth = oauth;
+    const customModel = normalizeString(record.customModel);
+    if (customModel) normalized.customModel = customModel;
     return normalized;
 }
 
@@ -227,7 +231,6 @@ export function getMaxOutputTokensForModel(
     options: LlmModelOption[] = [
         ...Object.values(PROVIDER_MODEL_OPTIONS).flat(),
         ...INTERNAL_MODEL_OPTIONS,
-        ...CODEX_MODEL_OPTIONS,
     ]
 ): number {
     const normalized = normalizeString(model);
@@ -238,10 +241,7 @@ export function getMaxOutputTokensForModel(
 
 export function getProviderForModel(
     model: unknown,
-    options: LlmModelOption[] = [
-        ...Object.values(PROVIDER_MODEL_OPTIONS).flat(),
-        ...CODEX_MODEL_OPTIONS,
-    ]
+    options: LlmModelOption[] = Object.values(PROVIDER_MODEL_OPTIONS).flat()
 ): LlmProvider {
     const normalized = normalizeString(model);
     if (!normalized) {
@@ -281,18 +281,27 @@ export function buildAvailableAgentModelOptions({
         const config = normalizedConfigs[provider];
         const serverModels = extractModels(availableModelsByProvider, provider);
         const isProviderInternal = isInternalProviderBaseUrl(config.baseUrl);
-        // `openai` in OAuth mode is Codex (WHAM) — surface the Codex slugs and ignore the
-        // server `/api/llm/models` catalog, which returns the standard OpenAI API models the
-        // WHAM runtime can't serve (the server isn't Codex-aware). Codex takes precedence over
-        // serverModels for exactly this reason.
+        // `openai` in OAuth mode is Codex (WHAM): use the live WHAM `/models` catalog
+        // (fetchLlmModelsEndpoint fetches it client-side for OAuth and overrides the openai
+        // catalog) — there is no hardcoded Codex list. Other providers keep their existing
+        // server/internal/static resolution.
         const isCodexOAuth = provider === 'openai' && config.authMode === 'oauth';
-        const models = isCodexOAuth
-            ? CODEX_MODEL_OPTIONS
+        let models = isCodexOAuth
+            ? serverModels
             : serverModels.length > 0
               ? serverModels
               : isProviderInternal
                 ? getInternalModelsForProvider(provider)
                 : getProviderModelOptions(provider);
+        // Manual fallback: a user-typed model the live catalog may not list (Codex models
+        // change often). Append it so it's selectable, if not already present.
+        const customModel = normalizeString(config.customModel);
+        if (customModel && !models.some(model => model.value === customModel)) {
+            models = [
+                ...models,
+                { label: customModel, value: customModel, provider, maxOutputTokens: 16000 },
+            ];
+        }
 
         return models.map(model => ({
             ...model,
@@ -325,6 +334,75 @@ export function resolveAgentProviderBaseUrl(provider: unknown, baseUrl: unknown)
     return effectiveBaseUrl;
 }
 
+/** Strip OAuth credentials (and the oauth auth-mode) from a config map. The Workbench server
+ *  can't use subscription tokens and they must not leave the client, so the model-catalog
+ *  request never carries them. */
+function stripOAuthFromProviderConfigs(configs: LlmProviderConfigMap): LlmProviderConfigMap {
+    return LLM_PROVIDERS.reduce((result, provider) => {
+        const { apiKey, baseUrl, useResponsesApi } = configs[provider];
+        result[provider] = { apiKey, baseUrl, ...(useResponsesApi ? { useResponsesApi } : {}) };
+        return result;
+    }, {} as LlmProviderConfigMap);
+}
+
+/** Fetch the live Codex (WHAM) model list for an OAuth-authenticated openai config. WHAM's
+ *  `/models` returns `{ models: [{ slug }] }` (slug-based, client_version required); falls back
+ *  to the standard `{ data: [{ id }] }` shape. Returns [] on any failure so callers degrade to
+ *  the static seed. Note: works from the extension (host permissions); the hosted web app would
+ *  need a server-side proxy (a documented follow-up). */
+export async function fetchCodexModels(
+    oauth: OAuthCredentials,
+    fetchImpl: typeof fetch = fetch
+): Promise<LlmModelOption[]> {
+    if (!oauth?.access) return [];
+    const headers: Record<string, string> = {
+        Authorization: `Bearer ${oauth.access}`,
+        Accept: 'application/json',
+    };
+    if (oauth.accountId) headers['ChatGPT-Account-Id'] = oauth.accountId;
+    const url = `${CODEX_WHAM_BASE_URL}/models?client_version=${encodeURIComponent(
+        CODEX_MODELS_CLIENT_VERSION
+    )}`;
+    const response = await fetchImpl(url, { headers });
+    if (!response.ok) {
+        throw new Error(`Codex /models request failed with status ${response.status}.`);
+    }
+    const data = (await response.json()) as { models?: unknown; data?: unknown };
+    const rawList = Array.isArray(data.models)
+        ? data.models
+        : Array.isArray(data.data)
+          ? data.data
+          : [];
+    const options: LlmModelOption[] = [];
+    for (const entry of rawList) {
+        if (!isRecord(entry)) continue;
+        const slug =
+            typeof entry.slug === 'string'
+                ? entry.slug
+                : typeof entry.id === 'string'
+                  ? entry.id
+                  : '';
+        if (slug) {
+            options.push({ label: slug, value: slug, provider: 'openai', maxOutputTokens: 16000 });
+        }
+    }
+    return options;
+}
+
+function emptyProviderCatalog(provider: LlmProvider): LlmProviderCatalog {
+    return { provider, status: 'missing_key', models: [], defaultModel: null, error: null };
+}
+
+function emptyProviderCatalogs(): Record<LlmProvider, LlmProviderCatalog> {
+    return LLM_PROVIDERS.reduce(
+        (catalogs, provider) => {
+            catalogs[provider] = emptyProviderCatalog(provider);
+            return catalogs;
+        },
+        {} as Record<LlmProvider, LlmProviderCatalog>
+    );
+}
+
 export async function fetchLlmModelsEndpoint({
     provider,
     providerConfigs,
@@ -332,20 +410,59 @@ export async function fetchLlmModelsEndpoint({
     provider: LlmProvider;
     providerConfigs: LlmProviderConfigMap;
 }): Promise<LlmModelsEndpointResponse> {
-    const response = await fetch(resolveWorkbenchEndpoint('/api/llm/models'), {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-            provider,
-            providerConfigs: normalizeProviderConfigMap(providerConfigs),
-        }),
-    });
+    const normalizedConfigs = normalizeProviderConfigMap(providerConfigs);
+    const openaiConfig = normalizedConfigs.openai;
+    const isCodexOAuth = openaiConfig?.authMode === 'oauth' && !!openaiConfig.oauth?.access;
 
-    if (!response.ok) {
-        throw new Error(`Model catalog request failed with status ${response.status}.`);
+    let result: LlmModelsEndpointResponse;
+    try {
+        const response = await fetch(resolveWorkbenchEndpoint('/api/llm/models'), {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                provider,
+                // Never send OAuth tokens to the server; it can't use them.
+                providerConfigs: stripOAuthFromProviderConfigs(normalizedConfigs),
+            }),
+        });
+        if (!response.ok) {
+            throw new Error(`Model catalog request failed with status ${response.status}.`);
+        }
+        result = (await response.json()) as LlmModelsEndpointResponse;
+    } catch (serverError) {
+        // The Workbench server may be unreachable (e.g. an extension user signed in with their
+        // own subscription and has no server). Still serve the Codex catalog client-side;
+        // otherwise propagate so API-key providers report the failure.
+        if (!isCodexOAuth) throw serverError;
+        result = {
+            provider,
+            catalog: emptyProviderCatalog(provider),
+            catalogs: emptyProviderCatalogs(),
+        };
     }
 
-    return response.json();
+    // openai in OAuth (Codex) mode: the server can't reach WHAM, so fetch the live model list
+    // client-side and override the openai catalog. Degrade gracefully on any failure (the
+    // picker then relies on the user-typed customModel).
+    if (isCodexOAuth && openaiConfig?.oauth) {
+        try {
+            const codexModels = await fetchCodexModels(openaiConfig.oauth);
+            result.catalogs = {
+                ...result.catalogs,
+                openai: {
+                    provider: 'openai',
+                    status: codexModels.length > 0 ? 'ok' : 'missing_key',
+                    models: codexModels,
+                    defaultModel: codexModels[0]?.value ?? null,
+                    error: null,
+                },
+            };
+        } catch {
+            // Leave the openai catalog empty; the user can type a model manually.
+        }
+    }
+
+    return result;
 }

--- a/packages/lwc/shared/modules/oauth/__tests__/jwt.test.ts
+++ b/packages/lwc/shared/modules/oauth/__tests__/jwt.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { decodeJwtPayload, extractAccountId } from '../jwt.ts';
+
+/** Build an unsigned-but-well-formed JWT for a given payload. */
+function makeJwt(payload: Record<string, unknown>): string {
+    const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+    const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+    return `${header}.${body}.sig`;
+}
+
+test('decodeJwtPayload: reads the payload, returns null on garbage', () => {
+    assert.deepEqual(decodeJwtPayload(makeJwt({ a: 1 })), { a: 1 });
+    assert.equal(decodeJwtPayload('not-a-jwt'), null);
+    assert.equal(decodeJwtPayload(''), null);
+    assert.equal(decodeJwtPayload(null), null);
+    assert.equal(decodeJwtPayload('a.b'), null); // payload "b" is not valid base64 JSON
+});
+
+test('extractAccountId: top-level chatgpt_account_id wins', () => {
+    const token = makeJwt({ chatgpt_account_id: 'acct-top' });
+    assert.equal(extractAccountId(token, null), 'acct-top');
+});
+
+test('extractAccountId: falls back to the api.openai.com/auth namespace', () => {
+    const token = makeJwt({
+        'https://api.openai.com/auth': { chatgpt_account_id: 'acct-ns' },
+    });
+    assert.equal(extractAccountId(token, null), 'acct-ns');
+});
+
+test('extractAccountId: falls back to organizations[0].id', () => {
+    const token = makeJwt({ organizations: [{ id: 'org-0' }, { id: 'org-1' }] });
+    assert.equal(extractAccountId(token, null), 'org-0');
+});
+
+test('extractAccountId: tries the access token when id_token lacks the claim', () => {
+    const idToken = makeJwt({ sub: 'no-account' });
+    const accessToken = makeJwt({ chatgpt_account_id: 'acct-access' });
+    assert.equal(extractAccountId(idToken, accessToken), 'acct-access');
+});
+
+test('extractAccountId: returns null when nothing matches or tokens are malformed', () => {
+    assert.equal(extractAccountId(makeJwt({ sub: 'x' }), makeJwt({ sub: 'y' })), null);
+    assert.equal(extractAccountId(null, null), null);
+    assert.equal(extractAccountId('garbage', 'also-garbage'), null);
+    assert.equal(extractAccountId(makeJwt({ organizations: [] }), null), null);
+});

--- a/packages/lwc/shared/modules/oauth/__tests__/oauthClient.test.ts
+++ b/packages/lwc/shared/modules/oauth/__tests__/oauthClient.test.ts
@@ -1,0 +1,210 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+    buildAuthorizeUrl,
+    credentialsFromTokenPayload,
+    isExpired,
+    refreshCredentials,
+    ensureFreshCredentials,
+    parseCallback,
+    createPendingFlowStore,
+    validateXaiEndpoint,
+    xaiDiscovery,
+    CODEX_OAUTH,
+    XAI_OAUTH,
+} from '../oauth.ts';
+
+function makeJwt(payload: Record<string, unknown>): string {
+    const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+    const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+    return `${header}.${body}.sig`;
+}
+
+/** A fetch stub that records calls and returns a fixed JSON body. */
+function mockFetch(payload: unknown, init: { ok?: boolean; status?: number } = {}) {
+    const calls: Array<{ url: string; body: string }> = [];
+    const fetchImpl = (async (url: string | URL, requestInit?: RequestInit) => {
+        calls.push({ url: String(url), body: String(requestInit?.body ?? '') });
+        return {
+            ok: init.ok ?? true,
+            status: init.status ?? 200,
+            json: async () => payload,
+            text: async () => (typeof payload === 'string' ? payload : JSON.stringify(payload)),
+        } as Response;
+    }) as unknown as typeof fetch;
+    return { fetchImpl, calls };
+}
+
+test('buildAuthorizeUrl: emits PKCE, state/nonce and extra params', () => {
+    const url = new URL(
+        buildAuthorizeUrl({
+            authorizeEndpoint: 'https://auth.openai.com/oauth/authorize',
+            clientId: 'cid',
+            redirectUri: 'http://localhost:1455/auth/callback',
+            scope: 'openid offline_access',
+            challenge: 'chal',
+            state: 'st',
+            nonce: 'no',
+            extraParams: { originator: 'codex_cli_rs', codex_cli_simplified_flow: 'true' },
+        })
+    );
+    assert.equal(`${url.origin}${url.pathname}`, 'https://auth.openai.com/oauth/authorize');
+    assert.equal(url.searchParams.get('response_type'), 'code');
+    assert.equal(url.searchParams.get('client_id'), 'cid');
+    assert.equal(url.searchParams.get('redirect_uri'), 'http://localhost:1455/auth/callback');
+    assert.equal(url.searchParams.get('code_challenge'), 'chal');
+    assert.equal(url.searchParams.get('code_challenge_method'), 'S256');
+    assert.equal(url.searchParams.get('state'), 'st');
+    assert.equal(url.searchParams.get('nonce'), 'no');
+    assert.equal(url.searchParams.get('originator'), 'codex_cli_rs');
+});
+
+test('credentialsFromTokenPayload: bakes skew into expiry and pulls accountId', () => {
+    const creds = credentialsFromTokenPayload(
+        {
+            access_token: 'at',
+            refresh_token: 'rt',
+            expires_in: 3600,
+            id_token: makeJwt({ chatgpt_account_id: 'acct' }),
+        },
+        { now: 1_000_000, refreshSkewMs: 30_000, tokenEndpoint: 'https://token.test' }
+    );
+    assert.equal(creds.access, 'at');
+    assert.equal(creds.refresh, 'rt');
+    assert.equal(creds.expires, 1_000_000 + 3_600_000 - 30_000);
+    assert.equal(creds.accountId, 'acct');
+    assert.equal(creds.tokenType, 'Bearer');
+    assert.equal(creds.tokenEndpoint, 'https://token.test');
+});
+
+test('credentialsFromTokenPayload: keeps prior refresh token when response omits one', () => {
+    const creds = credentialsFromTokenPayload(
+        { access_token: 'at2', expires_in: 100 },
+        { now: 0, fallbackRefresh: 'old-rt' }
+    );
+    assert.equal(creds.refresh, 'old-rt');
+});
+
+test('credentialsFromTokenPayload: throws without an access token', () => {
+    assert.throws(() => credentialsFromTokenPayload({ refresh_token: 'rt' }, { now: 0 }));
+});
+
+test('isExpired: honors the stored expiry and a missing access token', () => {
+    assert.equal(isExpired({ access: 'a', refresh: 'r', expires: 100 }, 50), false);
+    assert.equal(isExpired({ access: 'a', refresh: 'r', expires: 100 }, 100), true);
+    assert.equal(isExpired({ access: 'a', refresh: 'r', expires: 0 }, 50), true);
+    assert.equal(isExpired({ access: '', refresh: 'r', expires: 999 }, 0), true);
+});
+
+test('refreshCredentials: posts a refresh_token grant to the captured endpoint', async () => {
+    const { fetchImpl, calls } = mockFetch({
+        access_token: 'new',
+        refresh_token: 'new-rt',
+        expires_in: 3600,
+    });
+    const creds = await refreshCredentials(
+        { access: 'old', refresh: 'old-rt', expires: 0, tokenEndpoint: 'https://token.test' },
+        CODEX_OAUTH,
+        { now: 0, fetchImpl }
+    );
+    assert.equal(creds.access, 'new');
+    assert.equal(creds.refresh, 'new-rt');
+    assert.equal(calls[0].url, 'https://token.test');
+    assert.match(calls[0].body, /grant_type=refresh_token/);
+    assert.match(calls[0].body, /refresh_token=old-rt/);
+});
+
+test('refreshCredentials: falls back to provider.tokenUrl, and throws without a refresh token', async () => {
+    const { fetchImpl, calls } = mockFetch({ access_token: 'n', expires_in: 60 });
+    await refreshCredentials({ access: 'o', refresh: 'r', expires: 0 }, CODEX_OAUTH, {
+        now: 0,
+        fetchImpl,
+    });
+    assert.equal(calls[0].url, CODEX_OAUTH.tokenUrl);
+
+    await assert.rejects(
+        refreshCredentials({ access: 'o', refresh: '', expires: 0 }, CODEX_OAUTH, { now: 0 })
+    );
+});
+
+test('ensureFreshCredentials: returns fresh creds as-is, refreshes expired ones', async () => {
+    const fresh = { access: 'a', refresh: 'r', expires: 10_000 };
+    assert.equal(await ensureFreshCredentials(fresh, CODEX_OAUTH, { now: 0 }), fresh);
+
+    const { fetchImpl } = mockFetch({ access_token: 'refreshed', expires_in: 3600 });
+    const out = await ensureFreshCredentials(
+        { access: 'a', refresh: 'r', expires: 0, tokenEndpoint: 'https://t.test' },
+        CODEX_OAUTH,
+        { now: 100, fetchImpl }
+    );
+    assert.equal(out.access, 'refreshed');
+});
+
+test('parseCallback: full URL, bare query, bare code, error, empty', () => {
+    assert.deepEqual(parseCallback('http://127.0.0.1:56121/callback?code=abc&state=xyz'), {
+        code: 'abc',
+        state: 'xyz',
+        error: undefined,
+        errorDescription: undefined,
+    });
+    const q = parseCallback('code=abc&state=xyz');
+    assert.equal(q.code, 'abc');
+    assert.equal(q.state, 'xyz');
+    assert.deepEqual(parseCallback('abcDEF1234567890ghijk'), { code: 'abcDEF1234567890ghijk' });
+    const err = parseCallback('http://x/callback?error=access_denied&error_description=nope');
+    assert.equal(err.error, 'access_denied');
+    assert.equal(err.errorDescription, 'nope');
+    assert.deepEqual(parseCallback('   '), {});
+});
+
+test('createPendingFlowStore: single-use take, TTL, unknown state', () => {
+    const store = createPendingFlowStore(1000);
+    const flow = { state: 's', verifier: 'v', redirectUri: 'r', provider: 'codex', createdAt: 0 };
+    store.put(flow);
+    assert.equal(store.size, 1);
+    assert.equal(store.take('s', 10)?.verifier, 'v');
+    assert.equal(store.size, 0);
+    assert.equal(store.take('s', 10), null); // already consumed
+
+    store.put({ ...flow, state: 's2', createdAt: 0 });
+    assert.equal(store.take('s2', 2000), null); // expired: 2000 - 0 > 1000
+    assert.equal(store.take(undefined, 0), null);
+    assert.equal(store.take('missing', 0), null);
+});
+
+test('validateXaiEndpoint: pins https on x.ai / *.x.ai', () => {
+    assert.equal(validateXaiEndpoint('https://auth.x.ai/oauth2/auth'), 'https://auth.x.ai/oauth2/auth');
+    assert.equal(validateXaiEndpoint('https://x.ai/token'), 'https://x.ai/token');
+    assert.throws(() => validateXaiEndpoint('http://auth.x.ai/x')); // not https
+    assert.throws(() => validateXaiEndpoint('https://evil.com/x'));
+    assert.throws(() => validateXaiEndpoint('https://x.ai.evil.com/x'));
+    assert.throws(() => validateXaiEndpoint('not a url'));
+});
+
+test('xaiDiscovery: returns validated endpoints, rejects bad host or failure', async () => {
+    const ok = mockFetch({
+        authorization_endpoint: 'https://auth.x.ai/oauth2/auth',
+        token_endpoint: 'https://auth.x.ai/oauth2/token',
+    });
+    const discovery = await xaiDiscovery(ok.fetchImpl);
+    assert.equal(discovery.token_endpoint, 'https://auth.x.ai/oauth2/token');
+
+    const evil = mockFetch({
+        authorization_endpoint: 'https://evil.com/auth',
+        token_endpoint: 'https://evil.com/token',
+    });
+    await assert.rejects(xaiDiscovery(evil.fetchImpl));
+
+    const failed = mockFetch({}, { ok: false, status: 500 });
+    await assert.rejects(xaiDiscovery(failed.fetchImpl));
+});
+
+test('provider constants: Codex + xAI reuse the CLI client_ids', () => {
+    assert.equal(CODEX_OAUTH.clientId, 'app_EMoamEEZ73f0CkXaXp7hrann');
+    assert.equal(CODEX_OAUTH.redirectUri, 'http://localhost:1455/auth/callback');
+    assert.equal(CODEX_OAUTH.extraAuthParams?.originator, 'codex_cli_rs');
+    assert.equal(XAI_OAUTH.clientId, 'b1a00492-073a-47ea-816f-4c329264a828');
+    assert.equal(XAI_OAUTH.usesDiscovery, true);
+    assert.ok(XAI_OAUTH.scope.includes('grok-cli:access'));
+});

--- a/packages/lwc/shared/modules/oauth/__tests__/pkce.test.ts
+++ b/packages/lwc/shared/modules/oauth/__tests__/pkce.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { pkcePair, randomToken } from '../pkce.ts';
+
+function base64UrlOfDigest(digest: ArrayBuffer): string {
+    let binary = '';
+    for (const byte of new Uint8Array(digest)) binary += String.fromCharCode(byte);
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+test('pkcePair: verifier and challenge are base64url with no padding', async () => {
+    const { verifier, challenge } = await pkcePair();
+    assert.match(verifier, /^[A-Za-z0-9_-]+$/);
+    assert.match(challenge, /^[A-Za-z0-9_-]+$/);
+    assert.ok(verifier.length >= 43, 'verifier must satisfy the RFC 7636 minimum length');
+});
+
+test('pkcePair: challenge is exactly S256(verifier)', async () => {
+    const { verifier, challenge } = await pkcePair();
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+    assert.equal(challenge, base64UrlOfDigest(digest));
+});
+
+test('pkcePair: each call produces a fresh verifier', async () => {
+    const a = await pkcePair();
+    const b = await pkcePair();
+    assert.notEqual(a.verifier, b.verifier);
+    assert.notEqual(a.challenge, b.challenge);
+});
+
+test('randomToken: url-safe and unique', () => {
+    const a = randomToken();
+    const b = randomToken();
+    assert.match(a, /^[A-Za-z0-9_-]+$/);
+    assert.notEqual(a, b);
+});

--- a/packages/lwc/shared/modules/oauth/jwt.ts
+++ b/packages/lwc/shared/modules/oauth/jwt.ts
@@ -1,0 +1,58 @@
+// Minimal, signature-free JWT payload reader. We only read the payload to pull the Codex
+// account id — never to authenticate — so no verification library is needed (keeps this pure
+// and target-agnostic).
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Decode a JWT payload (the middle segment) without verifying the signature. Returns null
+ *  on any malformed input. */
+export function decodeJwtPayload(token: string | null | undefined): Record<string, unknown> | null {
+    if (!token || typeof token !== 'string') return null;
+    const segments = token.split('.');
+    if (segments.length < 2 || !segments[1]) return null;
+    try {
+        let base64 = segments[1].replace(/-/g, '+').replace(/_/g, '/');
+        base64 += '='.repeat((4 - (base64.length % 4)) % 4);
+        const binary = atob(base64);
+        const bytes = Uint8Array.from(binary, char => char.charCodeAt(0));
+        const json = new TextDecoder().decode(bytes);
+        const parsed = JSON.parse(json);
+        return isRecord(parsed) ? parsed : null;
+    } catch {
+        return null;
+    }
+}
+
+/** Extract the ChatGPT account id used for the `ChatGPT-Account-Id` header, with the same
+ *  three-level fallback as the Codex CLI: top-level claim → the api.openai.com/auth
+ *  namespace → the first organization's id. Tries the id_token first, then the access token,
+ *  because the claim location varies. */
+export function extractAccountId(
+    idToken?: string | null,
+    accessToken?: string | null
+): string | null {
+    for (const token of [idToken, accessToken]) {
+        const payload = decodeJwtPayload(token);
+        if (!payload) continue;
+
+        const topLevel = payload.chatgpt_account_id;
+        if (typeof topLevel === 'string' && topLevel) return topLevel;
+
+        const authNamespace = payload['https://api.openai.com/auth'];
+        if (isRecord(authNamespace)) {
+            const nested = authNamespace.chatgpt_account_id;
+            if (typeof nested === 'string' && nested) return nested;
+        }
+
+        const organizations = payload.organizations;
+        if (Array.isArray(organizations) && organizations.length > 0) {
+            const first = organizations[0];
+            if (isRecord(first) && typeof first.id === 'string' && first.id) {
+                return first.id;
+            }
+        }
+    }
+    return null;
+}

--- a/packages/lwc/shared/modules/oauth/oauth.ts
+++ b/packages/lwc/shared/modules/oauth/oauth.ts
@@ -1,0 +1,10 @@
+// Public entry for the shared OAuth core (imported as `shared/oauth`). Target-agnostic
+// PKCE + Authorization-Code helpers and the per-provider constants for the Codex (openai)
+// and xAI (grok) subscription sign-in flows. Per-target transport (loopback server /
+// extension popup capture) lives outside this module.
+
+export * from './pkce';
+export * from './jwt';
+export * from './oauthClient';
+export * from './providers/codex';
+export * from './providers/xai';

--- a/packages/lwc/shared/modules/oauth/oauthClient.ts
+++ b/packages/lwc/shared/modules/oauth/oauthClient.ts
@@ -1,0 +1,275 @@
+// Target-agnostic OAuth 2.0 Authorization-Code + PKCE client helpers, shared by both the
+// Codex (openai) and xAI (grok) subscription flows. Pure logic + fetch only — the
+// transport (loopback server / extension popup capture) lives per-target. `now` is passed
+// in (never read from Date here) so every function is deterministically testable.
+
+import type { OAuthCredentials } from 'shared/llm';
+
+import { extractAccountId } from './jwt';
+
+/** Static, provider-specific OAuth configuration (one constants object per provider). */
+export type OAuthProviderConfig = {
+    /** Stable id, e.g. 'codex' | 'xai'. */
+    id: string;
+    /** Authorize endpoint. Empty when resolved via OIDC discovery (xAI). */
+    authorizeUrl: string;
+    /** Token endpoint. Empty when resolved via OIDC discovery (xAI). */
+    tokenUrl: string;
+    clientId: string;
+    scope: string;
+    /** The exact redirect_uri registered for the reused CLI client_id. */
+    redirectUri: string;
+    /** Provider-specific authorize params (e.g. Codex's originator / simplified-flow). */
+    extraAuthParams?: Record<string, string>;
+    /** Refresh this many ms before the real expiry. */
+    refreshSkewMs: number;
+    /** Whether the endpoints come from OIDC discovery (xAI). */
+    usesDiscovery?: boolean;
+    discoveryUrl?: string;
+};
+
+/** Raw token-endpoint response. */
+export type TokenPayload = {
+    access_token?: string;
+    refresh_token?: string;
+    id_token?: string;
+    expires_in?: number;
+    token_type?: string;
+};
+
+export type CallbackResult = {
+    code?: string;
+    state?: string;
+    error?: string;
+    errorDescription?: string;
+};
+
+type FetchImpl = typeof fetch;
+
+export function buildAuthorizeUrl(params: {
+    authorizeEndpoint: string;
+    clientId: string;
+    redirectUri: string;
+    scope: string;
+    challenge: string;
+    state: string;
+    nonce?: string;
+    extraParams?: Record<string, string>;
+}): string {
+    const search = new URLSearchParams({
+        response_type: 'code',
+        client_id: params.clientId,
+        redirect_uri: params.redirectUri,
+        scope: params.scope,
+        code_challenge: params.challenge,
+        code_challenge_method: 'S256',
+        state: params.state,
+    });
+    if (params.nonce) search.set('nonce', params.nonce);
+    for (const [key, value] of Object.entries(params.extraParams ?? {})) {
+        search.set(key, value);
+    }
+    return `${params.authorizeEndpoint}?${search.toString()}`;
+}
+
+async function postToken(
+    tokenEndpoint: string,
+    body: Record<string, string>,
+    fetchImpl: FetchImpl
+): Promise<TokenPayload> {
+    const response = await fetchImpl(tokenEndpoint, {
+        method: 'POST',
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams(body).toString(),
+    });
+    if (!response.ok) {
+        const detail = await response.text().catch(() => '');
+        throw new Error(`OAuth token request failed: ${response.status} ${detail}`.trim());
+    }
+    return (await response.json()) as TokenPayload;
+}
+
+export function exchangeAuthCode(
+    opts: {
+        tokenEndpoint: string;
+        clientId: string;
+        code: string;
+        redirectUri: string;
+        verifier: string;
+    },
+    fetchImpl: FetchImpl = fetch
+): Promise<TokenPayload> {
+    return postToken(
+        opts.tokenEndpoint,
+        {
+            grant_type: 'authorization_code',
+            code: opts.code,
+            redirect_uri: opts.redirectUri,
+            client_id: opts.clientId,
+            code_verifier: opts.verifier,
+        },
+        fetchImpl
+    );
+}
+
+export function refreshAccessToken(
+    opts: { tokenEndpoint: string; clientId: string; refreshToken: string },
+    fetchImpl: FetchImpl = fetch
+): Promise<TokenPayload> {
+    return postToken(
+        opts.tokenEndpoint,
+        {
+            grant_type: 'refresh_token',
+            refresh_token: opts.refreshToken,
+            client_id: opts.clientId,
+        },
+        fetchImpl
+    );
+}
+
+/** Convert a token response into stored credentials. The refresh safety margin is baked into
+ *  `expires` (so `isExpired` is a plain `expires <= now` check). `fallbackRefresh` keeps the
+ *  previous refresh token when a refresh response omits a new one. */
+export function credentialsFromTokenPayload(
+    payload: TokenPayload,
+    opts: { now: number; refreshSkewMs?: number; tokenEndpoint?: string; fallbackRefresh?: string }
+): OAuthCredentials {
+    if (!payload.access_token) {
+        throw new Error('OAuth token response did not include an access_token');
+    }
+    const expiresIn = typeof payload.expires_in === 'number' ? payload.expires_in : 3600;
+    const credentials: OAuthCredentials = {
+        access: payload.access_token,
+        refresh: payload.refresh_token || opts.fallbackRefresh || '',
+        expires: opts.now + expiresIn * 1000 - (opts.refreshSkewMs ?? 0),
+        tokenType: payload.token_type || 'Bearer',
+    };
+    const accountId = extractAccountId(payload.id_token, payload.access_token);
+    if (accountId) credentials.accountId = accountId;
+    if (opts.tokenEndpoint) credentials.tokenEndpoint = opts.tokenEndpoint;
+    return credentials;
+}
+
+/** True when the access token is missing or at/after its (skew-adjusted) expiry. */
+export function isExpired(credentials: OAuthCredentials, now: number): boolean {
+    return !credentials.access || !credentials.expires || credentials.expires <= now;
+}
+
+/** Resolve the token endpoint for a refresh: the one captured at login (xAI discovery) or
+ *  the provider's static endpoint (Codex). */
+function resolveTokenEndpoint(
+    credentials: OAuthCredentials,
+    provider: OAuthProviderConfig
+): string {
+    const endpoint = credentials.tokenEndpoint || provider.tokenUrl;
+    if (!endpoint) {
+        throw new Error(`No token endpoint available to refresh ${provider.id} credentials`);
+    }
+    return endpoint;
+}
+
+/** Exchange the refresh token for a fresh access token. Throws when no refresh token exists
+ *  (caller should surface a re-authenticate state). */
+export async function refreshCredentials(
+    credentials: OAuthCredentials,
+    provider: OAuthProviderConfig,
+    opts: { now: number; fetchImpl?: FetchImpl }
+): Promise<OAuthCredentials> {
+    if (!credentials.refresh) {
+        throw new Error(`${provider.id} credentials are expired and have no refresh token`);
+    }
+    const tokenEndpoint = resolveTokenEndpoint(credentials, provider);
+    const payload = await refreshAccessToken(
+        { tokenEndpoint, clientId: provider.clientId, refreshToken: credentials.refresh },
+        opts.fetchImpl ?? fetch
+    );
+    return credentialsFromTokenPayload(payload, {
+        now: opts.now,
+        refreshSkewMs: provider.refreshSkewMs,
+        tokenEndpoint,
+        fallbackRefresh: credentials.refresh,
+    });
+}
+
+/** Return the credentials unchanged when still fresh, otherwise refresh them. */
+export async function ensureFreshCredentials(
+    credentials: OAuthCredentials,
+    provider: OAuthProviderConfig,
+    opts: { now: number; fetchImpl?: FetchImpl }
+): Promise<OAuthCredentials> {
+    if (!isExpired(credentials, opts.now)) return credentials;
+    return refreshCredentials(credentials, provider, opts);
+}
+
+const BARE_CODE_PATTERN = /^[A-Za-z0-9._~-]{20,}$/;
+
+/** Parse an OAuth callback the user may paste: a full redirect URL, a bare `?code=…&state=…`
+ *  query string, or just the authorization code on its own. */
+export function parseCallback(
+    input: string,
+    redirect: { host: string; path: string } = { host: '127.0.0.1', path: '/callback' }
+): CallbackResult {
+    const value = (input || '').trim();
+    if (!value) return {};
+
+    if (!value.includes('=') && !value.includes('/') && BARE_CODE_PATTERN.test(value)) {
+        return { code: value };
+    }
+
+    try {
+        const url = value.startsWith('http')
+            ? new URL(value)
+            : new URL(`http://${redirect.host}${redirect.path}?${value.replace(/^\?/, '')}`);
+        return {
+            code: url.searchParams.get('code') ?? undefined,
+            state: url.searchParams.get('state') ?? undefined,
+            error: url.searchParams.get('error') ?? undefined,
+            errorDescription: url.searchParams.get('error_description') ?? undefined,
+        };
+    } catch {
+        return {};
+    }
+}
+
+export type PendingFlow = {
+    state: string;
+    verifier: string;
+    nonce?: string;
+    redirectUri: string;
+    provider: string;
+    /** Token endpoint resolved at login time (xAI discovery); undefined for static-endpoint
+     *  providers like Codex. */
+    tokenEndpoint?: string;
+    createdAt: number;
+};
+
+/** In-memory store of in-flight OAuth requests, keyed by `state`. Enforces single-use
+ *  (take() deletes) and a TTL, so a stale or replayed authorization code is rejected before
+ *  token exchange (callback hardening). */
+export function createPendingFlowStore(ttlMs = 10 * 60 * 1000) {
+    const flows = new Map<string, PendingFlow>();
+    return {
+        put(flow: PendingFlow): void {
+            flows.set(flow.state, flow);
+        },
+        /** Consume the flow for `state`. Returns null when unknown, already consumed, or
+         *  past its TTL. */
+        take(state: string | undefined, now: number): PendingFlow | null {
+            if (!state) return null;
+            const flow = flows.get(state);
+            if (!flow) return null;
+            flows.delete(state);
+            if (now - flow.createdAt > ttlMs) return null;
+            return flow;
+        },
+        clear(): void {
+            flows.clear();
+        },
+        get size(): number {
+            return flows.size;
+        },
+    };
+}

--- a/packages/lwc/shared/modules/oauth/pkce.ts
+++ b/packages/lwc/shared/modules/oauth/pkce.ts
@@ -1,0 +1,36 @@
+// PKCE (RFC 7636) helpers, target-agnostic via Web Crypto so the same code runs in the
+// browser, the extension service worker, and Node/Electron. No Node-only APIs here.
+
+/** base64url-encode raw bytes (no padding), per RFC 4648 §5. */
+function base64UrlEncode(bytes: Uint8Array): string {
+    let binary = '';
+    for (const byte of bytes) {
+        binary += String.fromCharCode(byte);
+    }
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function randomBytes(length: number): Uint8Array {
+    return crypto.getRandomValues(new Uint8Array(length));
+}
+
+export type PkcePair = {
+    /** The high-entropy secret kept by the client and sent at token exchange. */
+    verifier: string;
+    /** base64url(SHA-256(verifier)) — sent on the authorize request. */
+    challenge: string;
+};
+
+/** Generate an S256 PKCE verifier/challenge pair (verifier is 43 chars, within the
+ *  RFC-mandated 43–128 range). */
+export async function pkcePair(): Promise<PkcePair> {
+    const verifier = base64UrlEncode(randomBytes(32));
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+    const challenge = base64UrlEncode(new Uint8Array(digest));
+    return { verifier, challenge };
+}
+
+/** A URL-safe random token for the OAuth `state` / `nonce` parameters. */
+export function randomToken(byteLength = 16): string {
+    return base64UrlEncode(randomBytes(byteLength));
+}

--- a/packages/lwc/shared/modules/oauth/providers/codex.ts
+++ b/packages/lwc/shared/modules/oauth/providers/codex.ts
@@ -1,0 +1,28 @@
+// OpenAI Codex (ChatGPT subscription) OAuth constants. Everything provider-specific lives
+// here so a future provider-side change (client_id, endpoints, originator, port) is a
+// one-file edit — see the roadmap compatibility note. These reuse the public Codex CLI
+// client_id and are the CLI integration surface, not a documented third-party API.
+
+import type { OAuthProviderConfig } from '../oauthClient';
+
+/** Fixed loopback port the Codex CLI client_id is registered against (must be 1455). */
+export const CODEX_OAUTH_PORT = 1455;
+export const CODEX_OAUTH_REDIRECT_URI = `http://localhost:${CODEX_OAUTH_PORT}/auth/callback`;
+
+export const CODEX_OAUTH: OAuthProviderConfig = {
+    id: 'codex',
+    authorizeUrl: 'https://auth.openai.com/oauth/authorize',
+    tokenUrl: 'https://auth.openai.com/oauth/token',
+    clientId: 'app_EMoamEEZ73f0CkXaXp7hrann',
+    scope: 'openid profile email offline_access',
+    redirectUri: CODEX_OAUTH_REDIRECT_URI,
+    // Genuine Codex CLI authorize params: originator identifies the CLI, the simplified flow
+    // enables the device-style consent, and id_token_add_organizations surfaces the org/
+    // account claims used to derive the ChatGPT-Account-Id header.
+    extraAuthParams: {
+        originator: 'codex_cli_rs',
+        codex_cli_simplified_flow: 'true',
+        id_token_add_organizations: 'true',
+    },
+    refreshSkewMs: 30 * 1000,
+};

--- a/packages/lwc/shared/modules/oauth/providers/xai.ts
+++ b/packages/lwc/shared/modules/oauth/providers/xai.ts
@@ -1,0 +1,65 @@
+// xAI (Grok / SuperGrok subscription) OAuth constants + OIDC discovery. Endpoints come from
+// discovery and are validated to the x.ai host before use. Reuses the public Grok CLI
+// client_id (CLI integration surface, may change — see roadmap compatibility note).
+
+import type { OAuthProviderConfig } from '../oauthClient';
+
+export const XAI_OAUTH_ISSUER = 'https://auth.x.ai';
+export const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`;
+
+/** Preferred loopback port (RFC 8252 allows falling back to an ephemeral port). */
+export const XAI_OAUTH_PORT = 56121;
+export const XAI_OAUTH_REDIRECT_HOST = '127.0.0.1';
+export const XAI_OAUTH_REDIRECT_PATH = '/callback';
+
+export const XAI_OAUTH: OAuthProviderConfig = {
+    id: 'xai',
+    // Resolved at login via OIDC discovery (see xaiDiscovery); left blank intentionally.
+    authorizeUrl: '',
+    tokenUrl: '',
+    clientId: 'b1a00492-073a-47ea-816f-4c329264a828',
+    scope: 'openid profile email offline_access grok-cli:access api:access',
+    redirectUri: `http://${XAI_OAUTH_REDIRECT_HOST}:${XAI_OAUTH_PORT}${XAI_OAUTH_REDIRECT_PATH}`,
+    refreshSkewMs: 2 * 60 * 1000,
+    usesDiscovery: true,
+    discoveryUrl: XAI_OAUTH_DISCOVERY_URL,
+};
+
+export type XaiDiscovery = {
+    authorization_endpoint: string;
+    token_endpoint: string;
+};
+
+/** Reject any discovery endpoint that isn't HTTPS on x.ai / *.x.ai — discovery responses are
+ *  attacker-influenceable, so the host must be pinned before we ever send a token there. */
+export function validateXaiEndpoint(url: string): string {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        throw new Error(`xAI OAuth discovery returned an invalid endpoint: ${url}`);
+    }
+    const host = parsed.hostname.toLowerCase();
+    if (parsed.protocol !== 'https:' || (host !== 'x.ai' && !host.endsWith('.x.ai'))) {
+        throw new Error(`xAI OAuth discovery returned an unexpected endpoint: ${url}`);
+    }
+    return url;
+}
+
+/** Fetch + validate the xAI OIDC discovery document. `fetchImpl` is injectable for tests. */
+export async function xaiDiscovery(fetchImpl: typeof fetch = fetch): Promise<XaiDiscovery> {
+    const response = await fetchImpl(XAI_OAUTH_DISCOVERY_URL, {
+        headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+        throw new Error(`xAI OAuth discovery failed: ${response.status}`);
+    }
+    const data = (await response.json()) as Partial<XaiDiscovery>;
+    if (!data.authorization_endpoint || !data.token_endpoint) {
+        throw new Error('xAI OAuth discovery response did not include authorization/token endpoints');
+    }
+    return {
+        authorization_endpoint: validateXaiEndpoint(data.authorization_endpoint),
+        token_endpoint: validateXaiEndpoint(data.token_endpoint),
+    };
+}

--- a/packages/lwc/shared/tsconfig.json
+++ b/packages/lwc/shared/tsconfig.json
@@ -9,6 +9,7 @@
             "shared/*": ["modules/*"],
             "shared/analytics": ["modules/analytics/analytics"],
             "shared/llm": ["modules/llm/llm"],
+            "shared/oauth": ["modules/oauth/oauth"],
             "shared/loader": ["modules/loader/loader"],
             "shared/markdown": ["modules/markdown/markdown"],
             "shared/sf": ["modules/sf/sf"],

--- a/tools/build/rollup.extension.mjs
+++ b/tools/build/rollup.extension.mjs
@@ -861,6 +861,7 @@ export default (args) => {
         [
             { name: 'shared/cacheManager', path: r('../../packages/lwc/shared/dist/modules/cacheManager/cacheManager.js') },
             { name: 'shared/llm', path: r('../../packages/lwc/shared/dist/modules/llm/llm.js') },
+            { name: 'shared/oauth', path: r('../../packages/lwc/shared/dist/modules/oauth/oauth.js') },
             { name: 'shared/logger', path: r('../../packages/lwc/shared/dist/modules/logger/logger.js') },
             { name: 'shared/utils', path: r('../../packages/lwc/shared/dist/modules/utils/utils.js') },
         ]

--- a/tools/build/rollup.extension.mjs
+++ b/tools/build/rollup.extension.mjs
@@ -291,6 +291,7 @@ const sharedModules = [
     { name: 'shared/analytics', path: getSharedModulePath('analytics') },
     { name: 'shared/cacheManager', path: getSharedModulePath('cacheManager') },
     { name: 'shared/llm', path: getSharedModulePath('llm') },
+    { name: 'shared/oauth', path: getSharedModulePath('oauth') },
     { name: 'shared/loader', path: getSharedModulePath('loader') },
     { name: 'shared/logger', path: getSharedModulePath('logger') },
     { name: 'shared/metadataApi', path: getSharedModulePath('metadataApi') },


### PR DESCRIPTION
**Status:** Extension implementation complete and working end-to-end for **both** providers. Implements the two subscription-OAuth features over one shared core — closes #23 (Codex) and closes #24 (xAI). They share ~90% of the code (OAuth core, refresh, persistence, settings UI), so they're delivered together.

## Summary

Adds **"Sign in with ChatGPT (Codex)"** and **"Sign in with xAI"** to the AI model picker, so users run agent sessions on their ChatGPT / SuperGrok subscription via OAuth instead of a billed API key. Implemented as a new `authMode: 'oauth'` on the existing `openai` and `grok` providers — no new provider ids.

- **Codex** (`openai` + oauth) → OpenAI's ChatGPT backend (`chatgpt.com/backend-api/wham`, Responses-API only, `store:false`, `ChatGPT-Account-Id`).
- **xAI** (`grok` + oauth) → unchanged `api.x.ai/v1`; the OAuth bearer replaces the API key.

A provider is in API-key mode **or** OAuth mode at a time; API-key usage is untouched.

## What's included

- **Shared OAuth core** (`shared/modules/oauth/`): PKCE/S256, authorize-URL builder, auth-code + refresh exchange, JWT account-id extraction, per-provider constants, xAI OIDC discovery with `x.ai` host pinning. Web Crypto only (runs in browser, extension worker, Node/Electron).
- **Provider runtime**: a Codex (WHAM) runtime + grok OAuth bearer. `createOAuthFetch` keeps the token fresh (proactive + on-401 single-flight refresh), emits exactly one `Authorization` header, and persists rotated tokens. WHAM body constraints handled (`store:false`, top-level `instructions` lifted from the system message, `stream:true`, no `max_output_tokens`).
- **Persistence fix**: `normalizeProviderConfig` no longer silently drops fields (it was even losing `useResponsesApi`); OAuth credentials now round-trip through every save/load path.
- **Credential gates**: the model picker, the send path, and the VS Code bridge all treat an OAuth provider as configured (not just an API key).
- **Extension transport (MV3)**: the background worker opens the consent popup, captures the loopback redirect via `chrome.webNavigation`, validates `state` single-use (pending flow stored in `chrome.storage.session`, so it survives worker suspension), exchanges the code, persists, and shows a branded success page. xAI also supports a manual-paste fallback for the case where it shows the code instead of returning to the loopback.
- **Dynamic models (both providers)**: no hardcoded subscription model lists — the picker is sourced from each provider's live model endpoint through one shared `fetchOAuthModelCatalog` + `parseModelCatalogResponse` helper:
  - **Codex** → WHAM `/models` (its `client_version` tracks the latest `@openai/codex` npm release).
  - **xAI** → `api.x.ai/v1/language-models` (the chat-model listing, which excludes the image/video generation models that `/v1/models` would include).

  A **Refresh models** button re-pulls on demand; a manual model-name field is the fallback **only when the live list comes back empty** (so the normal model selector covers the common case).
- **Settings UI**: Sign in / Sign out + connected state in the shared `aiSettings` component (used by both the side panel and the options page). When connected, the row shows **Connected · Sign out · Refresh models**; the manual Model input appears only if the live fetch returns nothing.

## Compatibility note

Reuses the providers' public CLI client_ids (OpenAI Codex CLI `app_EMoamEEZ73f0CkXaXp7hrann`, Grok CLI `b1a00492-073a-47ea-816f-4c329264a828`), which the providers permit. These are the CLI integration surface, not a documented third-party API, and may change in the future — every provider-specific value (client_id, endpoints, scopes, redirect URIs, client_version) is isolated to one constants file per provider for a one-line update, and the API-key path always remains as a fallback.

## Tests

~130 unit tests across the OAuth core, the provider runtime + refresh fetch, persistence round-trips, and the model catalog / dynamic-fetch logic (Codex WHAM + xAI `/language-models`, both list shapes). `npm run build:extension:main` builds clean.

## Scope & follow-ups

This PR delivers both providers on the **Chrome extension**, which is where the AI agent lives today.

- **Hosted web app** — needs a server-side token-exchange + provider proxy (browser CORS blocks the direct token/LLM calls); follow-up.
- **Desktop (Electron) app** — out of scope here, and larger than an OAuth transport. The AI agent (settings tab **and** chat surface) is currently extension-only: the settings "AI" tab is `isChrome`-gated and the chat panel lives in the extension package. The desktop renderer also runs with `webSecurity: true` and has no LLM egress proxy, so provider calls are CORS-blocked regardless of auth. Bringing AI to the desktop app is a separate initiative — surface the UI → add a main-process LLM egress proxy → then the OAuth loopback transport is a small delta. Tracked separately.
- **At-rest token encryption / OS keychain** — follow-up; tokens currently use the same storage trust model as the existing API keys (this PR deliberately does not change that foundation).

