### PR TITLE
fix(nginx): redirect misdirected VS Code iframe bridge requests

### DIFF
--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -54,6 +54,18 @@ http {
             return 200 "ok\n";
         }
 
+        # Some extension builds have WORKBENCH_VSCODE_URL unset at build time (falls
+        # back to WORKBENCH_BASE_URL / this domain), so their VS Code iframe loads
+        # this landing page instead of vscode.sf-workbench.com — it never answers the
+        # JSForce/FS bridge handshake and the editor times out. Those requests are
+        # identifiable by the bridge query params the iframe always appends. Redirect
+        # them to the real VS Code app so already-shipped/locally-built extensions
+        # keep working without a new release. 302 (not 301) so this can be removed
+        # once affected extension builds have aged out without leaving a stale cache.
+        if ($args ~ "(^|&)(fsBridge|jsforceBridge|aiBridge)=1(&|$)") {
+            return 302 https://vscode.sf-workbench.com$uri?$args;
+        }
+
         # Canonical redirect: /app and /app/<path> → api.sf-workbench.com/<path>
         # Declared before the SPA catch-all so try_files doesn't swallow it.
         location ~ ^/app(/.*)?$ {


### PR DESCRIPTION
## Summary
- Extension builds without `WORKBENCH_VSCODE_URL` set at build time fall back to `WORKBENCH_BASE_URL`, so their VS Code iframe loads `www.sf-workbench.com` (the marketing landing page) instead of `vscode.sf-workbench.com`. The landing page never answers the JSForce/FS bridge handshake, so the editor times out with "Failed to initialize VSCode workbench — Iframe JSForce bridge handshake timed out."
- Adds a redirect on the `sf-workbench.com` / `www.sf-workbench.com` nginx server block: requests carrying the iframe's bridge query params (`fsBridge=1`, `jsforceBridge=1`, `aiBridge=1`) are 302'd to the equivalent path on `vscode.sf-workbench.com`.
- This fixes already-shipped/locally-built extensions without requiring a new extension release — only a server redeploy.
- Uses 302 (not 301) so the redirect can be removed later without leaving a stale browser cache once affected extension builds age out.

## Test plan
- [x] Rendered the template locally with `envsubst '$PORT'` and confirmed the `if` block sits at server level (evaluated before location matching) and doesn't break the existing `/healthz` or `/app` redirect blocks.
- [ ] After deploy, verify `https://www.sf-workbench.com/?fsBridge=1&jsforceBridge=1&aiBridge=1` returns a 302 to `https://vscode.sf-workbench.com/`.
- [ ] Reproduce the original failure (extension built with unset `WORKBENCH_VSCODE_URL`) and confirm the VS Code editor now loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)