### PR TITLE
fix(soql): support full-line #/-- comments in editor and execution

### DIFF
--- a/assets/extension/releaseNotes.json
+++ b/assets/extension/releaseNotes.json
@@ -1,15 +1,76 @@
 [
     {
-        "version": "2.0.6",
-        "date": "TBD — release candidate",
+        "version": "2.0.7",
+        "date": "July 1st, 2026",
         "sections": [
             {
-                "title": "Highlights",
+                "title": "Bug Fixes",
                 "categories": [
                     {
-                        "category": "Pending",
+                        "category": "Record Explorer",
                         "items": [
-                            "Release candidate scaffold. Populate this entry as 2.0.6 work merges in (e.g. subscription OAuth sign-in for ChatGPT / xAI)."
+                            "Fixed a field value cell sometimes showing the stale value after a successful inline save; the cell now repaints when its record value changes."
+                        ]
+                    },
+                    {
+                        "category": "Current User",
+                        "items": [
+                            "Fixed the Current User panel showing blank fields in some orgs; the user lookup now resolves the user id from either identity shape (user_id or id), so OAuth/session and Login As connections populate correctly."
+                        ]
+                    },
+                    {
+                        "category": "Connector",
+                        "items": [
+                            "Derive the Org Id from the session token when the identity response omits organization_id, so org-scoped links and features keep working on those connections."
+                        ]
+                    },
+                    {
+                        "category": "SOQL Explorer",
+                        "items": [
+                            "Fixed full-line SOQL comments (`#` and `--`) so they are ignored at execution time and no longer break query parsing. Commented queries now keep object detection in sync, so the left object/fields panel updates correctly while you type."
+                        ]
+                    }
+                ]
+            },
+            {
+                "title": "Enhancements",
+                "categories": [
+                    {
+                        "category": "AI Agent",
+                        "items": [
+                            "The Agent button now appears whenever any AI provider has usable credentials — an API key or a subscription (OAuth) sign-in — instead of only when an OpenAI key was set."
+                        ]
+                    },
+                    {
+                        "category": "Overlay",
+                        "items": [
+                            "Refined the object type badges (Query / Create / Update) with a softer, higher-contrast style for better legibility."
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "version": "2.0.6",
+        "date": "June 18th, 2026",
+        "sections": [
+            {
+                "title": "Enhancements",
+                "categories": [
+                    {
+                        "category": "AI Agent — Subscription Sign-In",
+                        "items": [
+                            "Added subscription OAuth sign-in so you can connect AI providers with your existing ChatGPT (OpenAI / Codex) or xAI (Grok) subscription instead of pasting an API key.",
+                            "Codex (WHAM) models now appear in the model picker when the OpenAI provider is in OAuth mode.",
+                            "OAuth credentials now round-trip reliably through every provider save/load path, fixing config fields (including the model picker gate) being silently dropped."
+                        ]
+                    },
+                    {
+                        "category": "SOQL Explorer",
+                        "items": [
+                            "Added Load More and Load All so you can browse query results past the 2,000-record cap; the results grid now grows progressively as additional pages load.",
+                            "Added a \"{loaded} of {total}\" indicator in the results header so you can see how much of the result set is loaded."
                         ]
                     }
                 ]

--- a/assets/server/data/announcements.json
+++ b/assets/server/data/announcements.json
@@ -1,13 +1,13 @@
 {
     "announcement": {
-        "id": "2026-06-09-2-0-5",
+        "id": "2026-07-01-2-0-7",
         "active": true,
         "variant": "brand",
-        "title": "Workbench 2.0.5 is here",
-        "message": "Workbench 2.0.5 fixes the SOQL Explorer Recent / Saved Queries drawer rendering and the lingering loading screen after connect. 2.0.4 was rolled back due to the SOQL drawer regression.",
+        "title": "Workbench 2.0.7 is here",
+        "message": "Workbench 2.0.7 fixes stale value cells in the Record Explorer after saving, blank fields in the Current User panel on some orgs, Org Id detection on connections whose identity omits it, and SOQL Explorer line comments (`#` / `--`) so commented queries execute and keep object parsing in sync — plus the AI Agent button now shows for any provider with usable credentials.",
         "linkLabel": "View release notes",
         "linkUrl": "https://www.sf-workbench.com/app?applicationName=release",
-        "startsAt": "2026-06-09T00:00:00Z",
+        "startsAt": "2026-07-01T00:00:00Z",
         "endsAt": "2026-12-31T23:59:59Z"
     }
 }

--- a/packages/lwc/applications/soql/__tests__/stripSoqlComments.test.ts
+++ b/packages/lwc/applications/soql/__tests__/stripSoqlComments.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { stripSoqlComments, isSoqlCommentLine } from '../slices/stripSoqlComments.ts';
+
+test('soql/stripSoqlComments: strips a leading # full-line comment', () => {
+    const raw = '# this line is ignored\nSELECT Id FROM Account';
+    assert.equal(stripSoqlComments(raw), '\nSELECT Id FROM Account');
+});
+
+test('soql/stripSoqlComments: strips a leading -- full-line comment', () => {
+    const raw = '-- so is this one\nSELECT Id FROM Account';
+    assert.equal(stripSoqlComments(raw), '\nSELECT Id FROM Account');
+});
+
+test('soql/stripSoqlComments: allows leading whitespace before the marker', () => {
+    const raw = '   \t-- indented comment\n\t# also indented\nSELECT Id FROM Account';
+    assert.equal(stripSoqlComments(raw), '\n\nSELECT Id FROM Account');
+});
+
+test('soql/stripSoqlComments: preserves the line count (blanks, not deletes)', () => {
+    const raw = '# a\n# b\nSELECT Id FROM Account\n-- c';
+    const out = stripSoqlComments(raw);
+    assert.equal(out.split('\n').length, raw.split('\n').length);
+    assert.equal(out, '\n\nSELECT Id FROM Account\n');
+});
+
+test('soql/stripSoqlComments: does NOT treat # or -- inside a quoted literal as a comment', () => {
+    // The plan's explicit false-positive guard: markers after other tokens or
+    // inside a string literal must survive untouched.
+    const raw = "SELECT Id, Name FROM Account WHERE Name = 'a -- not a comment'";
+    assert.equal(stripSoqlComments(raw), raw);
+
+    const withHash = "SELECT Id FROM Account WHERE Name = 'tag #1'";
+    assert.equal(stripSoqlComments(withHash), withHash);
+});
+
+test('soql/stripSoqlComments: does NOT strip a marker that follows other tokens on the line', () => {
+    const raw = 'SELECT Id FROM Account -- trailing text stays';
+    assert.equal(stripSoqlComments(raw), raw);
+});
+
+test('soql/stripSoqlComments: normalises CRLF line endings to LF', () => {
+    const raw = '# c\r\nSELECT Id FROM Account';
+    assert.equal(stripSoqlComments(raw), '\nSELECT Id FROM Account');
+});
+
+test('soql/stripSoqlComments: returns nullish / empty input unchanged', () => {
+    assert.equal(stripSoqlComments(''), '');
+    assert.equal(stripSoqlComments(undefined as any), undefined);
+    assert.equal(stripSoqlComments(null as any), null);
+});
+
+test('soql/stripSoqlComments: a query with no comments is unchanged', () => {
+    const raw = 'SELECT Id, Name FROM Account\nWHERE Name != null\nLIMIT 50';
+    assert.equal(stripSoqlComments(raw), raw);
+});
+
+test('soql/isSoqlCommentLine: classifies lines correctly', () => {
+    assert.equal(isSoqlCommentLine('# x'), true);
+    assert.equal(isSoqlCommentLine('  -- x'), true);
+    assert.equal(isSoqlCommentLine("SELECT Id FROM Account WHERE Name = 'a -- b'"), false);
+    assert.equal(isSoqlCommentLine('SELECT Id -- trailing'), false);
+    assert.equal(isSoqlCommentLine(''), false);
+});

--- a/packages/lwc/applications/soql/app/util.ts
+++ b/packages/lwc/applications/soql/app/util.ts
@@ -1,6 +1,7 @@
 import { store } from 'host-api/store';
 import LightningConfirm from 'lightning/confirm';
 import { UI } from 'soql/slices';
+import { isSoqlCommentLine } from '../slices/stripSoqlComments';
 
 export const escapeCsvValue = (separator: string, value: unknown) => {
     if (value == null) return ''; // Handle null or undefined values
@@ -48,6 +49,9 @@ export const formatQueryWithComment = (query: string) => {
     return query
         .split('\n')
         .map(line => {
+            if (isSoqlCommentLine(line)) {
+                return '';
+            }
             const commentIndex = line.indexOf('//');
             if (commentIndex !== -1) {
                 // Include everything before `//`, excluding the comment

--- a/packages/lwc/applications/soql/slices/query.ts
+++ b/packages/lwc/applications/soql/slices/query.ts
@@ -5,6 +5,7 @@ import { ERROR, DOCUMENT } from 'host-api/store';
 import { lowerCaseKey } from 'host-api/utils';
 
 import { mergeQueryPage } from './queryPagination';
+import { stripSoqlComments } from './stripSoqlComments';
 
 export const queryAdapter = createEntityAdapter<any>();
 
@@ -32,8 +33,11 @@ export const executeQuery = createAsyncThunk(
         { dispatch }
     ) => {
         try {
+            // Strip full-line `#` / `--` comments just before the wire; the raw
+            // text (with comments) is what we persist to history below.
+            const executableSoql = stripSoqlComments(soql);
             const _conn = useToolingApi ? connector.conn.tooling : connector.conn;
-            const res = await _conn.query(soql).scanAll(includeDeletedRecords || false);
+            const res = await _conn.query(executableSoql).scanAll(includeDeletedRecords || false);
             dispatch(
                 DOCUMENT.reduxSlices.RECENT.actions.saveQuery({
                     soql: rawSoql ?? soql,
@@ -73,8 +77,9 @@ export const executeQueryIncognito = createAsyncThunk(
         { dispatch }
     ) => {
         try {
+            const executableSoql = stripSoqlComments(soql);
             const _conn = useToolingApi ? connector.conn.tooling : connector.conn;
-            const res = await _conn.query(soql).scanAll(includeDeletedRecords || false);
+            const res = await _conn.query(executableSoql).scanAll(includeDeletedRecords || false);
             return { data: res, soql };
         } catch (err) {
             getStore()?.dispatch(
@@ -150,8 +155,9 @@ export const explainQuery = createAsyncThunk(
         { dispatch }
     ) => {
         try {
+            const executableSoql = stripSoqlComments(soql);
             const _conn = useToolingApi ? connector.conn.tooling : connector.conn;
-            const query = _conn.query(soql);
+            const query = _conn.query(executableSoql);
             const res = await query.explain();
             return { data: res, soql, alias: connector.configuration.alias, tabId };
         } catch (err) {

--- a/packages/lwc/applications/soql/slices/stripSoqlComments.ts
+++ b/packages/lwc/applications/soql/slices/stripSoqlComments.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure helper for stripping full-line comments out of a SOQL query just before
+ * it is sent to Salesforce.
+ *
+ * Kept free of the `host-api/store` barrel (like `queryPagination.ts`) so it can
+ * be unit-tested in isolation — the slice itself pulls in Redux + core wiring
+ * the node test runner can't cheaply load.
+ *
+ * Contract (deliberately conservative):
+ *   - A line is a comment ONLY when its first non-whitespace characters are
+ *     `#` or `--`. Such lines are blanked (replaced with an empty string) so the
+ *     overall line count — and therefore any line numbers Salesforce reports in
+ *     an error — is preserved.
+ *   - A `#` or `--` that appears AFTER other tokens on a line, or INSIDE a
+ *     quoted string literal, is left untouched. Because SOQL string literals
+ *     cannot span newlines, a marker inside a literal always shares its line
+ *     with the surrounding query text, so the "first non-whitespace" rule never
+ *     misfires on it (e.g. `WHERE Name = 'a -- not a comment'`).
+ *
+ * The raw text (with comments) is what the caller keeps in the editor, drafts,
+ * saved files and history; only the value returned here reaches the wire.
+ */
+
+/** True when `line`'s first non-whitespace characters are a `#` or `--` marker. */
+export function isSoqlCommentLine(line: string): boolean {
+    return /^\s*(#|--)/.test(line);
+}
+
+/**
+ * Return `soql` with every full-line comment blanked out. Preserves line count
+ * and line endings semantics (splits on `\r?\n`, rejoins with `\n`). Returns the
+ * input unchanged (aside from newline normalisation) when it holds no comments.
+ * Nullish input is returned as-is.
+ */
+export function stripSoqlComments(soql: string): string {
+    if (!soql) return soql;
+    return soql
+        .split(/\r?\n/)
+        .map(line => (isSoqlCommentLine(line) ? '' : line))
+        .join('\n');
+}

--- a/packages/lwc/applications/soql/slices/ui.ts
+++ b/packages/lwc/applications/soql/slices/ui.ts
@@ -14,6 +14,7 @@ import {
 } from './queryFieldSelection';
 
 import * as QUERY from './query';
+import { stripSoqlComments } from './stripSoqlComments';
 
 const queryFilesSelectors = DOCUMENT.queryFileAdapter.getSelectors(s => s);
 
@@ -153,7 +154,8 @@ function updateSOQL(state, soql) {
         state.query = undefined;
         state.soql = soql;
     } else {
-        const q = isQueryValid(soql) ? parseQuery(soql) : state.query;
+        const soqlForParser = stripSoqlComments(soql);
+        const q = isQueryValid(soqlForParser) ? parseQuery(soqlForParser) : state.query;
         state.selectedSObject = q ? q.sObject : undefined;
         state.query = q;
         state.soql = soql;

--- a/packages/lwc/main/editor/languages/soql.js
+++ b/packages/lwc/main/editor/languages/soql.js
@@ -377,6 +377,7 @@ export const language = {
     builtinFunctions: ['AVG', 'COUNT', 'CUBE', 'FORMAT', 'GROUPING', 'MAX', 'MIN', 'SUM', 'UPDATE'],
     tokenizer: {
         root: [
+            [/^\s*(#|--).*$/, 'comment'],
             {
                 include: '@comments',
             },

--- a/packages/lwc/main/editor/soql/instructions/instructions.js
+++ b/packages/lwc/main/editor/soql/instructions/instructions.js
@@ -25,6 +25,10 @@ export default `
    - Use selective filters indexed in Salesforce (e.g., 'Id', 'Name', 'CreatedDate') for large datasets.
    - Avoid filtering on non-indexed fields in large objects without careful consideration.
 
+7. **Comment Out Lines**:
+   - Start a line with '#' or '--' (as its first non-whitespace characters) to comment it out. The line stays in the editor but is stripped before the query is sent to Salesforce.
+   - Only full-line comments are removed — a '#' or '--' that appears after other tokens, or inside a quoted string literal, is left as-is.
+
 ---
 
 ## Example Queries
@@ -75,6 +79,17 @@ FROM Account
 WHERE BillingCountry = 'United States'
 ORDER BY Name ASC
 LIMIT 50
+'''
+
+---
+
+### Example 5: Query with Line Comments
+**Prompt:** Retrieve account names while keeping notes in the editor that are not sent to Salesforce.
+**SOQL Query:**
+'''sql
+# this line is ignored
+-- so is this one
+SELECT Id, Name FROM Account WHERE Name = 'a -- not a comment'
 '''
 
 `;


### PR DESCRIPTION
## Summary
- support full-line SOQL comments (`#` / `--`) in execution paths by stripping them before wire calls
- keep SOQL UI parsing/object detection in sync by parsing a comment-stripped query in the UI slice
- add Monaco highlighting + SOQL instructions/examples for `#`/`--` line comments and update 2.0.7 release notes + announcement

## Test plan
- [x] `npx eslint packages/lwc/applications/soql/app/util.ts packages/lwc/applications/soql/slices/query.ts packages/lwc/applications/soql/slices/ui.ts packages/lwc/main/editor/languages/soql.js packages/lwc/main/editor/soql/instructions/instructions.js`
- [x] `node --experimental-strip-types --import=./tools/testing/register.mjs --test packages/lwc/applications/soql/__tests__/stripSoqlComments.test.ts`
- [ ] Manual: in SOQL Explorer, add full-line `#`/`--` comments and verify query execution + left object/fields panel stay in sync