### PR TITLE
fix(api): allow deleting an Open API library from the tree panel

### DIFF
--- a/packages/lwc/applications/api/apiTreePanel/apiTreePanel.html
+++ b/packages/lwc/applications/api/apiTreePanel/apiTreePanel.html
@@ -17,7 +17,6 @@
         <template if:false={selectedProject}>
             <!-- View 1: Project selection tree -->
             <slds-file-tree
-                is-delete-disabled
                 tree={projectTree}
                 min-search-length="1"
                 search-fields={projectSearchFields}


### PR DESCRIPTION
## Problem

In the API Explorer's **Open API** panel, an imported OpenAPI library could not be deleted from the UI. Hovering a library row showed no delete control, and the three-dots fallback menu didn't apply (projects declare no custom `actions`).

## Root cause

The project-selection tree (view 1) was rendered with `is-delete-disabled`:

```html
<slds-file-tree is-delete-disabled tree={projectTree} ... >
```

In `fileTreeItem.ts` the hover delete button is gated by:

```js
get isDeleteButtonVisible() {
    return this.isHover && this.isDeletable && !this.isDeleteDisabled; // always false
}
```

So even though each project is mapped with `isDeletable: true` and the delete flow is fully wired end-to-end (`deletefile` → `handleDeleteApiProject` → `OPENAPI_SCHEMA_FILE.removeOne`), the control could never render.

## Fix

Remove `is-delete-disabled` from the **project** tree (view 1). The API-operations tree (view 2) keeps the flag, since individual GET/POST operations aren't meant to be deletable.

Verified the delete path is correct: the tree root id is `info.title.toLowerCase()` and `upsertOne` stores it via `lowerCaseKey(payload.id)`, so `removeOne(item.id)` targets the right Redux entity and persists to localStorage.

## Testing

Rebuilt the extension (`build:extension:main`) and reloaded in Chrome. Hovering a library row in the Open API panel now shows the trash icon; clicking it removes the library.

> Note: deletion happens immediately with no confirmation prompt (pre-existing behavior of this control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)