### PR TITLE
chore(release): 2.0.9 - fix VS Code iframe bridge origin

### DIFF
--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -7,7 +7,7 @@ slug: /
 
 Workbench is a Salesforce productivity toolkit that ships as a **Chrome extension** and a **desktop app**. All surfaces share the same LWC frontend, an embedded VS Code workbench, and an AI agent for Salesforce-oriented tasks.
 
-Latest release: **v2.0.8**
+Latest release: **v2.0.9**
 
 It is the modern replacement for **Salesforce Workbench** and **Benchpress**.
 

--- a/assets/extension/releaseNotes.json
+++ b/assets/extension/releaseNotes.json
@@ -1,5 +1,22 @@
 [
     {
+        "version": "2.0.9",
+        "date": "August 8th, 2026",
+        "sections": [
+            {
+                "title": "Bug Fixes",
+                "categories": [
+                    {
+                        "category": "VS Code",
+                        "items": [
+                            "Fixed the VS Code editor iframe failing to load with an 'Iframe JSForce bridge handshake timed out' error on builds where the VS Code origin wasn't set correctly at build time; the iframe now always targets vscode.sf-workbench.com."
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
         "version": "2.0.8",
         "date": "July 15th, 2026",
         "sections": [

--- a/assets/server/data/announcements.json
+++ b/assets/server/data/announcements.json
@@ -1,13 +1,13 @@
 {
     "announcement": {
-        "id": "2026-07-15-2-0-8",
+        "id": "2026-08-08-2-0-9",
         "active": true,
         "variant": "brand",
-        "title": "Workbench 2.0.8 is here",
-        "message": "Workbench 2.0.8 fixes the overlay metadata spinner hanging on a stalled user/org lookup, the blank Current User card on non-enriched connections, stale Chrome reads after saving (record refreshes and async job polling now bypass the browser cache), a clipped picklist dropdown in the filtered Record Explorer, and two VS Code issues — undetected expired sessions across the iframe bridge and long Metadata API retrieves timing out (now cancellable).",
+        "title": "Workbench 2.0.9 is here",
+        "message": "Workbench 2.0.9 fixes the VS Code editor iframe failing to load with an 'Iframe JSForce bridge handshake timed out' error on builds where the VS Code origin wasn't set correctly at build time.",
         "linkLabel": "View release notes",
         "linkUrl": "https://www.sf-workbench.com/app?applicationName=release",
-        "startsAt": "2026-07-15T00:00:00Z",
+        "startsAt": "2026-08-08T00:00:00Z",
         "endsAt": "2026-12-31T23:59:59Z"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "workbench",
-    "version": "2.0.8",
+    "version": "2.0.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "workbench",
-            "version": "2.0.8",
+            "version": "2.0.9",
             "hasInstallScript": true,
             "dependencies": {
                 "@ai-sdk/anthropic": "^3.0.68",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "workbench",
-    "version": "2.0.8",
+    "version": "2.0.9",
     "scripts": {
         "start:dev:extension": "rm -rf dist/extension; npm-run-all --parallel watch:extension serve:extension",
         "start:dev:server": "npm run build:server && NODE_ENV=development DOTENV_CONFIG_PATH=.env.dev node -r dotenv/config packages/server/dist/server-dev.js",

--- a/packages/desktop/package-lock.json
+++ b/packages/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@workbench/desktop",
-    "version": "2.0.8",
+    "version": "2.0.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@workbench/desktop",
-            "version": "2.0.8",
+            "version": "2.0.9",
             "bin": {
                 "workbench-desktop": "dist/cli/desktopCli.js"
             },

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@workbench/desktop",
-    "version": "2.0.8",
+    "version": "2.0.9",
     "private": true,
     "description": "Electron desktop shell for Workbench",
     "productName": "Workbench Desktop",

--- a/packages/lwc/applications/object/sobject/sobject.html
+++ b/packages/lwc/applications/object/sobject/sobject.html
@@ -153,85 +153,314 @@
                 <!-- Detail Tabs -->
                 <div class="slds-m-top_small">
                     <lightning-tabset variant="scoped" active-tab-value={detailTab}>
-                        <lightning-tab label="Schema" value="schema" onactive={handleDetailTabActive}>
-                    <!-- Available APIs -->
-                    <section class={availableApisSectionClass}>
-                        <h3 class="slds-section__title">
-                            <button
-                                class="slds-button slds-section__title-action"
-                                data-section="availableApis"
-                                onclick={handleToggleSection}
-                                aria-expanded={isAvailableApisOpen}>
-                                <lightning-icon
-                                    icon-name={availableApisChevronIcon}
-                                    size="xx-small"
-                                    class="slds-m-right_x-small"></lightning-icon>
-                                <span class="slds-truncate" title="Available APIs">
-                                    Available APIs
-                                </span>
-                                <span class="slds-badge slds-m-left_x-small">
-                                    {availableApisCount}
-                                </span>
-                            </button>
-                        </h3>
-                        <template lwc:if={isAvailableApisOpen}>
-                            <div
-                                class="slds-section__content slds-p-horizontal_small slds-p-bottom_small">
-                                <div class="slds-grid slds-wrap">
-                                    <template for:each={availableApis} for:item="apiItem">
-                                        <div
-                                            key={apiItem.key}
-                                            class="slds-col slds-grow_none slds-m-top_x-small slds-m-right_x-small">
-                                            <span class={apiItem.colorClass}>{apiItem.label}</span>
+                        <lightning-tab
+                            label="Schema"
+                            value="schema"
+                            onactive={handleDetailTabActive}>
+                            <!-- Available APIs -->
+                            <section class={availableApisSectionClass}>
+                                <h3 class="slds-section__title">
+                                    <button
+                                        class="slds-button slds-section__title-action"
+                                        data-section="availableApis"
+                                        onclick={handleToggleSection}
+                                        aria-expanded={isAvailableApisOpen}>
+                                        <lightning-icon
+                                            icon-name={availableApisChevronIcon}
+                                            size="xx-small"
+                                            class="slds-m-right_x-small"></lightning-icon>
+                                        <span class="slds-truncate" title="Available APIs">
+                                            Available APIs
+                                        </span>
+                                        <span class="slds-badge slds-m-left_x-small">
+                                            {availableApisCount}
+                                        </span>
+                                    </button>
+                                </h3>
+                                <template lwc:if={isAvailableApisOpen}>
+                                    <div
+                                        class="slds-section__content slds-p-horizontal_small slds-p-bottom_small">
+                                        <div class="slds-grid slds-wrap">
+                                            <template for:each={availableApis} for:item="apiItem">
+                                                <div
+                                                    key={apiItem.key}
+                                                    class="slds-col slds-grow_none slds-m-top_x-small slds-m-right_x-small">
+                                                    <span class={apiItem.colorClass}>
+                                                        {apiItem.label}
+                                                    </span>
+                                                </div>
+                                            </template>
                                         </div>
-                                    </template>
-                                </div>
-                            </div>
-                        </template>
-                    </section>
+                                    </div>
+                                </template>
+                            </section>
 
-                    <!-- Relationships -->
-                    <section class={relationshipsSectionClass}>
-                        <h3 class="slds-section__title">
-                            <button
-                                class="slds-button slds-section__title-action"
-                                data-section="relationships"
-                                onclick={handleToggleSection}
-                                aria-expanded={isRelationshipsOpen}>
-                                <lightning-icon
-                                    icon-name={relationshipsChevronIcon}
-                                    size="xx-small"
-                                    class="slds-m-right_x-small"></lightning-icon>
-                                <span class="slds-truncate" title="Relationships">
-                                    Relationships
-                                </span>
-                                <span class="slds-badge slds-m-left_x-small">
-                                    {relationshipsCount}
-                                </span>
-                            </button>
-                        </h3>
-                        <template lwc:if={isRelationshipsOpen}>
-                            <div
-                                class="slds-section__content slds-p-horizontal_small slds-p-bottom_small">
-                                <lightning-tabset
-                                    variant="scoped"
-                                    active-tab-value={relationshipTab}>
-                                    <lightning-tab
-                                        label="Lookups"
-                                        value="lookups"
-                                        onactive={handleRelationshipTabActive}>
-                                        <div class="slds-m-bottom_x-small slds-m-top_x-small">
+                            <!-- Relationships -->
+                            <section class={relationshipsSectionClass}>
+                                <h3 class="slds-section__title">
+                                    <button
+                                        class="slds-button slds-section__title-action"
+                                        data-section="relationships"
+                                        onclick={handleToggleSection}
+                                        aria-expanded={isRelationshipsOpen}>
+                                        <lightning-icon
+                                            icon-name={relationshipsChevronIcon}
+                                            size="xx-small"
+                                            class="slds-m-right_x-small"></lightning-icon>
+                                        <span class="slds-truncate" title="Relationships">
+                                            Relationships
+                                        </span>
+                                        <span class="slds-badge slds-m-left_x-small">
+                                            {relationshipsCount}
+                                        </span>
+                                    </button>
+                                </h3>
+                                <template lwc:if={isRelationshipsOpen}>
+                                    <div
+                                        class="slds-section__content slds-p-horizontal_small slds-p-bottom_small">
+                                        <lightning-tabset
+                                            variant="scoped"
+                                            active-tab-value={relationshipTab}>
+                                            <lightning-tab
+                                                label="Lookups"
+                                                value="lookups"
+                                                onactive={handleRelationshipTabActive}>
+                                                <div
+                                                    class="slds-m-bottom_x-small slds-m-top_x-small">
+                                                    <lightning-input
+                                                        type="search"
+                                                        label=""
+                                                        placeholder="Search lookups..."
+                                                        variant="label-hidden"
+                                                        value={relationshipSearch}
+                                                        onchange={handleRelationshipSearch}></lightning-input>
+                                                </div>
+                                                <template lwc:if={hasNoLookups}>
+                                                    <div
+                                                        class="slds-text-color_weak slds-m-top_small">
+                                                        No lookups found.
+                                                    </div>
+                                                </template>
+                                                <template lwc:else>
+                                                    <div class="data-table-wrapper">
+                                                        <table
+                                                            class="slds-table slds-table_cell-buffer slds-table_bordered slds-table_col-bordered slds-table_striped">
+                                                            <thead>
+                                                                <tr class="slds-line-height_reset">
+                                                                    <th scope="col">
+                                                                        <div
+                                                                            class="slds-truncate"
+                                                                            title="Label">
+                                                                            Label
+                                                                        </div>
+                                                                    </th>
+                                                                    <th scope="col">
+                                                                        <div
+                                                                            class="slds-truncate"
+                                                                            title="API Field">
+                                                                            API Field
+                                                                        </div>
+                                                                    </th>
+                                                                    <th scope="col">
+                                                                        <div
+                                                                            class="slds-truncate"
+                                                                            title="Relationship Name">
+                                                                            Relationship
+                                                                        </div>
+                                                                    </th>
+                                                                    <th scope="col">
+                                                                        <div
+                                                                            class="slds-truncate"
+                                                                            title="Target Object">
+                                                                            Target Object
+                                                                        </div>
+                                                                    </th>
+                                                                </tr>
+                                                            </thead>
+                                                            <tbody>
+                                                                <template
+                                                                    for:each={filteredLookups}
+                                                                    for:item="lookup">
+                                                                    <tr key={lookup.key}>
+                                                                        <td
+                                                                            class="slds-truncate"
+                                                                            title={lookup.label}>
+                                                                            {lookup.label}
+                                                                        </td>
+                                                                        <td>
+                                                                            <div
+                                                                                class="slds-grid slds-grid_vertical-align-center row-api-name">
+                                                                                <span
+                                                                                    class="slds-truncate"
+                                                                                    title={lookup.fieldName}>
+                                                                                    {lookup.fieldName}
+                                                                                </span>
+                                                                                <lightning-button-icon
+                                                                                    icon-name="utility:copy"
+                                                                                    variant="bare"
+                                                                                    size="small"
+                                                                                    class="copy-btn"
+                                                                                    alternative-text="Copy field name"
+                                                                                    title="Copy field name"
+                                                                                    data-value={lookup.fieldName}
+                                                                                    onclick={handleCopyValue}></lightning-button-icon>
+                                                                            </div>
+                                                                        </td>
+                                                                        <td
+                                                                            class="slds-truncate"
+                                                                            title={lookup.relationshipName}>
+                                                                            {lookup.relationshipName}
+                                                                        </td>
+                                                                        <td>
+                                                                            <button
+                                                                                type="button"
+                                                                                class="slds-button slds-button_reset related-object-btn"
+                                                                                data-name={lookup.target}
+                                                                                onclick={handleOpenRelatedSObject}
+                                                                                title={lookup.target}>
+                                                                                {lookup.target}
+                                                                            </button>
+                                                                        </td>
+                                                                    </tr>
+                                                                </template>
+                                                            </tbody>
+                                                        </table>
+                                                    </div>
+                                                </template>
+                                            </lightning-tab>
+                                            <lightning-tab
+                                                label="Children"
+                                                value="children"
+                                                onactive={handleRelationshipTabActive}>
+                                                <div
+                                                    class="slds-m-bottom_x-small slds-m-top_x-small">
+                                                    <lightning-input
+                                                        type="search"
+                                                        label=""
+                                                        placeholder="Search children..."
+                                                        variant="label-hidden"
+                                                        value={relationshipSearch}
+                                                        onchange={handleRelationshipSearch}></lightning-input>
+                                                </div>
+                                                <template lwc:if={hasNoChildren}>
+                                                    <div
+                                                        class="slds-text-color_weak slds-m-top_small">
+                                                        No child relationships found.
+                                                    </div>
+                                                </template>
+                                                <template lwc:else>
+                                                    <div class="data-table-wrapper">
+                                                        <table
+                                                            class="slds-table slds-table_cell-buffer slds-table_bordered slds-table_col-bordered slds-table_striped">
+                                                            <thead>
+                                                                <tr class="slds-line-height_reset">
+                                                                    <th scope="col">
+                                                                        <div
+                                                                            class="slds-truncate"
+                                                                            title="Relationship Name">
+                                                                            Relationship
+                                                                        </div>
+                                                                    </th>
+                                                                    <th scope="col">
+                                                                        <div
+                                                                            class="slds-truncate"
+                                                                            title="Child SObject">
+                                                                            Child Object
+                                                                        </div>
+                                                                    </th>
+                                                                    <th scope="col">
+                                                                        <div
+                                                                            class="slds-truncate"
+                                                                            title="Field">
+                                                                            Field
+                                                                        </div>
+                                                                    </th>
+                                                                </tr>
+                                                            </thead>
+                                                            <tbody>
+                                                                <template
+                                                                    for:each={filteredChildren}
+                                                                    for:item="child">
+                                                                    <tr key={child.key}>
+                                                                        <td>
+                                                                            <div
+                                                                                class="slds-grid slds-grid_vertical-align-center row-api-name">
+                                                                                <span
+                                                                                    class="slds-truncate"
+                                                                                    title={child.relationshipName}>
+                                                                                    {child.relationshipName}
+                                                                                </span>
+                                                                                <lightning-button-icon
+                                                                                    icon-name="utility:copy"
+                                                                                    variant="bare"
+                                                                                    size="small"
+                                                                                    class="copy-btn"
+                                                                                    alternative-text="Copy relationship name"
+                                                                                    title="Copy relationship name"
+                                                                                    data-value={child.relationshipName}
+                                                                                    onclick={handleCopyValue}></lightning-button-icon>
+                                                                            </div>
+                                                                        </td>
+                                                                        <td>
+                                                                            <button
+                                                                                type="button"
+                                                                                class="slds-button slds-button_reset related-object-btn"
+                                                                                data-name={child.childSObject}
+                                                                                onclick={handleOpenRelatedSObject}
+                                                                                title={child.childSObject}>
+                                                                                {child.childSObject}
+                                                                            </button>
+                                                                        </td>
+                                                                        <td
+                                                                            class="slds-truncate"
+                                                                            title={child.field}>
+                                                                            {child.field}
+                                                                        </td>
+                                                                    </tr>
+                                                                </template>
+                                                            </tbody>
+                                                        </table>
+                                                    </div>
+                                                </template>
+                                            </lightning-tab>
+                                        </lightning-tabset>
+                                    </div>
+                                </template>
+                            </section>
+
+                            <!-- Fields -->
+                            <section class={fieldsSectionClass}>
+                                <h3 class="slds-section__title">
+                                    <button
+                                        class="slds-button slds-section__title-action"
+                                        data-section="fields"
+                                        onclick={handleToggleSection}
+                                        aria-expanded={isFieldsOpen}>
+                                        <lightning-icon
+                                            icon-name={fieldsChevronIcon}
+                                            size="xx-small"
+                                            class="slds-m-right_x-small"></lightning-icon>
+                                        <span class="slds-truncate" title="Fields">Fields</span>
+                                        <span class="slds-badge slds-m-left_x-small">
+                                            {fieldsCount}
+                                        </span>
+                                    </button>
+                                </h3>
+                                <template lwc:if={isFieldsOpen}>
+                                    <div
+                                        class="slds-section__content slds-p-horizontal_small slds-p-bottom_small">
+                                        <div class="slds-m-bottom_x-small">
                                             <lightning-input
                                                 type="search"
                                                 label=""
-                                                placeholder="Search lookups..."
+                                                placeholder="Search fields..."
                                                 variant="label-hidden"
-                                                value={relationshipSearch}
-                                                onchange={handleRelationshipSearch}></lightning-input>
+                                                value={fieldSearch}
+                                                onchange={handleFieldSearch}></lightning-input>
                                         </div>
-                                        <template lwc:if={hasNoLookups}>
+                                        <template lwc:if={hasNoFields}>
                                             <div class="slds-text-color_weak slds-m-top_small">
-                                                No lookups found.
+                                                No fields found.
                                             </div>
                                         </template>
                                         <template lwc:else>
@@ -240,6 +469,13 @@
                                                     class="slds-table slds-table_cell-buffer slds-table_bordered slds-table_col-bordered slds-table_striped">
                                                     <thead>
                                                         <tr class="slds-line-height_reset">
+                                                            <th scope="col" class="col-type">
+                                                                <div
+                                                                    class="slds-truncate"
+                                                                    title="Type">
+                                                                    Type
+                                                                </div>
+                                                            </th>
                                                             <th scope="col">
                                                                 <div
                                                                     class="slds-truncate"
@@ -250,434 +486,243 @@
                                                             <th scope="col">
                                                                 <div
                                                                     class="slds-truncate"
-                                                                    title="API Field">
-                                                                    API Field
+                                                                    title="API Name">
+                                                                    API Name
                                                                 </div>
                                                             </th>
-                                                            <th scope="col">
+                                                            <th scope="col" class="col-flag">
                                                                 <div
                                                                     class="slds-truncate"
-                                                                    title="Relationship Name">
-                                                                    Relationship
+                                                                    title="Required">
+                                                                    Req.
                                                                 </div>
                                                             </th>
-                                                            <th scope="col">
+                                                            <th scope="col" class="col-extras">
                                                                 <div
                                                                     class="slds-truncate"
-                                                                    title="Target Object">
-                                                                    Target Object
+                                                                    title="Extra">
+                                                                    Extra
                                                                 </div>
                                                             </th>
                                                         </tr>
                                                     </thead>
                                                     <tbody>
                                                         <template
-                                                            for:each={filteredLookups}
-                                                            for:item="lookup">
-                                                            <tr key={lookup.key}>
+                                                            for:each={filteredFieldsWithMeta}
+                                                            for:item="field">
+                                                            <tr
+                                                                key={field.name}
+                                                                class={field._rowClass}>
+                                                                <td class="col-type">
+                                                                    <div
+                                                                        class="type-cell"
+                                                                        title={field._type}>
+                                                                        <slds-lucide-icon
+                                                                            name={field._iconName}
+                                                                            size="13"
+                                                                            stroke-width="1.75"
+                                                                            class="type-icon"></slds-lucide-icon>
+                                                                        <span
+                                                                            class="field-type-tag">
+                                                                            {field._type}
+                                                                        </span>
+                                                                    </div>
+                                                                </td>
                                                                 <td
                                                                     class="slds-truncate"
-                                                                    title={lookup.label}>
-                                                                    {lookup.label}
+                                                                    title={field.label}>
+                                                                    {field.label}
                                                                 </td>
                                                                 <td>
                                                                     <div
                                                                         class="slds-grid slds-grid_vertical-align-center row-api-name">
                                                                         <span
                                                                             class="slds-truncate"
-                                                                            title={lookup.fieldName}>
-                                                                            {lookup.fieldName}
+                                                                            title={field.name}>
+                                                                            {field.name}
                                                                         </span>
                                                                         <lightning-button-icon
                                                                             icon-name="utility:copy"
                                                                             variant="bare"
                                                                             size="small"
                                                                             class="copy-btn"
-                                                                            alternative-text="Copy field name"
-                                                                            title="Copy field name"
-                                                                            data-value={lookup.fieldName}
+                                                                            alternative-text="Copy API name"
+                                                                            title="Copy API name"
+                                                                            data-value={field.name}
                                                                             onclick={handleCopyValue}></lightning-button-icon>
                                                                     </div>
                                                                 </td>
                                                                 <td
-                                                                    class="slds-truncate"
-                                                                    title={lookup.relationshipName}>
-                                                                    {lookup.relationshipName}
+                                                                    class="col-flag slds-text-align_center">
+                                                                    <template
+                                                                        lwc:if={field._isRequired}>
+                                                                        <lightning-icon
+                                                                            icon-name="utility:check"
+                                                                            size="xx-small"
+                                                                            class="req-check-icon"
+                                                                            title="Required"></lightning-icon>
+                                                                    </template>
                                                                 </td>
-                                                                <td>
-                                                                    <button
-                                                                        type="button"
-                                                                        class="slds-button slds-button_reset related-object-btn"
-                                                                        data-name={lookup.target}
-                                                                        onclick={handleOpenRelatedSObject}
-                                                                        title={lookup.target}>
-                                                                        {lookup.target}
-                                                                    </button>
+                                                                <td
+                                                                    class="col-extras slds-text-align_center">
+                                                                    <template
+                                                                        lwc:if={field._hasExtra}>
+                                                                        <button
+                                                                            type="button"
+                                                                            class={field._expandBtnClass}
+                                                                            data-key={field.name}
+                                                                            onclick={handleToggleFieldExpand}
+                                                                            title="Show field details">
+                                                                            <lightning-icon
+                                                                                icon-name="utility:info"
+                                                                                size="x-small"></lightning-icon>
+                                                                        </button>
+                                                                    </template>
                                                                 </td>
                                                             </tr>
                                                         </template>
                                                     </tbody>
                                                 </table>
                                             </div>
-                                        </template>
-                                    </lightning-tab>
-                                    <lightning-tab
-                                        label="Children"
-                                        value="children"
-                                        onactive={handleRelationshipTabActive}>
-                                        <div class="slds-m-bottom_x-small slds-m-top_x-small">
-                                            <lightning-input
-                                                type="search"
-                                                label=""
-                                                placeholder="Search children..."
-                                                variant="label-hidden"
-                                                value={relationshipSearch}
-                                                onchange={handleRelationshipSearch}></lightning-input>
-                                        </div>
-                                        <template lwc:if={hasNoChildren}>
-                                            <div class="slds-text-color_weak slds-m-top_small">
-                                                No child relationships found.
-                                            </div>
-                                        </template>
-                                        <template lwc:else>
-                                            <div class="data-table-wrapper">
-                                                <table
-                                                    class="slds-table slds-table_cell-buffer slds-table_bordered slds-table_col-bordered slds-table_striped">
-                                                    <thead>
-                                                        <tr class="slds-line-height_reset">
-                                                            <th scope="col">
-                                                                <div
-                                                                    class="slds-truncate"
-                                                                    title="Relationship Name">
-                                                                    Relationship
-                                                                </div>
-                                                            </th>
-                                                            <th scope="col">
-                                                                <div
-                                                                    class="slds-truncate"
-                                                                    title="Child SObject">
-                                                                    Child Object
-                                                                </div>
-                                                            </th>
-                                                            <th scope="col">
-                                                                <div
-                                                                    class="slds-truncate"
-                                                                    title="Field">
-                                                                    Field
-                                                                </div>
-                                                            </th>
-                                                        </tr>
-                                                    </thead>
-                                                    <tbody>
-                                                        <template
-                                                            for:each={filteredChildren}
-                                                            for:item="child">
-                                                            <tr key={child.key}>
-                                                                <td>
-                                                                    <div
-                                                                        class="slds-grid slds-grid_vertical-align-center row-api-name">
-                                                                        <span
-                                                                            class="slds-truncate"
-                                                                            title={child.relationshipName}>
-                                                                            {child.relationshipName}
-                                                                        </span>
-                                                                        <lightning-button-icon
-                                                                            icon-name="utility:copy"
-                                                                            variant="bare"
-                                                                            size="small"
-                                                                            class="copy-btn"
-                                                                            alternative-text="Copy relationship name"
-                                                                            title="Copy relationship name"
-                                                                            data-value={child.relationshipName}
-                                                                            onclick={handleCopyValue}></lightning-button-icon>
-                                                                    </div>
-                                                                </td>
-                                                                <td>
-                                                                    <button
-                                                                        type="button"
-                                                                        class="slds-button slds-button_reset related-object-btn"
-                                                                        data-name={child.childSObject}
-                                                                        onclick={handleOpenRelatedSObject}
-                                                                        title={child.childSObject}>
-                                                                        {child.childSObject}
-                                                                    </button>
-                                                                </td>
-                                                                <td
-                                                                    class="slds-truncate"
-                                                                    title={child.field}>
-                                                                    {child.field}
-                                                                </td>
-                                                            </tr>
-                                                        </template>
-                                                    </tbody>
-                                                </table>
-                                            </div>
-                                        </template>
-                                    </lightning-tab>
-                                </lightning-tabset>
-                            </div>
-                        </template>
-                    </section>
-
-                    <!-- Fields -->
-                    <section class={fieldsSectionClass}>
-                        <h3 class="slds-section__title">
-                            <button
-                                class="slds-button slds-section__title-action"
-                                data-section="fields"
-                                onclick={handleToggleSection}
-                                aria-expanded={isFieldsOpen}>
-                                <lightning-icon
-                                    icon-name={fieldsChevronIcon}
-                                    size="xx-small"
-                                    class="slds-m-right_x-small"></lightning-icon>
-                                <span class="slds-truncate" title="Fields">Fields</span>
-                                <span class="slds-badge slds-m-left_x-small">{fieldsCount}</span>
-                            </button>
-                        </h3>
-                        <template lwc:if={isFieldsOpen}>
-                            <div
-                                class="slds-section__content slds-p-horizontal_small slds-p-bottom_small">
-                                <div class="slds-m-bottom_x-small">
-                                    <lightning-input
-                                        type="search"
-                                        label=""
-                                        placeholder="Search fields..."
-                                        variant="label-hidden"
-                                        value={fieldSearch}
-                                        onchange={handleFieldSearch}></lightning-input>
-                                </div>
-                                <template lwc:if={hasNoFields}>
-                                    <div class="slds-text-color_weak slds-m-top_small">
-                                        No fields found.
-                                    </div>
-                                </template>
-                                <template lwc:else>
-                                    <div class="data-table-wrapper">
-                                        <table
-                                            class="slds-table slds-table_cell-buffer slds-table_bordered slds-table_col-bordered slds-table_striped">
-                                            <thead>
-                                                <tr class="slds-line-height_reset">
-                                                    <th scope="col" class="col-type">
-                                                        <div class="slds-truncate" title="Type">
-                                                            Type
-                                                        </div>
-                                                    </th>
-                                                    <th scope="col">
-                                                        <div class="slds-truncate" title="Label">
-                                                            Label
-                                                        </div>
-                                                    </th>
-                                                    <th scope="col">
-                                                        <div class="slds-truncate" title="API Name">
-                                                            API Name
-                                                        </div>
-                                                    </th>
-                                                    <th scope="col" class="col-flag">
-                                                        <div class="slds-truncate" title="Required">
-                                                            Req.
-                                                        </div>
-                                                    </th>
-                                                    <th scope="col" class="col-extras">
-                                                        <div class="slds-truncate" title="Extra">
-                                                            Extra
-                                                        </div>
-                                                    </th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                <template
-                                                    for:each={filteredFieldsWithMeta}
-                                                    for:item="field">
-                                                    <tr key={field.name} class={field._rowClass}>
-                                                        <td class="col-type">
+                                            <!-- Field detail panel, shown when a row is expanded -->
+                                            <template lwc:if={expandedField}>
+                                                <div class="field-detail-panel">
+                                                    <div class="field-detail-panel__header">
+                                                        <div class="field-detail-panel__title">
                                                             <div
-                                                                class="type-cell"
-                                                                title={field._type}>
+                                                                class="type-cell slds-m-right_x-small"
+                                                                title={expandedField._type}>
                                                                 <slds-lucide-icon
-                                                                    name={field._iconName}
+                                                                    name={expandedField._iconName}
                                                                     size="13"
                                                                     stroke-width="1.75"
                                                                     class="type-icon"></slds-lucide-icon>
                                                                 <span class="field-type-tag">
-                                                                    {field._type}
+                                                                    {expandedField._type}
                                                                 </span>
                                                             </div>
-                                                        </td>
-                                                        <td
-                                                            class="slds-truncate"
-                                                            title={field.label}>
-                                                            {field.label}
-                                                        </td>
-                                                        <td>
-                                                            <div
-                                                                class="slds-grid slds-grid_vertical-align-center row-api-name">
+                                                            <strong>{expandedField.label}</strong>
+                                                            <span
+                                                                class="slds-text-color_weak slds-m-left_x-small">
+                                                                — {expandedField.name}
+                                                            </span>
+                                                        </div>
+                                                        <button
+                                                            type="button"
+                                                            class="slds-button slds-button_icon slds-button_icon-bare"
+                                                            onclick={handleCloseFieldDetail}
+                                                            title="Close">
+                                                            <lightning-icon
+                                                                icon-name="utility:close"
+                                                                size="x-small"></lightning-icon>
+                                                        </button>
+                                                    </div>
+                                                    <div class="field-detail-panel__body">
+                                                        <!-- Capabilities -->
+                                                        <div class="field-detail-caps">
+                                                            <template
+                                                                for:each={expandedFieldCapabilities}
+                                                                for:item="cap">
                                                                 <span
-                                                                    class="slds-truncate"
-                                                                    title={field.name}>
-                                                                    {field.name}
+                                                                    key={cap.key}
+                                                                    class={cap.cls}
+                                                                    title={cap.label}>
+                                                                    {cap.label}
                                                                 </span>
-                                                                <lightning-button-icon
-                                                                    icon-name="utility:copy"
-                                                                    variant="bare"
-                                                                    size="small"
-                                                                    class="copy-btn"
-                                                                    alternative-text="Copy API name"
-                                                                    title="Copy API name"
-                                                                    data-value={field.name}
-                                                                    onclick={handleCopyValue}></lightning-button-icon>
+                                                            </template>
+                                                        </div>
+                                                        <!-- Help text -->
+                                                        <template lwc:if={expandedFieldHelpText}>
+                                                            <div class="field-detail-row">
+                                                                <span
+                                                                    class="field-detail-row__label">
+                                                                    Help text
+                                                                </span>
+                                                                <span
+                                                                    class="field-detail-row__value">
+                                                                    {expandedFieldHelpText}
+                                                                </span>
                                                             </div>
-                                                        </td>
-                                                        <td class="col-flag slds-text-align_center">
-                                                            <template lwc:if={field._isRequired}>
-                                                                <lightning-icon
-                                                                    icon-name="utility:check"
-                                                                    size="xx-small"
-                                                                    class="req-check-icon"
-                                                                    title="Required"></lightning-icon>
-                                                            </template>
-                                                        </td>
-                                                        <td
-                                                            class="col-extras slds-text-align_center">
-                                                            <template lwc:if={field._hasExtra}>
-                                                                <button
-                                                                    type="button"
-                                                                    class={field._expandBtnClass}
-                                                                    data-key={field.name}
-                                                                    onclick={handleToggleFieldExpand}
-                                                                    title="Show field details">
-                                                                    <lightning-icon
-                                                                        icon-name="utility:info"
-                                                                        size="x-small"></lightning-icon>
-                                                                </button>
-                                                            </template>
-                                                        </td>
-                                                    </tr>
-                                                </template>
-                                            </tbody>
-                                        </table>
+                                                        </template>
+                                                        <!-- Formula -->
+                                                        <template lwc:if={expandedField._isFormula}>
+                                                            <div class="field-detail-row">
+                                                                <span
+                                                                    class="field-detail-row__label">
+                                                                    Formula
+                                                                </span>
+                                                                <code
+                                                                    class="field-detail-row__code">
+                                                                    {expandedField._formulaPreview}
+                                                                </code>
+                                                            </div>
+                                                        </template>
+                                                        <!-- Picklist values -->
+                                                        <template
+                                                            lwc:if={expandedField._isPicklist}>
+                                                            <div class="field-detail-row">
+                                                                <span
+                                                                    class="field-detail-row__label">
+                                                                    Values
+                                                                    ({expandedField._picklistCount})
+                                                                </span>
+                                                                <span
+                                                                    class="field-detail-row__value">
+                                                                    {expandedField._picklistValuesPreview}
+                                                                </span>
+                                                            </div>
+                                                        </template>
+                                                    </div>
+                                                </div>
+                                            </template>
+                                        </template>
                                     </div>
-                                    <!-- Field detail panel, shown when a row is expanded -->
-                                    <template lwc:if={expandedField}>
-                                        <div class="field-detail-panel">
-                                            <div class="field-detail-panel__header">
-                                                <div class="field-detail-panel__title">
-                                                    <div
-                                                        class="type-cell slds-m-right_x-small"
-                                                        title={expandedField._type}>
-                                                        <slds-lucide-icon
-                                                            name={expandedField._iconName}
-                                                            size="13"
-                                                            stroke-width="1.75"
-                                                            class="type-icon"></slds-lucide-icon>
-                                                        <span class="field-type-tag">
-                                                            {expandedField._type}
-                                                        </span>
-                                                    </div>
-                                                    <strong>{expandedField.label}</strong>
-                                                    <span
-                                                        class="slds-text-color_weak slds-m-left_x-small">
-                                                        — {expandedField.name}
-                                                    </span>
-                                                </div>
-                                                <button
-                                                    type="button"
-                                                    class="slds-button slds-button_icon slds-button_icon-bare"
-                                                    onclick={handleCloseFieldDetail}
-                                                    title="Close">
-                                                    <lightning-icon
-                                                        icon-name="utility:close"
-                                                        size="x-small"></lightning-icon>
-                                                </button>
-                                            </div>
-                                            <div class="field-detail-panel__body">
-                                                <!-- Capabilities -->
-                                                <div class="field-detail-caps">
-                                                    <template
-                                                        for:each={expandedFieldCapabilities}
-                                                        for:item="cap">
-                                                        <span
-                                                            key={cap.key}
-                                                            class={cap.cls}
-                                                            title={cap.label}>
-                                                            {cap.label}
-                                                        </span>
-                                                    </template>
-                                                </div>
-                                                <!-- Help text -->
-                                                <template lwc:if={expandedFieldHelpText}>
-                                                    <div class="field-detail-row">
-                                                        <span class="field-detail-row__label">
-                                                            Help text
-                                                        </span>
-                                                        <span class="field-detail-row__value">
-                                                            {expandedFieldHelpText}
-                                                        </span>
-                                                    </div>
-                                                </template>
-                                                <!-- Formula -->
-                                                <template lwc:if={expandedField._isFormula}>
-                                                    <div class="field-detail-row">
-                                                        <span class="field-detail-row__label">
-                                                            Formula
-                                                        </span>
-                                                        <code class="field-detail-row__code">
-                                                            {expandedField._formulaPreview}
-                                                        </code>
-                                                    </div>
-                                                </template>
-                                                <!-- Picklist values -->
-                                                <template lwc:if={expandedField._isPicklist}>
-                                                    <div class="field-detail-row">
-                                                        <span class="field-detail-row__label">
-                                                            Values ({expandedField._picklistCount})
-                                                        </span>
-                                                        <span class="field-detail-row__value">
-                                                            {expandedField._picklistValuesPreview}
-                                                        </span>
-                                                    </div>
-                                                </template>
-                                            </div>
-                                        </div>
-                                    </template>
                                 </template>
-                            </div>
-                        </template>
-                    </section>
+                            </section>
 
-                    <!-- Diagram -->
-                    <section class="slds-section slds-is-open slds-m-top_small">
-                        <h3 class="slds-section__title">
-                            <span class="slds-button slds-section__title-action slds-p-left_none">
-                                <span class="slds-truncate" title="Diagram">Diagram</span>
-                            </span>
-                        </h3>
-                        <div
-                            class="slds-section__content slds-p-horizontal_small slds-p-bottom_small">
-                            <div class="slds-grid slds-grid_align-end slds-m-bottom_small">
-                                <lightning-input
-                                    type="toggle"
-                                    label="Display Diagram"
-                                    name="displayDiagram"
-                                    message-toggle-active=""
-                                    message-toggle-inactive=""
-                                    checked={isDiagramDisplayed}
-                                    onchange={handleDisplayDiagram}></lightning-input>
-                            </div>
-                            <div class="slds-is-relative">
-                                <div class={mermaidClass} lwc:ref="mermaid" lwc:dom="manual"></div>
-                            </div>
-                        </div>
-                    </section>
+                            <!-- Diagram -->
+                            <section class="slds-section slds-is-open slds-m-top_small">
+                                <h3 class="slds-section__title">
+                                    <span
+                                        class="slds-button slds-section__title-action slds-p-left_none">
+                                        <span class="slds-truncate" title="Diagram">Diagram</span>
+                                    </span>
+                                </h3>
+                                <div
+                                    class="slds-section__content slds-p-horizontal_small slds-p-bottom_small">
+                                    <div class="slds-grid slds-grid_align-end slds-m-bottom_small">
+                                        <lightning-input
+                                            type="toggle"
+                                            label="Display Diagram"
+                                            name="displayDiagram"
+                                            message-toggle-active=""
+                                            message-toggle-inactive=""
+                                            checked={isDiagramDisplayed}
+                                            onchange={handleDisplayDiagram}></lightning-input>
+                                    </div>
+                                    <div class="slds-is-relative">
+                                        <div
+                                            class={mermaidClass}
+                                            lwc:ref="mermaid"
+                                            lwc:dom="manual"></div>
+                                    </div>
+                                </div>
+                            </section>
                         </lightning-tab>
 
-                        <lightning-tab label="Blueprint" value="blueprint" onactive={handleDetailTabActive}>
+                        <lightning-tab
+                            label="Blueprint"
+                            value="blueprint"
+                            onactive={handleDetailTabActive}>
                             <object-blueprint
                                 lwc:ref="blueprintView"
                                 object-name={activeObjectName}></object-blueprint>
                         </lightning-tab>
 
-                        <lightning-tab label="Limits" value="limits" onactive={handleDetailTabActive}>
+                        <lightning-tab
+                            label="Limits"
+                            value="limits"
+                            onactive={handleDetailTabActive}>
                             <object-blueprint-limits
                                 lwc:ref="limitsView"
                                 object-name={activeObjectName}></object-blueprint-limits>

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > The modern replacement for **Salesforce Workbench** and **Benchpress**
 
-Latest release: **v2.0.8**
+Latest release: **v2.0.9**
 
 Workbench is a Salesforce administration toolkit that embeds directly into your browser — bringing an overlay panel, a VS Code editor, a full metadata explorer, a SOQL editor, and an AI agent capable of controlling your browser, all from a single Chrome extension.
 


### PR DESCRIPTION
## Summary
- Bumps version to 2.0.9 (root + desktop package/lockfiles)
- Adds 2.0.9 release notes entry and in-app announcement for the VS Code iframe bridge origin fix
- Rebuilt extension now bakes in the correct `WORKBENCH_VSCODE_URL` (`https://vscode.sf-workbench.com`), fixing the CSP `frame-src` and bridge origin check that were blocking the iframe (nginx redirect from #45 only covered top-level navigation, not the iframe case)

## Test plan
- [x] `releaseDocsSync` test passes (README/docs/release-notes/announcement version-synced)
- [x] `announcements` unit tests pass
- [x] `extension-release` CI workflow built the RC zip; confirmed `manifest.json` `frame-src` = `https://vscode.sf-workbench.com/` and version 2.0.9
- [ ] Manual production deploy pending (nginx/server side already live from #45; this PR's docs/announcement content still needs deploying)