### PR TITLE
test(extension): guard VS Code iframe origin against manifest/bundle drift

### DIFF
--- a/packages/extension/__tests__/workbenchVscodeOrigin.test.js
+++ b/packages/extension/__tests__/workbenchVscodeOrigin.test.js
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { test } from 'node:test';
+
+import {
+    getChromeChatCopyTargets,
+    getChromeCopyTargets,
+    resolveWorkbenchVscodeOrigin,
+} from '../../../tools/build/rollup.extension.mjs';
+
+const manifestTemplate = fs.readFileSync('packages/extension/manifest.template.json', 'utf8');
+const chatManifestTemplate = fs.readFileSync(
+    'packages/extension-chat/manifest.template.json',
+    'utf8'
+);
+const constantsSource = fs.readFileSync('packages/lwc/main/vscode/fullApp/constants.ts', 'utf8');
+
+function withEnv(overrides, fn) {
+    const previous = {};
+    for (const key of Object.keys(overrides)) {
+        previous[key] = process.env[key];
+        if (overrides[key] === undefined) {
+            delete process.env[key];
+        } else {
+            process.env[key] = overrides[key];
+        }
+    }
+    try {
+        return fn();
+    } finally {
+        for (const key of Object.keys(overrides)) {
+            if (previous[key] === undefined) {
+                delete process.env[key];
+            } else {
+                process.env[key] = previous[key];
+            }
+        }
+    }
+}
+
+function manifestFrameSrcFor(targets, template) {
+    const manifestTarget = targets.find(t => t.rename === 'manifest.json');
+    const transformed = manifestTarget.transform(template);
+    const extensionPages = JSON.parse(transformed).content_security_policy.extension_pages;
+    const match = extensionPages.match(/frame-src [^;]+;/);
+    assert.ok(
+        match,
+        `expected extension_pages to contain a frame-src directive, got: ${extensionPages}`
+    );
+    return match[0];
+}
+
+test('resolveWorkbenchVscodeOrigin prefers WORKBENCH_VSCODE_URL, then WORKBENCH_BASE_URL, then the default', () => {
+    assert.equal(
+        resolveWorkbenchVscodeOrigin({ WORKBENCH_VSCODE_URL: 'https://vscode.sf-workbench.com/' }),
+        'https://vscode.sf-workbench.com'
+    );
+    assert.equal(
+        resolveWorkbenchVscodeOrigin({ WORKBENCH_BASE_URL: 'https://custom.example.com/' }),
+        'https://custom.example.com'
+    );
+    assert.equal(resolveWorkbenchVscodeOrigin({}), 'https://www.sf-workbench.com');
+});
+
+test('main extension manifest frame-src matches resolveWorkbenchVscodeOrigin for the same env', () => {
+    withEnv(
+        { WORKBENCH_VSCODE_URL: 'https://vscode.sf-workbench.com', WORKBENCH_BASE_URL: undefined },
+        () => {
+            const targets = getChromeCopyTargets({ isProduction: true });
+            const frameSrc = manifestFrameSrcFor(targets, manifestTemplate);
+            assert.equal(frameSrc, `frame-src ${resolveWorkbenchVscodeOrigin()}/;`);
+        }
+    );
+});
+
+test('chat extension manifest frame-src matches resolveWorkbenchVscodeOrigin for the same env', () => {
+    withEnv(
+        { WORKBENCH_VSCODE_URL: undefined, WORKBENCH_BASE_URL: 'https://custom.example.com' },
+        () => {
+            const targets = getChromeChatCopyTargets(true);
+            const frameSrc = manifestFrameSrcFor(targets, chatManifestTemplate);
+            assert.equal(frameSrc, `frame-src ${resolveWorkbenchVscodeOrigin()}/;`);
+        }
+    );
+});
+
+test('vscode fullApp constants derive WORKBENCH_IFRAME_ORIGIN from process.env.WORKBENCH_VSCODE_URL', () => {
+    // The JS bundle only gets the correct iframe origin if this literal expression survives —
+    // the rollup `replace` plugin substitutes the exact string `process.env.WORKBENCH_VSCODE_URL`
+    // with the value returned by resolveWorkbenchVscodeOrigin(). If this ever changes to a
+    // different expression (e.g. its own fallback chain), it will silently diverge from the
+    // manifest's frame-src again.
+    assert.match(
+        constantsSource,
+        /WORKBENCH_IFRAME_ORIGIN\s*=\s*process\.env\.WORKBENCH_VSCODE_URL\s+as\s+string/
+    );
+});

--- a/tools/build/rollup.extension.mjs
+++ b/tools/build/rollup.extension.mjs
@@ -52,11 +52,16 @@ const workbenchAnnouncementsUrl = JSON.stringify(
         .trim()
         .replace(/\/+$/, '')
 );
