### PR TITLE
feat(api): add file request bodies

### DIFF
--- a/packages/lwc/applications/api/README.md
+++ b/packages/lwc/applications/api/README.md
@@ -6,7 +6,7 @@ Compose and send REST API requests against your org with saved requests and rece
 - Developer → API Explorer
 
 ## Key features
-- Choose method, endpoint, and body; add headers
+- Choose method, endpoint, and raw, form-data, binary, or empty bodies; add headers
 - Execute requests using the connected session
 - View response body and headers
 - Recents and Saved requests (Global / Org-specific)
@@ -22,5 +22,8 @@ Compose and send REST API requests against your org with saved requests and rece
 ## Tips
 - Use saved requests for common integrations
 - Store and reuse headers (e.g., content-type) as needed
-
+- For form-data and binary requests, selected files are kept only in the active browser session.
+  They are never saved with requests or included in request history.
+- File uploads are restricted to the connected Salesforce org origin. Leave `Content-Type`
+  unset for form-data requests so the browser can generate the multipart boundary.
 

--- a/packages/lwc/applications/api/__tests__/multipart-upload.test.ts
+++ b/packages/lwc/applications/api/__tests__/multipart-upload.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+const template = readFileSync(new URL('../app/app.html', import.meta.url), 'utf8');
+
+test('body type controls support raw, form-data, and binary requests', () => {
+    assert.match(template, /label="Body type"/);
+    assert.match(template, /label="Add part"/);
+    assert.match(template, /label="Binary file"/);
+});
+
+test('file body modes persist their type without persisting file objects', () => {
+    const component = readFileSync(new URL('../app/app.ts', import.meta.url), 'utf8');
+    assert.match(component, /bodyMode: this\.bodyMode/);
+    assert.match(component, /isConnectedOrgUrl\(_formattedRequest\.url\)/);
+    assert.match(component, /executedRequest\.bodyMode === 'form-data'/);
+    assert.match(component, /clearFormDataFiles\(this\.currentTab\.id\)/);
+    assert.match(component, /clearBinaryFile\(this\.currentTab\.id\)/);
+    assert.match(component, /bodyMode: extra\?\.bodyMode \?\? 'raw'/);
+    assert.match(component, /clearFormDataFiles\(this\.currentTab\?\.id\)/);
+});
+
+test('form-data supports multiple independent parts', () => {
+    assert.match(template, /for:each={formDataParts}/);
+    assert.match(template, /alternative-text="Remove part"/);
+});
+
+test('no-body mode retains an explicit null execution body', () => {
+    const slice = readFileSync(new URL('../slices/api.ts', import.meta.url), 'utf8');
+    assert.match(slice, /executionBody !== undefined \? executionBody : formattedRequest\?\.body/);
+});
+
+test('changing body type updates the saved draft state', () => {
+    const component = readFileSync(new URL('../app/app.ts', import.meta.url), 'utf8');
+    assert.match(component, /this\.bodyMode !== \(api\.bodyMode \|\| 'raw'\)/);
+    assert.match(
+        component,
+        /\(this\.currentFile\.extra\?\.bodyMode \|\| 'raw'\) !== this\.bodyMode/
+    );
+});

--- a/packages/lwc/applications/api/apiTreePanel/apiTreePanel.html
+++ b/packages/lwc/applications/api/apiTreePanel/apiTreePanel.html
@@ -20,6 +20,7 @@
                 tree={projectTree}
                 min-search-length="1"
                 search-fields={projectSearchFields}
+                item-font-size="1.125rem"
                 onselect={handleSelectProject}></slds-file-tree>
         </template>
         <template if:true={selectedProject}>
@@ -50,6 +51,7 @@
                     tree={apiDetailsTree}
                     min-search-length="1"
                     search-fields={apiSearchFields}
+                    item-font-size="1.125rem"
                     onselect={handleSelect}></slds-file-tree>
                 <template if:true={selectedNode}>
                     <div class="api-treepanel-details slds-m-top_small">

--- a/packages/lwc/applications/api/app/app.css
+++ b/packages/lwc/applications/api/app/app.css
@@ -35,6 +35,131 @@
     min-height: 0;
 }
 
