### PR TITLE
ci(extension-release): run lint + unit tests before building the extension

### DIFF
--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -52,6 +52,12 @@ jobs:
             - name: Install dependencies
               run: npm ci --no-audit --no-fund
 
+            - name: Lint
+              run: npm run lint
+
+            - name: Run unit tests
+              run: npm test
+
             - name: Build extension (production)
               run: npm run build:prod:extension
 


### PR DESCRIPTION
## Summary
- Adds `npm run lint` and `npm test` steps to `.github/workflows/extension-release.yml`, right after `npm ci` and before `npm run build:prod:extension`.
- Previously this workflow built and published (RC pre-release, and Chrome Web Store draft upload for `extension-v*` tags) with zero test gate — only a tag/package.json version check. A broken build or a regression (e.g. the VS Code iframe origin drift fixed in #45/#46/#47) could reach a distributable artifact untested.

## Test plan
- [x] Ran `npm run lint` and `npm test` locally against the change — both pass
- [ ] Push to a `release-candidate/**` branch (or `workflow_dispatch`) to confirm the new steps run and gate the build in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)