-const workbenchVscodeUrl = JSON.stringify(
-    String(process.env.WORKBENCH_VSCODE_URL || process.env.WORKBENCH_BASE_URL || 'https://www.sf-workbench.com')
+// Single source of truth for the VS Code iframe origin. The manifest's CSP `frame-src`
+// (getChromeCopyTargets/getChromeChatCopyTargets) and the compiled JS bundle's
+// WORKBENCH_IFRAME_ORIGIN constant (via the `replace` plugin below) MUST both derive from
+// this exact function — see packages/lwc/main/vscode/fullApp/constants.ts and
+// packages/extension/__tests__/workbenchVscodeOrigin.test.js.
+export const resolveWorkbenchVscodeOrigin = (env = process.env) =>
+    String(env.WORKBENCH_VSCODE_URL || env.WORKBENCH_BASE_URL || 'https://www.sf-workbench.com')
         .trim()
-        .replace(/\/+$/, '')
-);
+        .replace(/\/+$/, '');
+const workbenchVscodeUrl = JSON.stringify(resolveWorkbenchVscodeOrigin());
 const fullAppPathFragment = `${path.sep}vscode${path.sep}fullApp${path.sep}`;
 
 function importerIsUnderVscodeFullApp(importer) {
@@ -395,7 +400,7 @@ const getAssetCopyTargets = (distRoot) => [
     { src: r('../../assets/extension/releaseNotes.json'), dest: r(distRoot) }
 ];
 
-const getChromeCopyTargets = ({
+export const getChromeCopyTargets = ({
     isProduction,
     distRoot = '../../dist/extension',
     manifestTemplatePath = '../../packages/extension/manifest.template.json',
@@ -424,11 +429,7 @@ const getChromeCopyTargets = ({
             newContents = newContents.replace('__buildVersion__', data.version);
             newContents = newContents.replace(
                 '__buildWorkbenchOrigin__',
-                String(
-                    process.env.WORKBENCH_VSCODE_URL ||
-                        process.env.WORKBENCH_BASE_URL ||
-                        'https://www.sf-workbench.com'
-                ).trim().replace(/\/+$/, '') + '/'
+                resolveWorkbenchVscodeOrigin() + '/'
             );
             const googleClientId = String(process.env.GOOGLE_CLIENT_ID_EXTENSION || '');
             if (googleClientId) {
@@ -447,7 +448,7 @@ const getChromeCopyTargets = ({
     }
 ];
 
-const getChromeChatCopyTargets = (isProduction) => [
+export const getChromeChatCopyTargets = (isProduction) => [
     { src: r('../../packages/extension-chat/src/views/chat.html'), dest: r('../../dist/extension-chat/views') },
     { src: r('../../packages/extension-chat/src/views/sandbox.html'), dest: r('../../dist/extension-chat/views') },
     { src: r('../../packages/extension-chat/src/views/sandbox-render.html'), dest: r('../../dist/extension-chat/views') },
@@ -471,13 +472,7 @@ const getChromeChatCopyTargets = (isProduction) => [
             newContents = newContents.replace('__buildVersion__', data.version);
             newContents = newContents.replace(
                 '__buildWorkbenchOrigin__',
-                String(
-                    process.env.WORKBENCH_VSCODE_URL ||
-                        process.env.WORKBENCH_BASE_URL ||
-                        'https://www.sf-workbench.com'
-                )
-                    .trim()
-                    .replace(/\/+$/, '') + '/'
+                resolveWorkbenchVscodeOrigin() + '/'
             );
             const googleClientId = String(process.env.GOOGLE_CLIENT_ID_EXTENSION || '');
             if (googleClientId) {


### PR DESCRIPTION
## Summary
- Dedupes the `WORKBENCH_VSCODE_URL`/`WORKBENCH_BASE_URL` fallback chain in `tools/build/rollup.extension.mjs` (previously copy-pasted in 3 places) into a single exported `resolveWorkbenchVscodeOrigin()`.
- Adds `packages/extension/__tests__/workbenchVscodeOrigin.test.js`, asserting the manifest's CSP `frame-src` (main + chat extensions) and the `vscode/fullApp` `WORKBENCH_IFRAME_ORIGIN` constant stay derived from the same source.
- Prevents a repeat of the VS Code iframe bridge handshake timeout (#45/#46) caused by these values silently diverging.

This commit landed on `release-candidate/2.0.9` after PR #46 was already merged, so it needs its own PR against `master`.

## Test plan
- [x] `npm test` — 1906/1906 passing
- [x] `npm run lint` — clean
- [x] Manually verified the test fails if the manifest transform's origin diverges from `resolveWorkbenchVscodeOrigin()` (temporarily hardcoded a wrong domain, confirmed failure, reverted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)