+.multipart-toggle {
+    margin-top: 0.25rem;
+}
+
+.multipart-body {
+    overflow: auto;
+}
+
+.form-data-table-wrap {
+    border: 1px solid var(--slds-g-color-border-base-1, #dddbda);
+    border-radius: 0.25rem;
+    overflow-x: auto;
+}
+
+.form-data-table {
+    border-collapse: collapse;
+    table-layout: fixed;
+    width: 100%;
+}
+
+.form-data-table th,
+.form-data-table td {
+    border-bottom: 1px solid var(--slds-g-color-border-base-1, #e5e5e5);
+    padding: 0.375rem;
+    text-align: left;
+    vertical-align: middle;
+}
+
+.form-data-table th {
+    background: var(--slds-g-color-neutral-base-95, #f3f3f3);
+    color: var(--slds-g-color-neutral-base-50, #444);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.form-data-table tr:last-child td {
+    border-bottom: 0;
+}
+
+.form-data-table th:nth-child(1) {
+    width: 32%;
+}
+
+.form-data-table th:nth-child(2) {
+    width: 22%;
+}
+
+.form-data-table th:nth-child(4) {
+    width: 4rem;
+}
+
+.form-data-table__actions {
+    text-align: center !important;
+    width: 4rem;
+}
+
+.form-data-table__file {
+    color: var(--slds-g-color-neutral-base-50, #444);
+    font-size: 0.75rem;
+    margin: 0.25rem 0 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.form-data-add-part {
+    display: flex;
+    justify-content: center;
+    padding-top: 0.75rem;
+}
+
+.multipart-files {
+    border-top: 1px solid var(--slds-g-color-border-base-1, #e5e5e5);
+    margin-top: 0.75rem;
+}
+
+.multipart-files__summary {
+    color: var(--slds-g-color-neutral-base-50, #444);
+    display: flex;
+    font-size: 0.75rem;
+    font-weight: 700;
+    justify-content: space-between;
+    letter-spacing: 0.04em;
+    padding: 0.625rem 0 0.375rem;
+    text-transform: uppercase;
+}
+
+.multipart-files__grid {
+    display: grid;
+    gap: 0.5rem;
+    grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
+}
+
+.multipart-file-card {
+    align-items: center;
+    background: var(--slds-g-color-neutral-base-95, #f3f3f3);
+    border: 1px solid var(--slds-g-color-border-base-1, #dddbda);
+    border-radius: 0.25rem;
+    display: flex;
+    gap: 0.625rem;
+    min-width: 0;
+    padding: 0.625rem;
+}
+
+.multipart-file-card__details {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.multipart-file-card__name {
+    color: var(--slds-g-color-neutral-base-10, #181818);
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.multipart-file-card__size {
+    color: var(--slds-g-color-neutral-base-50, #444);
+    font-size: 0.75rem;
+}
+
 /* Result toolbar */
 .result-toolbar {
     display: flex;

--- a/packages/lwc/applications/api/app/app.html
+++ b/packages/lwc/applications/api/app/app.html
@@ -221,19 +221,146 @@
                                                 Auto-format based on headers
                                             </div>
                                         </div>
-                                        <div class="slds-form-element__control slds-fill-height">
-                                            <!--
-                                            <textarea class="slds-textarea slds-text-longform slds-textarea-body" placeholder="Write body here" disabled={isBodyDisabled} oninput={body_change}>
-                                                {body}
-                                            </textarea>
-                                            -->
-                                            <editor-default
-                                                lwc:ref="bodyEditor"
-                                                class="slds-full-height slds-is-relative"
-                                                model={currentModel}
-                                                onmonacoloaded={initBodyEditor}
-                                                onchange={body_change}></editor-default>
-                                        </div>
+                                        <lightning-radio-group
+                                            class="body-mode"
+                                            label="Body type"
+                                            variant="label-hidden"
+                                            options={bodyModeOptions}
+                                            value={bodyMode}
+                                            disabled={isBodyDisabled}
+                                            onchange={bodyMode_change}></lightning-radio-group>
+                                        <template lwc:if={isFormDataBody}>
+                                            <div class="multipart-body slds-p-top_small">
+                                                <template lwc:if={formDataFileSummary}>
+                                                    <p
+                                                        class="slds-text-body_small slds-text-color_weak slds-p-bottom_x-small">
+                                                        Selected files: {formDataFileSummary}
+                                                    </p>
+                                                </template>
+                                                <div class="form-data-table-wrap">
+                                                    <table class="form-data-table">
+                                                        <thead>
+                                                            <tr>
+                                                                <th scope="col">Key</th>
+                                                                <th scope="col">Type</th>
+                                                                <th scope="col">Value</th>
+                                                                <th scope="col">
+                                                                    <span
+                                                                        class="slds-assistive-text">
+                                                                        Actions
+                                                                    </span>
+                                                                </th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                            <template
+                                                                for:each={formDataParts}
+                                                                for:item="part">
+                                                                <tr key={part.id}>
+                                                                    <td>
+                                                                        <lightning-input
+                                                                            data-id={part.id}
+                                                                            data-field="name"
+                                                                            label="Key"
+                                                                            variant="label-hidden"
+                                                                            placeholder="Key"
+                                                                            value={part.name}
+                                                                            onchange={formDataPart_change}></lightning-input>
+                                                                    </td>
+                                                                    <td
+                                                                        class="form-data-table__type">
+                                                                        <lightning-combobox
+                                                                            data-id={part.id}
+                                                                            data-field="type"
+                                                                            label="Type"
+                                                                            variant="label-hidden"
+                                                                            value={part.type}
+                                                                            options={formDataTypeOptions}
+                                                                            onchange={formDataPart_change}></lightning-combobox>
+                                                                    </td>
+                                                                    <td>
+                                                                        <template
+                                                                            lwc:if={part.isFile}>
+                                                                            <lightning-input
+                                                                                data-id={part.id}
+                                                                                type="file"
+                                                                                label="File"
+                                                                                variant="label-hidden"
+                                                                                onchange={formDataFile_change}></lightning-input>
+                                                                            <template
+                                                                                lwc:if={part.hasFile}>
+                                                                                <p
+                                                                                    class="form-data-table__file">
+                                                                                    {part.fileName}
+                                                                                    ({part.fileSize})
+                                                                                </p>
+                                                                            </template>
+                                                                        </template>
+                                                                        <template lwc:else>
+                                                                            <lightning-input
+                                                                                data-id={part.id}
+                                                                                data-field="value"
+                                                                                label="Value"
+                                                                                variant="label-hidden"
+                                                                                placeholder="Value"
+                                                                                value={part.value}
+                                                                                onchange={formDataPart_change}></lightning-input>
+                                                                        </template>
+                                                                    </td>
+                                                                    <td
+                                                                        class="form-data-table__actions">
+                                                                        <lightning-button-icon
+                                                                            data-id={part.id}
+                                                                            icon-name="utility:close"
+                                                                            alternative-text="Remove part"
+                                                                            title="Remove part"
+                                                                            onclick={removeFormDataPart}></lightning-button-icon>
+                                                                    </td>
+                                                                </tr>
+                                                            </template>
+                                                        </tbody>
+                                                    </table>
+                                                </div>
+                                                <div class="form-data-add-part">
+                                                    <lightning-button
+                                                        label="Add part"
+                                                        icon-name="utility:add"
+                                                        onclick={addFormDataPart}></lightning-button>
+                                                </div>
+                                            </div>
+                                        </template>
+                                        <template lwc:elseif={isBinaryBody}>
+                                            <div class="multipart-body slds-p-top_small">
+                                                <lightning-input
+                                                    type="file"
+                                                    label="Binary file"
+                                                    disabled={isFileInputDisabled}
+                                                    onchange={binaryFile_change}></lightning-input>
+                                                <template lwc:if={binaryFile}>
+                                                    <p
+                                                        class="slds-text-body_small slds-text-color_weak slds-p-top_x-small">
+                                                        {binaryFile.name} ({binaryFileSize}) will be
+                                                        sent as the raw request body.
+                                                    </p>
+                                                </template>
+                                            </div>
+                                        </template>
+                                        <template lwc:elseif={isRawBody}>
+                                            <div
+                                                class="slds-form-element__control slds-fill-height">
+                                                <editor-default
+                                                    lwc:ref="bodyEditor"
+                                                    class="slds-full-height slds-is-relative"
+                                                    model={currentModel}
+                                                    onmonacoloaded={initBodyEditor}
+                                                    onchange={body_change}></editor-default>
+                                            </div>
+                                        </template>
+                                        <template lwc:else>
+                                            <div class="slds-p-top_small slds-text-color_weak">
+                                                This request will be sent without a body.
+                                            </div>
+                                        </template>
                                     </div>
                                 </template>
                                 <template lwc:elseif={isRequestVariablesDisplayed}>

--- a/packages/lwc/applications/api/app/app.ts
+++ b/packages/lwc/applications/api/app/app.ts
@@ -27,6 +27,7 @@ import {
     normalizeString as normalize,
     prettifyXml,
     autoDetectAndFormat,
+    formatBytes,
     API as API_UTILS,
 } from 'shared/utils';
 
@@ -162,6 +163,10 @@ export default class App extends ToolkitElement {
     @api header: string | null = null;
     @api body: string | null = null;
     @track defaultHeader: string | null = null;
+    bodyModes: Record<string, 'raw' | 'form-data' | 'binary' | 'none'> = {};
+    formDataPartsByTab: Record<string, API_UTILS.FormDataPart[]> = {};
+    formDataFilesByTab: Record<string, Record<string, File>> = {};
+    binaryFilesByTab: Record<string, File> = {};
 
     // Undo/Redo
     @track actions: Array<Record<string, any>> = [];
@@ -333,6 +338,19 @@ export default class App extends ToolkitElement {
             this.body = api.body;
             this.updateBodyEditor();
         }
+        if (api.currentTab) {
+            const tabId = api.currentTab.id;
+            const bodyMode = api.bodyMode || 'raw';
+            if (this.bodyModes[tabId] !== bodyMode) {
+                this.bodyModes = { ...this.bodyModes, [tabId]: bodyMode };
+            }
+            if (bodyMode === 'form-data' && !this.formDataPartsByTab[tabId]) {
+                this.formDataPartsByTab = {
+                    ...this.formDataPartsByTab,
+                    [tabId]: API_UTILS.parseFormDataParts(api.body || ''),
+                };
+            }
+        }
         if (this.method != api.method) {
             this.method = api.method;
             if (this._hasRendered) {
@@ -500,8 +518,27 @@ export default class App extends ToolkitElement {
     executeAction = () => {
         const _originalRequest = this.currentRequestToStore;
         const _formattedRequest = this.formatRequest();
+        const executionBody = this.buildExecutionBody(_formattedRequest);
         LOGGER.log('App [executeAction] _formattedRequest', _formattedRequest);
-        if (isUndefinedOrNull(_formattedRequest)) return;
+        if (isUndefinedOrNull(_formattedRequest) || executionBody === undefined) return;
+
+        if (
+            (this.isFormDataBody || this.isBinaryBody) &&
+            !this.isConnectedOrgUrl(_formattedRequest.url)
+        ) {
+            Toast.show({
+                label: 'File uploads are limited to the connected org',
+                message: 'Use an endpoint on the active Salesforce org to send a local file.',
+                variant: 'error',
+            });
+            return;
+        }
+
+        if (this.isFormDataBody) {
+            Object.keys(_formattedRequest.headers || {}).forEach(key => {
+                if (key.toLowerCase() === 'content-type') delete _formattedRequest.headers![key];
+            });
+        }
 
         this.isApiRunning = true;
         try {
@@ -519,6 +556,7 @@ export default class App extends ToolkitElement {
                 connector: this.connector,
                 request: _originalRequest,
                 formattedRequest: _formattedRequest,
+                executionBody,
                 tabId: this.currentTab.id,
                 createdDate: Date.now(),
             })
@@ -540,6 +578,12 @@ export default class App extends ToolkitElement {
             this.method = action.request.method;
             this.endpoint = action.request.endpoint;
             this.header = action.request.header;
+            if (this.currentTab) {
+                this.bodyModes = {
+                    ...this.bodyModes,
+                    [this.currentTab.id]: action.request.bodyMode || 'raw',
+                };
+            }
             this.statusCode = action.response.statusCode;
             this.contentType = action.response.contentType;
             this.contentHeaders = action.response.contentHeaders;
@@ -562,13 +606,9 @@ export default class App extends ToolkitElement {
             header: this.header,
             body: this.body,
         });
-        this.refs.method.value = this.method;
-        this.refs.url.value = this.endpoint;
-        this.refs.bodyEditor.currentModel.setValue(this.body || '');
-        this.refs.bodyEditor.currentMonaco.editor.setModelLanguage(
-            this.refs.bodyEditor.currentModel,
-            autoDetectAndFormat(this.body, this.header) || 'txt'
-        );
+        if (this.refs.method) this.refs.method.value = this.method;
+        if (this.refs.url) this.refs.url.value = this.endpoint;
+        this.updateBodyEditor();
         if (this.refs.responseEditor) {
             //this.refs.responseEditor.currentModel.setValue(this.content);
         }
@@ -759,6 +799,7 @@ export default class App extends ToolkitElement {
     };
 
     reset_click = e => {
+        this.clearMultipartState(this.currentTab?.id);
         store.dispatch(
             API.reduxSlice.actions.resetTab({
                 tabId: this.currentTab?.id,
@@ -776,11 +817,13 @@ export default class App extends ToolkitElement {
                 const _newDraft =
                     (this.currentFile &&
                         (this.currentFile.extra?.body != this.body ||
+                            (this.currentFile.extra?.bodyMode || 'raw') !== this.bodyMode ||
                             this.currentFile.extra?.method != this.method ||
                             this.currentFile.extra?.endpoint != this.endpoint ||
                             this.currentFile.extra?.header != this.header)) === true; // variables removed from draft check
                 if (
                     this.body !== api.body ||
+                    this.bodyMode !== (api.bodyMode || 'raw') ||
                     this.method !== api.method ||
                     this.endpoint !== api.endpoint ||
                     this.header !== api.header ||
@@ -829,6 +872,8 @@ export default class App extends ToolkitElement {
 
     endpoint_change = e => {
         LOGGER.log('App [endpoint_change]', e.detail.value);
+        this.clearFormDataFiles(this.currentTab?.id);
+        this.clearBinaryFile(this.currentTab?.id);
         this.endpoint = e.detail.value;
         this.updateRequestStates(e);
     };
@@ -842,6 +887,70 @@ export default class App extends ToolkitElement {
         if (this.body == e.detail.value) return;
         this.body = e.detail.value;
         this.updateRequestStates(e);
+    };
+
+    bodyMode_change = e => {
+        if (!this.currentTab) return;
+        const bodyMode = e.detail.value;
+        this.bodyModes = { ...this.bodyModes, [this.currentTab.id]: bodyMode };
+        if (bodyMode === 'form-data' && !this.formDataPartsByTab[this.currentTab.id]) {
+            this.formDataPartsByTab = {
+                ...this.formDataPartsByTab,
+                [this.currentTab.id]: API_UTILS.parseFormDataParts(this.body || ''),
+            };
+        }
+        if (bodyMode !== 'form-data') {
+            this.clearFormDataFiles(this.currentTab.id);
+        }
+        if (bodyMode !== 'binary') {
+            this.clearBinaryFile(this.currentTab.id);
+        }
+        this.updateRequestStates(e);
+    };
+
+    binaryFile_change = e => {
+        if (!this.currentTab) return;
+        const file = e.target.files?.[0];
+        const files = { ...this.binaryFilesByTab };
+        if (file) files[this.currentTab.id] = file;
+        else delete files[this.currentTab.id];
+        this.binaryFilesByTab = files;
+    };
+
+    formDataPart_change = e => {
+        const { id, field } = e.target.dataset;
+        const value = e.detail.value;
+        this.updateFormDataParts(
+            this.formDataParts.map(part => (part.id === id ? { ...part, [field]: value } : part)),
+            e
+        );
+    };
+
+    formDataFile_change = e => {
+        const files = { ...(this.formDataFilesByTab[this.currentTab.id] || {}) };
+        if (e.target.files?.[0]) files[e.target.dataset.id] = e.target.files[0];
+        else delete files[e.target.dataset.id];
+        this.formDataFilesByTab = { ...this.formDataFilesByTab, [this.currentTab.id]: files };
+    };
+
+    addFormDataPart = () => {
+        this.updateFormDataParts([
+            ...this.formDataParts,
+            { id: guid(), name: '', type: 'text', value: '' },
+        ]);
+    };
+
+    removeFormDataPart = e => {
+        const id = e.target.dataset.id;
+        this.clearFormDataFile(this.currentTab?.id, id);
+        this.updateFormDataParts(this.formDataParts.filter(part => part.id !== id));
+    };
+
+    updateFormDataParts = (parts, event?) => {
+        if (!this.currentTab) return;
+        this.formDataPartsByTab = { ...this.formDataPartsByTab, [this.currentTab.id]: parts };
+        this.body = JSON.stringify(parts);
+        this.updateRequestStates(event || { type: 'form-data' });
     };
 
     variables_change = e => {
@@ -1053,6 +1162,12 @@ export default class App extends ToolkitElement {
     };
 
     get apexHttpRequestSnippet() {
+        if (
+            this.executedRequest?.bodyMode === 'form-data' ||
+            this.executedRequest?.bodyMode === 'binary'
+        ) {
+            return '/* File request bodies are not available as Apex snippets. */';
+        }
         const formatted = this.formatRequest();
         if (isUndefinedOrNull(formatted)) {
             return '/* Unable to format request */';
@@ -1084,6 +1199,12 @@ export default class App extends ToolkitElement {
     }
 
     get curlSnippet() {
+        if (
+            this.executedRequest?.bodyMode === 'form-data' ||
+            this.executedRequest?.bodyMode === 'binary'
+        ) {
+            return '# File request bodies are not available as cURL snippets.';
+        }
         const formatted = this.formatRequest();
         if (isUndefinedOrNull(formatted)) {
             return '# Unable to format request';
@@ -1106,6 +1227,12 @@ export default class App extends ToolkitElement {
     }
 
     get jsforceSnippet() {
+        if (
+            this.executedRequest?.bodyMode === 'form-data' ||
+            this.executedRequest?.bodyMode === 'binary'
+        ) {
+            return '/* File request bodies are not available as jsforce snippets. */';
+        }
         const formatted = this.formatRequest();
         if (isUndefinedOrNull(formatted)) {
             return '/* Unable to format request */';
@@ -1551,6 +1678,17 @@ export default class App extends ToolkitElement {
         if (!tabId || !this.executedRequest || !this.executedFormattedRequest) return;
         if (this.isApiRunning) return;
 
+        if (
+            this.executedRequest.bodyMode === 'form-data' ||
+            this.executedRequest.bodyMode === 'binary'
+        ) {
+            Toast.show({
+                label: 'Retry unavailable for file request bodies',
+                message: 'Select the files and upload them again to send new binary payloads.',
+                variant: 'warning',
+            });
+            return;
+        }
         this.isApiRunning = true;
         const apiPromise = store.dispatch(
             API.executeApiRequest({
@@ -2064,6 +2202,7 @@ export default class App extends ToolkitElement {
 
     handleSelectTab = e => {
         const tabId = e.target.value;
+        this.clearMultipartState(this.currentTab?.id);
         store.dispatch(API.reduxSlice.actions.selectionTab({ id: tabId, alias: this.alias }));
     };
 
@@ -2079,9 +2218,15 @@ export default class App extends ToolkitElement {
             (currentTab.isDraft && isUndefinedOrNull(currentTab.fileId)) ||
             (currentTab.isDraft && (await LightningConfirm.open(params)))
         ) {
+            this.clearMultipartState(tabId);
             store.dispatch(API.reduxSlice.actions.removeTab({ id: tabId, alias: this.alias }));
         }
     };
+
+    disconnectedCallback() {
+        this.formDataFilesByTab = {};
+        this.binaryFilesByTab = {};
+    }
 
     /** Cached Settings */
 
@@ -2151,6 +2296,7 @@ export default class App extends ToolkitElement {
         if (category === CATEGORY_STORAGE.SAVED) {
             const savedRequest = {
                 body: extra?.body ?? '',
+                bodyMode: extra?.bodyMode ?? 'raw',
                 header: extra?.header ?? this.defaultHeader ?? API_UTILS.DEFAULT.HEADER,
                 method: extra?.method ?? API_UTILS.DEFAULT.METHOD,
                 endpoint: extra?.endpoint ?? API_UTILS.DEFAULT.ENDPOINT(this.currentApiVersion),
@@ -2172,6 +2318,7 @@ export default class App extends ToolkitElement {
             } else {
                 const tab = API_UTILS.generateDefaultTab(this.currentApiVersion);
                 tab.body = savedRequest.body;
+                tab.bodyMode = savedRequest.bodyMode;
                 tab.header = savedRequest.header;
                 tab.method = savedRequest.method;
                 tab.endpoint = savedRequest.endpoint;
@@ -2182,6 +2329,7 @@ export default class App extends ToolkitElement {
             // Open in new tab
             const tab = API_UTILS.generateDefaultTab(this.currentApiVersion);
             tab.body = extra.body;
+            tab.bodyMode = extra.bodyMode || 'raw';
             tab.header = extra.header;
             tab.method = extra.method;
             tab.endpoint = extra.endpoint;
@@ -2233,6 +2381,7 @@ export default class App extends ToolkitElement {
             method: this.method,
             body: this.body,
             header: this.header,
+            bodyMode: this.bodyMode,
         };
     }
 
@@ -2277,6 +2426,148 @@ export default class App extends ToolkitElement {
             this.isApiRunning
         );
     }
+
+    get bodyMode() {
+        return this.currentTab ? this.bodyModes[this.currentTab.id] || 'raw' : 'raw';
+    }
+
+    get bodyModeOptions() {
+        return [
+            { label: 'None', value: 'none' },
+            { label: 'Raw', value: 'raw' },
+            { label: 'Form-data', value: 'form-data' },
+            { label: 'Binary', value: 'binary' },
+        ];
+    }
+
+    get formDataTypeOptions() {
+        return [
+            { label: 'Text', value: 'text' },
+            { label: 'File', value: 'file' },
+        ];
+    }
+
+    get isFormDataBody() {
+        return this.bodyMode === 'form-data';
+    }
+
+    get isBinaryBody() {
+        return this.bodyMode === 'binary';
+    }
+
+    get isRawBody() {
+        return this.bodyMode === 'raw';
+    }
+
+    get formDataParts() {
+        return (this.currentTab ? this.formDataPartsByTab[this.currentTab.id] || [] : []).map(
+            part => {
+                const file = this.currentTab
+                    ? this.formDataFilesByTab[this.currentTab.id]?.[part.id]
+                    : null;
+                return {
+                    ...part,
+                    isFile: part.type === 'file',
+                    fileName: file?.name || '',
+                    fileSize: file ? formatBytes(file.size) : '',
+                    hasFile: Boolean(file),
+                };
+            }
+        );
+    }
+
+    get binaryFile() {
+        return this.currentTab ? this.binaryFilesByTab[this.currentTab.id] || null : null;
+    }
+
+    get binaryFileSize() {
+        return this.binaryFile ? formatBytes(this.binaryFile.size) : '';
+    }
+
+    get formDataFileSummary() {
+        const files = this.currentTab ? this.formDataFilesByTab[this.currentTab.id] || {} : {};
+        const selectedFiles = Object.values(files);
+        if (!selectedFiles.length) return '';
+        const totalBytes = selectedFiles.reduce((total, file) => total + file.size, 0);
+        return `${selectedFiles.length} ${selectedFiles.length === 1 ? 'file' : 'files'} (${formatBytes(totalBytes)})`;
+    }
+
+    get isFileInputDisabled() {
+        return this.isBodyDisabled;
+    }
+
+    clearMultipartState = tabId => {
+        if (!tabId) return;
+        const { [tabId]: removedParts, ...parts } = this.formDataPartsByTab;
+        const { [tabId]: removedFiles, ...files } = this.formDataFilesByTab;
+        const { [tabId]: removedBinary, ...binaryFiles } = this.binaryFilesByTab;
+        const { [tabId]: removedMode, ...modes } = this.bodyModes;
+        this.formDataPartsByTab = parts;
+        this.formDataFilesByTab = files;
+        this.binaryFilesByTab = binaryFiles;
+        this.bodyModes = modes;
+    };
+
+    clearFormDataFiles = tabId => {
+        if (!tabId) return;
+        const { [tabId]: removed, ...files } = this.formDataFilesByTab;
+        this.formDataFilesByTab = files;
+    };
+
+    clearFormDataFile = (tabId, id) => {
+        if (!tabId || !id) return;
+        const { [id]: removed, ...files } = this.formDataFilesByTab[tabId] || {};
+        this.formDataFilesByTab = { ...this.formDataFilesByTab, [tabId]: files };
+    };
+
+    clearBinaryFile = tabId => {
+        if (!tabId) return;
+        const { [tabId]: removed, ...files } = this.binaryFilesByTab;
+        this.binaryFilesByTab = files;
+    };
+
+    buildExecutionBody = request => {
+        if (this.bodyMode === 'none') return null;
+        if (!this.isFormDataBody && !this.isBinaryBody) return request?.body;
+        if (this.isBinaryBody) {
+            if (!this.binaryFile) {
+                Toast.show({
+                    label: 'Select a binary file',
+                    message: 'Choose a file before running.',
+                    variant: 'error',
+                });
+                return undefined;
+            }
+            return this.binaryFile;
+        }
+        const body = new FormData();
+        const files = this.formDataFilesByTab[this.currentTab.id] || {};
+        for (const part of this.formDataParts) {
+            if (!part.name.trim()) continue;
+            if (part.type === 'file') {
+                if (!files[part.id]) {
+                    Toast.show({
+                        label: 'Select a file',
+                        message: `Choose a file for ${part.name}.`,
+                        variant: 'error',
+                    });
+                    return undefined;
+                }
+                body.append(part.name, files[part.id], files[part.id].name);
+            } else {
+                body.append(part.name, this.replaceVariableValues(part.value) || '');
+            }
+        }
+        return body;
+    };
+
+    isConnectedOrgUrl = url => {
+        try {
+            return new URL(url).origin === new URL(this.connector.conn.instanceUrl).origin;
+        } catch {
+            return false;
+        }
+    };
 
     get isHeaderDisabled() {
         return this.isLoading || this.isApiRunning;

--- a/packages/lwc/applications/api/slices/api.ts
+++ b/packages/lwc/applications/api/slices/api.ts
@@ -54,6 +54,7 @@ function formatTab({
     name,
     header,
     body,
+    bodyMode,
     method,
     endpoint,
     isDraft,
@@ -67,6 +68,7 @@ function formatTab({
         name,
         header,
         body,
+        bodyMode: bodyMode || 'raw',
         method,
         endpoint,
         isDraft,
@@ -89,6 +91,7 @@ function enrichTab(tab, state, selector) {
     const fileData = file?.extra || {};
     const differs =
         norm(fileData.body) !== norm(tab.body) ||
+        norm(fileData.bodyMode || 'raw') !== norm(tab.bodyMode || 'raw') ||
         norm(fileData.header) !== norm(tab.header) ||
         norm(fileData.method) !== norm(tab.method) ||
         norm(fileData.endpoint) !== norm(tab.endpoint);
@@ -104,6 +107,7 @@ function assignNewApiData(item, value) {
         method: value.method,
         endpoint: value.endpoint,
         body: value.body,
+        bodyMode: value.bodyMode || 'raw',
         actions: value.actions,
         actionPointer: value.actionPointer,
     });
@@ -137,12 +141,14 @@ export const executeApiRequest = createAsyncThunk(
             connector,
             request,
             formattedRequest,
+            executionBody,
             tabId,
             createdDate,
         }: {
             connector: ConnectorLike;
             request: Record<string, any>;
             formattedRequest: Record<string, any>;
+            executionBody?: BodyInit | null;
             tabId: string;
             createdDate: string | number | Date;
         },
@@ -155,7 +161,9 @@ export const executeApiRequest = createAsyncThunk(
                 method: formattedRequest?.method || request?.method || 'GET',
                 url: formattedRequest?.url,
                 headers: formattedRequest?.headers,
-                body: formattedRequest?.body,
+                // `null` deliberately represents the no-body mode; only fall back when a
+                // caller did not provide an execution body at all.
+                body: executionBody !== undefined ? executionBody : formattedRequest?.body,
                 accessToken: connector?.conn?.accessToken,
                 signal,
             });
@@ -261,7 +269,7 @@ const apiSlice = createSlice({
             }
         },
         updateRequest: (state, action) => {
-            const { header, method, endpoint, body, tabId, isDraft } = action.payload;
+            const { header, method, endpoint, body, bodyMode, tabId, isDraft } = action.payload;
             const tabIndex = state.tabs.findIndex(x => x.id === tabId);
             // Reset Tab
             if (tabIndex > -1) {
@@ -270,6 +278,7 @@ const apiSlice = createSlice({
                     method,
                     endpoint,
                     body,
+                    bodyMode: bodyMode || 'raw',
                     isDraft,
                 });
                 assignNewApiData(state, state.tabs[tabIndex]);

--- a/packages/lwc/main/component/slds/fileTree/fileTree.ts
+++ b/packages/lwc/main/component/slds/fileTree/fileTree.ts
@@ -44,6 +44,7 @@ export default class FileTree extends LightningElement {
     @api isFolderSelectable = false;
     @api enableToggleOnItemClick = false;
     @api nestedItemSpacing = '0.35rem';
+    @api itemFontSize = '';
 
     /** Event Handlers */
 
@@ -236,6 +237,9 @@ export default class FileTree extends LightningElement {
 
     get treeStyle() {
         const spacing = String(this.nestedItemSpacing || '').trim() || '0.35rem';
-        return `--slds-file-tree-nested-item-spacing: ${spacing};`;
+        const itemFontSize = String(this.itemFontSize || '').trim();
+        return `--slds-file-tree-nested-item-spacing: ${spacing};${
+            itemFontSize ? `--slds-file-tree-item-font-size: ${itemFontSize};` : ''
+        }`;
     }
 }

--- a/packages/lwc/main/component/slds/fileTreeItem/fileTreeItem.css
+++ b/packages/lwc/main/component/slds/fileTreeItem/fileTreeItem.css
@@ -79,7 +79,7 @@
 }
 
 .file-tree-item-title {
-    font-size: small;
+    font-size: var(--slds-file-tree-item-font-size, small);
 }
 
 .tree-item-selected {

--- a/packages/lwc/shared/modules/utils/__tests__/api.test.ts
+++ b/packages/lwc/shared/modules/utils/__tests__/api.test.ts
@@ -13,6 +13,7 @@ import {
     substituteVariables,
     parseVariables,
     executeApiRequest,
+    parseFormDataParts,
 } from '../modules/api.ts';
 
 test('constants: exports expected enums', () => {
@@ -124,6 +125,22 @@ test('formatApiRequest: header object is forwarded; replaceVariableValues applie
     assert.equal(request.headers!['X-Token'], 'secret');
 });
 
+test('parseFormDataParts: returns valid serializable text and file parts', () => {
+    assert.deepEqual(
+        parseFormDataParts(
+            '[{"id":"1","name":"metadata","type":"text","value":"x"},{"id":"2","name":"file","type":"file","value":""}]'
+        ),
+        [
+            { id: '1', name: 'metadata', type: 'text', value: 'x' },
+            { id: '2', name: 'file', type: 'file', value: '' },
+        ]
+    );
+});
+
+test('parseFormDataParts: returns an empty list for malformed content', () => {
+    assert.deepEqual(parseFormDataParts('not json'), []);
+});
+
 test('DEFAULT_API_VERSION is a non-empty version string', () => {
     assert.match(DEFAULT_API_VERSION, /^\d+\.\d+$/);
 });
@@ -230,6 +247,51 @@ test('executeApiRequest: does not override an existing Authorization header', as
         fetchImpl: fakeFetch as typeof fetch,
     });
     assert.equal(seen.Authorization, 'Bearer EXPLICIT');
+});
+
+test('executeApiRequest: does not inject Salesforce authorization for a presigned upload', async () => {
+    let seen: Record<string, string> = {};
+    const fakeFetch = async (_url: string, init: RequestInit) => {
+        seen = (init.headers as Record<string, string>) || {};
+        return new Response('', { status: 200 }) as unknown as Response;
+    };
+    await executeApiRequest({
+        method: 'PUT',
+        url: 'https://bucket.example/upload?signature=1',
+        headers: { 'Content-Type': 'application/pdf' },
+        body: new Blob(['file']),
+        accessToken: 'SALESFORCE_TOKEN',
+        skipAuthorization: true,
+        fetchImpl: fakeFetch as typeof fetch,
+    });
+    assert.equal(seen.Authorization, undefined);
+    assert.equal(seen['Content-Type'], 'application/pdf');
+});
+
+test('executeApiRequest: forwards FormData without setting Content-Type', async () => {
+    const body = new FormData();
+    body.append('file', new Blob(['contents'], { type: 'text/plain' }), 'note.txt');
+    let seenBody: BodyInit | null | undefined;
+    let seenHeaders: Record<string, string> = {};
+    const fakeFetch = async (_url: string, init: RequestInit) => {
+        seenBody = init.body;
+        seenHeaders = (init.headers as Record<string, string>) || {};
+        return new Response('{}', {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+        }) as unknown as Response;
+    };
+
+    await executeApiRequest({
+        method: 'POST',
+        url: 'https://ex/api',
+        headers: { Accept: 'application/json' },
+        body,
+        fetchImpl: fakeFetch as typeof fetch,
+    });
+
+    assert.equal(seenBody, body);
+    assert.equal(seenHeaders['Content-Type'], undefined);
 });
 
 test('executeApiRequest: missing URL throws', async () => {

--- a/packages/lwc/shared/modules/utils/modules/api.ts
+++ b/packages/lwc/shared/modules/utils/modules/api.ts
@@ -39,6 +39,7 @@ type ApiTab = {
     header: string;
     endpoint: string;
     body: string;
+    bodyMode?: 'none' | 'raw' | 'form-data' | 'binary';
     method: string;
     variables: string;
     actions: unknown[];
@@ -51,6 +52,7 @@ export const generateDefaultTab = (version: string, id?: string): ApiTab => {
         header: DEFAULT.HEADER,
         endpoint: DEFAULT.ENDPOINT(version),
         body: DEFAULT.BODY,
+        bodyMode: 'raw',
         method: DEFAULT.METHOD,
         variables: DEFAULT.VARIABLES,
         actions: [],
@@ -115,6 +117,25 @@ type FormattedApiRequest = {
     endpoint: string;
     body?: string;
     headers?: Record<string, string>;
+};
+
+export type FormDataPart = { id: string; name: string; type: 'text' | 'file'; value: string };
+
+export const parseFormDataParts = (raw: string): FormDataPart[] => {
+    try {
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [];
+        return parsed.filter(
+            (part): part is FormDataPart =>
+                part &&
+                typeof part.id === 'string' &&
+                typeof part.name === 'string' &&
+                (part.type === 'text' || part.type === 'file') &&
+                typeof part.value === 'string'
+        );
+    } catch {
+        return [];
+    }
 };
 
 export const formatApiRequest = ({
@@ -285,6 +306,8 @@ export type ExecuteApiInput = {
     accessToken?: string;
     /** Optional fetch override (useful for tests / sanitized wrappers). */
     fetchImpl?: typeof fetch;
+    /** Presigned URLs must not receive the active Salesforce bearer token. */
+    skipAuthorization?: boolean;
 };
 
 export type ExecuteApiResult = {
@@ -316,6 +339,7 @@ export const executeApiRequest = async ({
     signal,
     accessToken,
     fetchImpl,
+    skipAuthorization,
 }: ExecuteApiInput): Promise<ExecuteApiResult> => {
     if (!url) {
         throw new Error('Missing request URL');
@@ -323,7 +347,7 @@ export const executeApiRequest = async ({
     const executionStartDate = Date.now();
     const mergedHeaders: Record<string, string> = { ...(headers || {}) };
     const hasAuth = Object.keys(mergedHeaders).some(k => k.toLowerCase() === 'authorization');
-    if (!hasAuth && accessToken) {
+    if (!hasAuth && accessToken && !skipAuthorization) {
         mergedHeaders.Authorization = `Bearer ${accessToken}`;
     }
 


### PR DESCRIPTION
## Summary
- add raw, multipart form-data, binary, and no-body modes to API Explorer
- keep browser-selected files transient and restrict uploads to the connected Salesforce org
- make the form-data action control consistently visible and center the add-part button

## Validation
- (node:72807) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
✔ body type controls support raw, form-data, and binary requests (0.3875ms)
✔ file body modes persist their type without persisting file objects (0.47075ms)
✔ form-data supports multiple independent parts (0.0695ms)
✔ no-body mode retains an explicit null execution body (0.379125ms)
✔ changing body type updates the saved draft state (0.390667ms)
(node:72807) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/grebmann/zcc-workspace/workbench/packages/lwc/applications/api/__tests__/multipart-upload.test.ts is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /Users/grebmann/zcc-workspace/workbench/package.json.
(Use `node --trace-warnings ...` to show where the warning was created)
(node:72808) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
✔ constants: exports expected enums (0.540042ms)
✔ generateDefaultTab: builds a tab with a guid id and the DEFAULT values (0.1565ms)
✔ generateDefaultTab: honours explicit id (0.092375ms)
✔ formattedContentType: recognises json/xml/csv/html/image types (0.176792ms)
✔ formattedContentType: unknown / null → text (0.066959ms)
✔ formatApiRequest: GET against relative endpoint uses instanceUrl (0.123667ms)
✔ formatApiRequest: absolute http URL is used as-is (0.039917ms)
✔ formatApiRequest: POST includes body + parses header string (0.077667ms)
✔ formatApiRequest: invalid header string sets error="Invalid Header" (0.0535ms)
✔ formatApiRequest: injects Sforce-Call-Options from _callOptions.client (0.075334ms)
✔ formatApiRequest: header object is forwarded; replaceVariableValues applied (0.067417ms)
✔ parseFormDataParts: returns valid serializable text and file parts (0.378458ms)
✔ parseFormDataParts: returns an empty list for malformed content (0.05025ms)
✔ DEFAULT_API_VERSION is a non-empty version string (0.038708ms)
✔ substituteVariables: replaces {key} tokens with variable values (0.099542ms)
✔ substituteVariables: replaces {sessionId} when a session token is provided (0.030209ms)
✔ substituteVariables: is safe against $-sequences in values (0.037292ms)
✔ substituteVariables: ignores null/undefined values, leaves token as-is (0.0275ms)
✔ parseVariables: valid JSON object → object; anything else → {} (0.063291ms)
✔ executeApiRequest: success path returns parsed JSON + headers + timing (10.146125ms)
✔ executeApiRequest: non-JSON response returns raw string content (0.139542ms)
✔ executeApiRequest: injects Bearer Authorization from accessToken when absent (0.124666ms)
✔ executeApiRequest: does not override an existing Authorization header (0.124209ms)
✔ executeApiRequest: does not inject Salesforce authorization for a presigned upload (0.15775ms)
✔ executeApiRequest: forwards FormData without setting Content-Type (0.259833ms)
✔ executeApiRequest: missing URL throws (0.182166ms)
(node:72808) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/grebmann/zcc-workspace/workbench/packages/lwc/shared/modules/utils/__tests__/api.test.ts is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /Users/grebmann/zcc-workspace/workbench/package.json.
(Use `node --trace-warnings ...` to show where the warning was created)
ℹ tests 31
ℹ suites 0
ℹ pass 31
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 153.582791
- 
> workbench@2.0.8 build:extension:main
> rm -rf dist/extension; npm run build:shared; npm run build:vendor:just-bash; rollup -c tools/build/rollup.extension.mjs --environment NODE_ENV:production,BUNDLE_TARGET:main


> workbench@2.0.8 build:shared
> node tools/scripts/generate_manifest_skill.js && node tools/scripts/generate_application_manifest.js && tsc -p packages/lwc/shared/tsconfig.json

Generated /Users/grebmann/zcc-workspace/workbench/assets/shared/skills/skill.manifest.json with 20 skill paths.
packages/lwc/main/application/applicationRegistry/application.manifest.json 21ms (unchanged)
packages/lwc/main/application/applicationRegistry/applicationRegistry.ts 26ms
Generated packages/lwc/main/application/applicationRegistry/application.manifest.json and packages/lwc/main/application/applicationRegistry/applicationRegistry.ts with 20 app manifests.

> workbench@2.0.8 build:vendor:just-bash
> cd vendor-bundles/just-bash && npm install && npm run build && cp dist/* ../../assets/extension/libs/just-bash/


up to date in 433ms

46 packages are looking for funding
  run `npm fund` for details

> just-bash-bundler@1.0.0 build
> rollup -c rollup.config.mjs