### PR TITLE
fix(extension): prevent double-injection of inject_salesforce.js

### DIFF
--- a/packages/extension/src/workers/background.js
+++ b/packages/extension/src/workers/background.js
@@ -176,6 +176,11 @@ async function findExistingSession({ alias, instanceUrl } = {}) {
 /** Runtime connection state shared across ports and windows. */
 const _lastSidePanelOptionsByTabId = new Map(); // tabId -> { ts }
 const openedSidePanelTabIds = new Set();
+// Tabs whose content-script injection is currently in flight. Prevents a second
+// onUpdated `complete` event from injecting inject_salesforce.js again before the
+// first injection has set window.__SF_TOOLKIT_SCRIPT_INJECTED (which would throw
+// "Identifier 'sOt' has already been declared" from re-running the bundle).
+const injectingTabIds = new Set();
 const injectedConnections = new Set();
 const sidePanelConnections = new Set();
 const sidePanelTabIdByPort = new Map();
@@ -518,6 +523,12 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
 });
 
 function injectToolkit(tabId) {
+    // Guard against concurrent injections: onUpdated can fire `complete` multiple
+    // times before the async injection chain below sets the injected flag. Without
+    // this, inject_salesforce.js gets executed twice in the same context and throws
+    // "Identifier '…' has already been declared".
+    if (injectingTabIds.has(tabId)) return;
+    injectingTabIds.add(tabId);
     // Inject CSS files first
     chrome.scripting.insertCSS(
         {
@@ -530,6 +541,10 @@ function injectToolkit(tabId) {
             ],
         },
         () => {
+            if (chrome.runtime.lastError) {
+                injectingTabIds.delete(tabId);
+                return;
+            }
             // Then inject the JS content script, and set the injected flag
             chrome.scripting.executeScript(
                 {
@@ -537,12 +552,21 @@ function injectToolkit(tabId) {
                     files: ['scripts/inject_salesforce.js'],
                 },
                 () => {
-                    chrome.scripting.executeScript({
-                        target: { tabId: tabId },
-                        func: () => {
-                            window.__SF_TOOLKIT_SCRIPT_INJECTED = true;
+                    if (chrome.runtime.lastError) {
+                        injectingTabIds.delete(tabId);
+                        return;
+                    }
+                    chrome.scripting.executeScript(
+                        {
+                            target: { tabId: tabId },
+                            func: () => {
+                                window.__SF_TOOLKIT_SCRIPT_INJECTED = true;
+                            },
                         },
-                    });
+                        () => {
+                            injectingTabIds.delete(tabId);
+                        }
+                    );
                 }
             );
         }
@@ -581,6 +605,9 @@ async function handleTabActivated({ tabId }) {
 
 async function handleTabUpdated(tabId, info, tab) {
     if (!tab.url || info.status !== 'complete') return;
+    // Skip if an injection for this tab is already in flight (the injected flag is
+    // set only at the end of injectToolkit's async chain).
+    if (injectingTabIds.has(tabId)) return;
     if (await shouldInjectScriptAsync(tab.url)) {
         chrome.scripting.executeScript(
             {
@@ -915,6 +942,7 @@ chrome.tabs.onActivated.addListener(handleTabActivated);
 chrome.tabs.onRemoved.addListener(tabId => {
     openedSidePanelTabIds.delete(tabId);
     _lastSidePanelOptionsByTabId.delete(tabId);
+    injectingTabIds.delete(tabId);
 });
 chrome.tabs.onUpdated.addListener(handleTabUpdated);
 chrome.runtime.onMessage.addListener(wrapAsyncFunction(handleRuntimeMessage));

--- a/tools/testing/__tests__/releaseDocsSync.test.mjs
+++ b/tools/testing/__tests__/releaseDocsSync.test.mjs
@@ -38,14 +38,19 @@ test('docs/release: README, docs, and release metadata stay version-synced', () 
     );
 
     const releaseNotes = JSON.parse(readRepoFile('assets/extension/releaseNotes.json'));
-    assert.ok(Array.isArray(releaseNotes) && releaseNotes.length > 0, 'releaseNotes.json must be non-empty');
+    assert.ok(
+        Array.isArray(releaseNotes) && releaseNotes.length > 0,
+        'releaseNotes.json must be non-empty'
+    );
     assert.equal(
         String(releaseNotes[0]?.version),
         expectedVersion,
         'Top releaseNotes.json entry must match package.json version'
     );
 
-    const announcement = JSON.parse(readRepoFile('assets/server/data/announcements.json'))?.announcement;
+    const announcement = JSON.parse(
+        readRepoFile('assets/server/data/announcements.json')
+    )?.announcement;
     assert.ok(announcement, 'announcements.json must contain an announcement payload');
     assert.match(
         String(announcement.title || ''),


### PR DESCRIPTION
## Problem

Intermittent `Uncaught SyntaxError: Identifier '…' has already been declared` thrown from `scripts/inject_salesforce.js` on Salesforce pages — it looked like the content script was being injected twice.

## Root cause

`chrome.tabs.onUpdated` fires `status: 'complete'` **multiple times per navigation** (notably on Lightning SPA transitions). The double-injection guard relied on `window.__SF_TOOLKIT_SCRIPT_INJECTED`, but that flag was only set at the **end** of `injectToolkit`'s async chain:

```
insertCSS → executeScript(inject_salesforce.js) → executeScript(set flag)
```

Two `complete` events arriving inside that window both read the flag as unset and both called `injectToolkit`, so the bundled content script executed twice in the same page context — its top-level `const` declarations then collide → `Identifier '…' has already been declared`.

## Fix

- Add an `injectingTabIds` Set tracking in-flight injections, set **synchronously** at the start of `injectToolkit` and cleared only once the flag is actually set (or on any `chrome.runtime.lastError` path).
- `injectToolkit` and `handleTabUpdated` both bail out when an injection is already in flight for that tab.
- `chrome.tabs.onRemoved` clears the entry so it doesn't leak for closed tabs.

## Testing

- `npm run build:extension:main` — builds clean (including `background.js`).
- `npx eslint packages/extension/src/workers/background.js` — clean.
- Manual verification of Lightning navigation on a real org (owner testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)