### PR TITLE
feat(soql): paginate query results past the 2,000-record cap (#32)

### DIFF
--- a/packages/lwc/applications/soql/__tests__/queryPagination.test.ts
+++ b/packages/lwc/applications/soql/__tests__/queryPagination.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { mergeQueryPage, getPaginationSummary } from '../slices/queryPagination.ts';
+
+test('soql/queryPagination: mergeQueryPage appends records and advances the cursor', () => {
+    const existing = {
+        totalSize: 5,
+        done: false,
+        nextRecordsUrl: '/services/data/v60.0/query/01g0',
+        records: [{ Id: 'a' }, { Id: 'b' }],
+    };
+    const page = {
+        totalSize: 5,
+        done: false,
+        nextRecordsUrl: '/services/data/v60.0/query/01g1',
+        records: [{ Id: 'c' }, { Id: 'd' }],
+    };
+
+    const merged = mergeQueryPage(existing, page);
+
+    assert.equal(merged.records.length, 4);
+    assert.deepEqual(
+        merged.records.map(r => r.Id),
+        ['a', 'b', 'c', 'd']
+    );
+    assert.equal(merged.totalSize, 5, 'totalSize stays the whole-result count');
+    assert.equal(merged.nextRecordsUrl, '/services/data/v60.0/query/01g1');
+    assert.equal(merged.done, false);
+});
+
+test('soql/queryPagination: mergeQueryPage normalises the final page', () => {
+    const existing = {
+        totalSize: 3,
+        done: false,
+        nextRecordsUrl: '/services/data/v60.0/query/01g0',
+        records: [{ Id: 'a' }, { Id: 'b' }],
+    };
+    // Final page: jsforce omits nextRecordsUrl entirely.
+    const page = { totalSize: 3, done: true, records: [{ Id: 'c' }] };
+
+    const merged = mergeQueryPage(existing, page);
+
+    assert.equal(merged.records.length, 3);
+    assert.equal(merged.nextRecordsUrl, null);
+    assert.equal(merged.done, true);
+});
+
+test('soql/queryPagination: mergeQueryPage does not mutate inputs', () => {
+    const existing = { totalSize: 2, records: [{ Id: 'a' }] };
+    const page = { records: [{ Id: 'b' }] };
+
+    const merged = mergeQueryPage(existing, page);
+
+    assert.equal(existing.records.length, 1, 'existing untouched');
+    assert.equal(page.records.length, 1, 'page untouched');
+    assert.notEqual(merged.records, existing.records);
+});
+
+test('soql/queryPagination: mergeQueryPage tolerates a null base', () => {
+    const merged = mergeQueryPage(null, {
+        totalSize: 1,
+        done: true,
+        records: [{ Id: 'a' }],
+    });
+    assert.equal(merged.records.length, 1);
+    assert.equal(merged.totalSize, 1);
+    assert.equal(merged.done, true);
+});
+
+test('soql/queryPagination: getPaginationSummary reflects loaded/total/hasMore', () => {
+    assert.deepEqual(
+        getPaginationSummary({
+            totalSize: 10,
+            nextRecordsUrl: '/q/01g0',
+            records: [{ Id: 'a' }, { Id: 'b' }],
+        }),
+        { loaded: 2, total: 10, hasMore: true }
+    );
+
+    assert.deepEqual(getPaginationSummary({ totalSize: 2, records: [{ Id: 'a' }, { Id: 'b' }] }), {
+        loaded: 2,
+        total: 2,
+        hasMore: false,
+    });
+
+    assert.deepEqual(getPaginationSummary(null), { loaded: 0, total: 0, hasMore: false });
+});

--- a/packages/lwc/applications/soql/app/app.html
+++ b/packages/lwc/applications/soql/app/app.html
@@ -125,10 +125,29 @@
                 </div>
 
                 <template lwc:if={isMetaDisplayed}>
-                    <p slot="meta" class="slds-page-header__meta-text">
-                        {totalRecordsFormatted} {sobjectPlurialLabel} • Queried
-                        {_responseCreatedDateFormatted}
-                    </p>
+                    <div slot="meta" class="slds-flex-row slds-grid_vertical-align-center">
+                        <p class="slds-page-header__meta-text">
+                            <template lwc:if={hasMoreRecords}>
+                                {loadedRecordsFormatted} of {totalRecordsFormatted}
+                            </template>
+                            <template lwc:else>{totalRecordsFormatted}</template>
+                            {sobjectPlurialLabel} • Queried {_responseCreatedDateFormatted}
+                        </p>
+                        <template lwc:if={isLoadMoreDisplayed}>
+                            <lightning-button-group class="slds-p-left_small">
+                                <lightning-button
+                                    label={loadMoreLabel}
+                                    icon-name="utility:chevrondown"
+                                    onclick={handleLoadMore}
+                                    disabled={isLoadMoreDisabled}></lightning-button>
+                                <lightning-button
+                                    label="Load all"
+                                    title="Fetch every remaining record"
+                                    onclick={handleLoadAll}
+                                    disabled={isLoadMoreDisabled}></lightning-button>
+                            </lightning-button-group>
+                        </template>
+                    </div>
                 </template>
             </builder-header>
             <!-- Left Panel -->

--- a/packages/lwc/applications/soql/app/app.ts
+++ b/packages/lwc/applications/soql/app/app.ts
@@ -149,6 +149,7 @@ export default class App extends ToolkitElement {
     _responseRows: Array<Record<string, any>> | null = null;
     _sobject: Record<string, any> | null = null;
     _interval: ReturnType<typeof setInterval> | null = null;
+    _isFetchingMore = false;
 
     // Aborting
     _abortingMap: Record<string, any> = {};
@@ -299,6 +300,7 @@ export default class App extends ToolkitElement {
                 this._responseCreatedDate = queryState.createdDate;
                 this._responseNextRecordsUrl = queryState.data.nextRecordsUrl;
                 this._responseRows = queryState.data.records;
+                this._isFetchingMore = queryState.isFetchingMore === true;
                 this._abortingMap[ui.currentTab.id] = null; // Reset the abortingMap
                 this._displayStopButton = false;
                 this._sobject = getDescribeByName({
@@ -346,6 +348,7 @@ export default class App extends ToolkitElement {
         this._responseNextRecordsUrl = null;
         this._responseRows = null;
         this._sobject = null;
+        this._isFetchingMore = false;
     };
 
     formatDate = () => {
@@ -474,6 +477,22 @@ export default class App extends ToolkitElement {
         if (queryPromise) {
             queryPromise.abort();
         }
+    };
+
+    handleLoadMore = () => this._loadMore(false);
+
+    handleLoadAll = () => this._loadMore(true);
+
+    _loadMore = (loadAll: boolean) => {
+        if (this._isFetchingMore || !this._responseNextRecordsUrl) return;
+        const { ui } = store.getState() as any;
+        store.dispatch(
+            QUERY.loadMoreRecords({
+                connector: this.connector,
+                tabId: ui.currentTab.id,
+                loadAll,
+            }) as any
+        );
     };
 
     handleSaveClick = () => {
@@ -993,6 +1012,37 @@ export default class App extends ToolkitElement {
 
     get totalRecordsFormatted() {
         return shortFormatter.format(this.totalRecords);
+    }
+
+    get loadedRecords() {
+        return this._responseRows?.length || 0;
+    }
+
+    get loadedRecordsFormatted() {
+        return shortFormatter.format(this.loadedRecords);
+    }
+
+    // True when Salesforce returned a cursor (more than the loaded records exist).
+    get hasMoreRecords() {
+        return isNotUndefinedOrNull(this._responseNextRecordsUrl);
+    }
+
+    // Show the pagination footer only when there is something more to load
+    // or a load-more fetch is in flight.
+    get isLoadMoreDisplayed() {
+        return (
+            isNotUndefinedOrNull(this._response) && (this.hasMoreRecords || this._isFetchingMore)
+        );
+    }
+
+    get isLoadMoreDisabled() {
+        return this._isFetchingMore || !this.hasMoreRecords;
+    }
+
+    get loadMoreLabel() {
+        return this._isFetchingMore
+            ? `Loading… ${this.loadedRecordsFormatted}/${this.totalRecordsFormatted}`
+            : `Load more (${this.loadedRecordsFormatted} of ${this.totalRecordsFormatted})`;
     }
 
     get sobjectPlurialLabel() {

--- a/packages/lwc/applications/soql/slices/query.ts
+++ b/packages/lwc/applications/soql/slices/query.ts
@@ -4,6 +4,8 @@ import type { ConnectorLike } from 'host-api/connector';
 import { ERROR, DOCUMENT } from 'host-api/store';
 import { lowerCaseKey } from 'host-api/utils';
 
+import { mergeQueryPage } from './queryPagination';
+
 export const queryAdapter = createEntityAdapter<any>();
 
 // Thunks using createAsyncThunk
@@ -78,6 +80,56 @@ export const executeQueryIncognito = createAsyncThunk(
             getStore()?.dispatch(
                 ERROR.reduxSlice.actions.addError({
                     message: 'Error executing query',
+                    details: err.message,
+                })
+            );
+            throw err;
+        }
+    }
+);
+
+/**
+ * Fetch additional records for an already-executed query via Salesforce
+ * `queryMore` (the `nextRecordsUrl` cursor jsforce returns on the first page).
+ *
+ * The merged result is written back to the store on every page through the
+ * `loadMorePage` action, so the table grows reactively as pages arrive. With
+ * `loadAll: true` it walks the cursor to the end (a single SOQL run can return
+ * far more than the initial 2,000 records); otherwise it fetches one page.
+ */
+export const loadMoreRecords = createAsyncThunk(
+    'queries/loadMoreRecords',
+    async (
+        {
+            connector,
+            tabId,
+            loadAll,
+        }: {
+            connector: ConnectorLike;
+            tabId: string;
+            loadAll?: boolean;
+        },
+        { dispatch, getState, signal }
+    ) => {
+        const conn = connector.conn;
+        let cursor: string | null | undefined = querySelectors.selectById(
+            getState() as any,
+            lowerCaseKey(tabId)
+        )?.data?.nextRecordsUrl;
+
+        try {
+            while (cursor) {
+                if (signal.aborted) break;
+                const page: any = await conn.request({ method: 'GET', url: cursor });
+                dispatch(queriesSlice.actions.loadMorePage({ tabId, page }));
+                cursor = page?.nextRecordsUrl ?? null;
+                if (!loadAll) break;
+            }
+            return { tabId };
+        } catch (err) {
+            getStore()?.dispatch(
+                ERROR.reduxSlice.actions.addError({
+                    message: 'Error loading more records',
                     details: err.message,
                 })
             );
@@ -165,6 +217,18 @@ const queriesSlice = createSlice({
                 },
             });
         },
+        loadMorePage: (state, action) => {
+            // Append a fetched `queryMore` page to the tab's current result set.
+            const { tabId, page } = action.payload;
+            const existingRecord = queryAdapter
+                .getSelectors()
+                .selectById(state, lowerCaseKey(tabId));
+            if (!existingRecord?.data) return;
+            queryAdapter.upsertOne(state, {
+                ...existingRecord,
+                data: mergeQueryPage(existingRecord.data, page),
+            });
+        },
         clearQueryError: (state, action) => {
             const { tabId } = action.payload;
             queryAdapter.upsertOne(state, {
@@ -205,6 +269,27 @@ const queriesSlice = createSlice({
                     id: lowerCaseKey(tabId),
                     isFetching: false,
                     error,
+                });
+            })
+            .addCase(loadMoreRecords.pending, (state, action) => {
+                const { tabId } = action.meta.arg;
+                queryAdapter.upsertOne(state, {
+                    id: lowerCaseKey(tabId),
+                    isFetchingMore: true,
+                });
+            })
+            .addCase(loadMoreRecords.fulfilled, (state, action) => {
+                const { tabId } = action.meta.arg;
+                queryAdapter.upsertOne(state, {
+                    id: lowerCaseKey(tabId),
+                    isFetchingMore: false,
+                });
+            })
+            .addCase(loadMoreRecords.rejected, (state, action) => {
+                const { tabId } = action.meta.arg;
+                queryAdapter.upsertOne(state, {
+                    id: lowerCaseKey(tabId),
+                    isFetchingMore: false,
                 });
             })
             .addCase(explainQuery.pending, (state, action) => {

--- a/packages/lwc/applications/soql/slices/queryPagination.ts
+++ b/packages/lwc/applications/soql/slices/queryPagination.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure helpers for SOQL `queryMore` pagination.
+ *
+ * Kept free of the `host-api/store` barrel so they can be unit-tested in
+ * isolation (the slice itself pulls in Redux + core wiring that the node
+ * test runner can't cheaply load).
+ */
+
+/** Minimal shape of a jsforce query result we care about for pagination. */
+export interface QueryPage {
+    totalSize?: number;
+    done?: boolean;
+    nextRecordsUrl?: string | null;
+    records?: Array<Record<string, any>>;
+    [key: string]: any;
+}
+
+/**
+ * Merge a freshly fetched `queryMore` page into the existing query result.
+ *
+ * Appends the new page's records to the ones already loaded and carries over
+ * the latest `done` / `nextRecordsUrl` cursor. `totalSize` stays the value
+ * Salesforce reported for the whole result set — it does not shrink as pages
+ * arrive. Returns a new object; never mutates either input.
+ */
+export function mergeQueryPage(existing: QueryPage | null | undefined, page: QueryPage): QueryPage {
+    const existingRecords = existing?.records ?? [];
+    const pageRecords = page?.records ?? [];
+    return {
+        ...existing,
+        ...page,
+        totalSize: existing?.totalSize ?? page?.totalSize ?? existingRecords.length,
+        records: [...existingRecords, ...pageRecords],
+        // jsforce omits nextRecordsUrl once the cursor is exhausted; normalise to null.
+        nextRecordsUrl: page?.nextRecordsUrl ?? null,
+        done: page?.done ?? !page?.nextRecordsUrl,
+    };
+}
+
+export interface PaginationSummary {
+    /** Records currently held in the store for this tab. */
+    loaded: number;
+    /** Total records the server reports for the whole result set. */
+    total: number;
+    /** True when more records can be fetched (a cursor is present). */
+    hasMore: boolean;
+}
+
+/**
+ * Derive the loaded / total / hasMore counts the UI needs from a query result.
+ * `hasMore` is driven purely by the presence of a cursor so a result whose
+ * `totalSize` is an estimate (reports, aggregate queries) still paginates
+ * correctly.
+ */
+export function getPaginationSummary(data: QueryPage | null | undefined): PaginationSummary {
+    const loaded = data?.records?.length ?? 0;
+    const total = data?.totalSize ?? loaded;
+    const hasMore = Boolean(data?.nextRecordsUrl);
+    return { loaded, total, hasMore };
+}


### PR DESCRIPTION
## Summary

Closes #32 — SOQL results were capped at the first ~2,000 records, forcing users to export data and analyze it outside the extension.

A single SOQL call returns the first batch (≤2,000 rows) plus a `nextRecordsUrl` cursor. The app already walked that cursor — but **only for CSV/JSON export**, mutating component-local state (`_responseRows`). The Tabulator grid renders from the Redux store, so the table never showed beyond the first batch.

This routes `queryMore` pagination through Redux so the grid grows reactively, delivering all three options from the ticket: a **Load More** button, progressive browsing, and **Load All**.

## Changes

- **`slices/queryPagination.ts`** (new) — pure `mergeQueryPage()` (append records, carry the cursor, never mutate) + `getPaginationSummary()`. Kept off the `host-api/store` barrel so they unit-test in isolation (the repo's established convention).
- **`slices/query.ts`** — `loadMoreRecords` thunk (fetches via `conn.request`, honours an abort signal; `loadAll` walks the cursor to the end, dispatching each page so the grid fills progressively), `loadMorePage` reducer, `isFetchingMore` flag.
- **`app/app.ts`** — `handleLoadMore` / `handleLoadAll` handlers + getters (`loadedRecordsFormatted`, `hasMoreRecords`, `loadMoreLabel`, …).
- **`app/app.html`** — header meta now shows **"{loaded} of {total}"** with a **Load more** + **Load all** button group, shown only while a cursor exists.

## Validation

- ✅ All 36 SOQL unit tests pass (5 new in `queryPagination.test.ts`).
- ✅ ESLint + Prettier clean on every touched file.
- ✅ `tsc` shows the same 18 pre-existing soql type errors on baseline and this branch — **zero new type errors**; the new helper module is fully clean.

## Not yet done

Not exercised live against a real org returning >2,000 rows. The store → `outputPanel` → `outputTable` reactivity is wired correctly (the merge produces a new `data` object, so `outputTable.set response` re-renders), but a manual run via `npm run start:dev:extension` is recommended before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)