### PR TITLE
test: expand unit test coverage across applications

### DIFF
--- a/packages/extension/src/workers/shared/__tests__/mcpProxy.test.js
+++ b/packages/extension/src/workers/shared/__tests__/mcpProxy.test.js
@@ -1,0 +1,412 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+function makeChrome({ storedConfig = {} } = {}) {
+    const calls = { storageGet: [] };
+    globalThis.chrome = {
+        runtime: {
+            getURL: path => `chrome-extension://abc123/${path}`,
+        },
+        storage: {
+            local: {
+                get: keys => {
+                    calls.storageGet.push(keys);
+                    return Promise.resolve(storedConfig);
+                },
+            },
+        },
+    };
+    return calls;
+}
+
+const EXTENSION_SENDER = { url: 'chrome-extension://abc123/panel.html' };
+
+const { handleMcpHttpRequest } = await import('../mcpProxy.js');
+
+function makeFetchSpy({ response, throws } = {}) {
+    const calls = [];
+    const fetchSpy = (url, init) => {
+        calls.push({ url, init });
+        if (throws) return Promise.reject(throws);
+        return Promise.resolve(
+            response || {
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                headers: new Map(),
+                text: async () => 'body',
+            }
+        );
+    };
+    return { fetchSpy, calls };
+}
+
+function withFetch(fetchSpy, fn) {
+    const orig = globalThis.fetch;
+    globalThis.fetch = fetchSpy;
+    return Promise.resolve()
+        .then(fn)
+        .finally(() => {
+            globalThis.fetch = orig;
+        });
+}
+
+// --- sender validation ---
+
+test('handleMcpHttpRequest: rejects when sender is missing', async () => {
+    makeChrome();
+    const result = await handleMcpHttpRequest({
+        message: { url: 'https://mcp.example.com/api' },
+        sender: undefined,
+    });
+    assert.deepEqual(result, { error: 'Untrusted sender' });
+});
+
+test('handleMcpHttpRequest: rejects when sender url is not an extension page', async () => {
+    makeChrome();
+    const result = await handleMcpHttpRequest({
+        message: { url: 'https://mcp.example.com/api' },
+        sender: { url: 'https://evil.example.com/panel.html' },
+    });
+    assert.deepEqual(result, { error: 'Untrusted sender' });
+});
+
+test('handleMcpHttpRequest: accepts a valid extension-page sender (passes sender check)', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const { fetchSpy } = makeFetchSpy();
+    const result = await withFetch(fetchSpy, () =>
+        handleMcpHttpRequest({
+            message: { url: 'https://mcp.example.com/api' },
+            sender: EXTENSION_SENDER,
+        })
+    );
+    assert.equal(result.error, undefined);
+    assert.equal(result.ok, true);
+});
+
+// --- method allowlist ---
+
+test('handleMcpHttpRequest: allows GET/POST/PUT/PATCH/DELETE', async () => {
+    for (const method of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'get']) {
+        makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+        const { fetchSpy, calls } = makeFetchSpy();
+        const result = await withFetch(fetchSpy, () =>
+            handleMcpHttpRequest({
+                message: { url: 'https://mcp.example.com/api', method },
+                sender: EXTENSION_SENDER,
+            })
+        );
+        assert.equal(result.error, undefined, `method ${method} should be allowed`);
+        assert.equal(calls[0].init.method, method.toUpperCase());
+    }
+});
+
+test('handleMcpHttpRequest: rejects disallowed HTTP method', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const result = await handleMcpHttpRequest({
+        message: { url: 'https://mcp.example.com/api', method: 'TRACE' },
+        sender: EXTENSION_SENDER,
+    });
+    assert.deepEqual(result, { error: 'Invalid MCP request' });
+});
+
+test('handleMcpHttpRequest: rejects when url is missing', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const result = await handleMcpHttpRequest({
+        message: { method: 'GET' },
+        sender: EXTENSION_SENDER,
+    });
+    assert.deepEqual(result, { error: 'Invalid MCP request' });
+});
+
+// --- URL allowlist ---
+
+test('handleMcpHttpRequest: allows a URL matching a configured MCP server', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const { fetchSpy } = makeFetchSpy();
+    const result = await withFetch(fetchSpy, () =>
+        handleMcpHttpRequest({
+            message: { url: 'https://mcp.example.com/api' },
+            sender: EXTENSION_SENDER,
+        })
+    );
+    assert.equal(result.ok, true);
+});
+
+test('handleMcpHttpRequest: rejects a URL not present in the allowlist', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const result = await handleMcpHttpRequest({
+        message: { url: 'https://not-configured.example.com/api' },
+        sender: EXTENSION_SENDER,
+    });
+    assert.deepEqual(result, { error: 'MCP server URL is not configured' });
+});
+
+test('handleMcpHttpRequest: rejects when no MCP servers are configured', async () => {
+    makeChrome({ storedConfig: {} });
+    const result = await handleMcpHttpRequest({
+        message: { url: 'https://mcp.example.com/api' },
+        sender: EXTENSION_SENDER,
+    });
+    assert.deepEqual(result, { error: 'MCP server URL is not configured' });
+});
+
+test('handleMcpHttpRequest: rejects malformed request URLs gracefully', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const result = await handleMcpHttpRequest({
+        message: { url: 'not a url at all' },
+        sender: EXTENSION_SENDER,
+    });
+    assert.deepEqual(result, { error: 'MCP server URL is not configured' });
+});
+
+test('handleMcpHttpRequest: ignores malformed entries in the server allowlist', async () => {
+    makeChrome({
+        storedConfig: { mcp_servers: [null, 'not-an-object', { name: 'no-url' }, { url: 42 }] },
+    });
+    const result = await handleMcpHttpRequest({
+        message: { url: 'https://mcp.example.com/api' },
+        sender: EXTENSION_SENDER,
+    });
+    assert.deepEqual(result, { error: 'MCP server URL is not configured' });
+});
+
+test('handleMcpHttpRequest: allows a request URL with trailing slash matching a server without one (normalization)', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const { fetchSpy } = makeFetchSpy();
+    const result = await withFetch(fetchSpy, () =>
+        handleMcpHttpRequest({
+            message: { url: 'https://mcp.example.com/api/' },
+            sender: EXTENSION_SENDER,
+        })
+    );
+    assert.equal(result.ok, true);
+});
+
+test('handleMcpHttpRequest: allows a request URL with different query/hash but same origin+path as server (path match ignores query/hash)', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const { fetchSpy } = makeFetchSpy();
+    const result = await withFetch(fetchSpy, () =>
+        handleMcpHttpRequest({
+            message: { url: 'https://mcp.example.com/api?foo=bar#frag' },
+            sender: EXTENSION_SENDER,
+        })
+    );
+    assert.equal(result.ok, true);
+});
+
+test('handleMcpHttpRequest: allows any path on the same origin as a configured server (origin fallback match)', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const { fetchSpy } = makeFetchSpy();
+    const result = await withFetch(fetchSpy, () =>
+        handleMcpHttpRequest({
+            message: { url: 'https://mcp.example.com/other-path' },
+            sender: EXTENSION_SENDER,
+        })
+    );
+    assert.equal(result.ok, true);
+});
+
+test('handleMcpHttpRequest: rejects credentials embedded in the request URL', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const result = await handleMcpHttpRequest({
+        message: { url: 'https://user:pass@mcp.example.com/api' },
+        sender: EXTENSION_SENDER,
+    });
+    assert.deepEqual(result, { error: 'MCP server URL is not configured' });
+});
+
+test('handleMcpHttpRequest: rejects non-http(s) protocols such as file:', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const result = await handleMcpHttpRequest({
+        message: { url: 'file:///etc/passwd' },
+        sender: EXTENSION_SENDER,
+    });
+    assert.deepEqual(result, { error: 'MCP server URL is not configured' });
+});
+
+test('handleMcpHttpRequest: rejects plain http to a non-local host even if configured (server itself would fail normalization)', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'http://mcp.example.com/api' }] } });
+    const result = await handleMcpHttpRequest({
+        message: { url: 'http://mcp.example.com/api' },
+        sender: EXTENSION_SENDER,
+    });
+    assert.deepEqual(result, { error: 'MCP server URL is not configured' });
+});
+
+test('handleMcpHttpRequest: allows plain http to localhost when configured', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'http://localhost:3000/mcp' }] } });
+    const { fetchSpy } = makeFetchSpy();
+    const result = await withFetch(fetchSpy, () =>
+        handleMcpHttpRequest({
+            message: { url: 'http://localhost:3000/mcp' },
+            sender: EXTENSION_SENDER,
+        })
+    );
+    assert.equal(result.ok, true);
+});
+
+// --- timeout clamping ---
+
+test('handleMcpHttpRequest: defaults to a 30s timeout when unspecified', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const setTimeoutCalls = [];
+    const origSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = (fn, delay) => {
+        setTimeoutCalls.push(delay);
+        return origSetTimeout(fn, delay);
+    };
+    const { fetchSpy } = makeFetchSpy();
+    try {
+        await withFetch(fetchSpy, () =>
+            handleMcpHttpRequest({
+                message: { url: 'https://mcp.example.com/api' },
+                sender: EXTENSION_SENDER,
+            })
+        );
+    } finally {
+        globalThis.setTimeout = origSetTimeout;
+    }
+    assert.ok(setTimeoutCalls.includes(30000), `expected 30000 among ${setTimeoutCalls}`);
+});
+
+test('handleMcpHttpRequest: clamps timeoutMs below 1000 up to 1000', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const setTimeoutCalls = [];
+    const origSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = (fn, delay) => {
+        setTimeoutCalls.push(delay);
+        return origSetTimeout(fn, delay);
+    };
+    const { fetchSpy } = makeFetchSpy();
+    try {
+        await withFetch(fetchSpy, () =>
+            handleMcpHttpRequest({
+                message: { url: 'https://mcp.example.com/api', timeoutMs: 10 },
+                sender: EXTENSION_SENDER,
+            })
+        );
+    } finally {
+        globalThis.setTimeout = origSetTimeout;
+    }
+    assert.ok(setTimeoutCalls.includes(1000), `expected 1000 among ${setTimeoutCalls}`);
+});
+
+test('handleMcpHttpRequest: clamps timeoutMs above 120000 down to 120000', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const setTimeoutCalls = [];
+    const origSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = (fn, delay) => {
+        setTimeoutCalls.push(delay);
+        return origSetTimeout(fn, delay);
+    };
+    const { fetchSpy } = makeFetchSpy();
+    try {
+        await withFetch(fetchSpy, () =>
+            handleMcpHttpRequest({
+                message: { url: 'https://mcp.example.com/api', timeoutMs: 999999 },
+                sender: EXTENSION_SENDER,
+            })
+        );
+    } finally {
+        globalThis.setTimeout = origSetTimeout;
+    }
+    assert.ok(setTimeoutCalls.includes(120000), `expected 120000 among ${setTimeoutCalls}`);
+});
+
+test('handleMcpHttpRequest: non-numeric timeoutMs falls back to default 30000', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const setTimeoutCalls = [];
+    const origSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = (fn, delay) => {
+        setTimeoutCalls.push(delay);
+        return origSetTimeout(fn, delay);
+    };
+    const { fetchSpy } = makeFetchSpy();
+    try {
+        await withFetch(fetchSpy, () =>
+            handleMcpHttpRequest({
+                message: { url: 'https://mcp.example.com/api', timeoutMs: 'soon' },
+                sender: EXTENSION_SENDER,
+            })
+        );
+    } finally {
+        globalThis.setTimeout = origSetTimeout;
+    }
+    assert.ok(setTimeoutCalls.includes(30000), `expected 30000 among ${setTimeoutCalls}`);
+});
+
+// --- fetch behavior / response shape ---
+
+test('handleMcpHttpRequest: issues fetch with redirect: error and passes through headers/body', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const { fetchSpy, calls } = makeFetchSpy({
+        response: {
+            ok: false,
+            status: 404,
+            statusText: 'Not Found',
+            headers: new Map([['content-type', 'application/json']]),
+            text: async () => '{"err":true}',
+        },
+    });
+    const result = await withFetch(fetchSpy, () =>
+        handleMcpHttpRequest({
+            message: {
+                url: 'https://mcp.example.com/api',
+                method: 'POST',
+                headers: { 'x-api-key': 'secret' },
+                body: '{"a":1}',
+            },
+            sender: EXTENSION_SENDER,
+        })
+    );
+    assert.equal(calls[0].init.redirect, 'error');
+    assert.equal(calls[0].init.method, 'POST');
+    assert.deepEqual(calls[0].init.headers, { 'x-api-key': 'secret' });
+    assert.equal(calls[0].init.body, '{"a":1}');
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 404);
+    assert.equal(result.statusText, 'Not Found');
+    assert.equal(result.body, '{"err":true}');
+});
+
+test('handleMcpHttpRequest: ignores non-object headers and non-string body', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const { fetchSpy, calls } = makeFetchSpy();
+    await withFetch(fetchSpy, () =>
+        handleMcpHttpRequest({
+            message: {
+                url: 'https://mcp.example.com/api',
+                headers: ['not', 'an', 'object'],
+                body: { not: 'a string' },
+            },
+            sender: EXTENSION_SENDER,
+        })
+    );
+    assert.deepEqual(calls[0].init.headers, {});
+    assert.equal(calls[0].init.body, undefined);
+});
+
+test('handleMcpHttpRequest: returns an error object when fetch rejects (e.g. abort/timeout)', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const { fetchSpy } = makeFetchSpy({ throws: new Error('The operation was aborted') });
+    const result = await withFetch(fetchSpy, () =>
+        handleMcpHttpRequest({
+            message: { url: 'https://mcp.example.com/api' },
+            sender: EXTENSION_SENDER,
+        })
+    );
+    assert.deepEqual(result, { error: 'The operation was aborted' });
+});
+
+test('handleMcpHttpRequest: safeDebug is invoked on rejection paths', async () => {
+    makeChrome({ storedConfig: { mcp_servers: [{ url: 'https://mcp.example.com/api' }] } });
+    const debugCalls = [];
+    await handleMcpHttpRequest({
+        message: { url: 'https://mcp.example.com/api' },
+        sender: { url: 'https://evil.example.com' },
+        safeDebug: (...args) => debugCalls.push(args),
+    });
+    assert.equal(debugCalls.length, 1);
+    assert.match(debugCalls[0][0], /untrusted sender/i);
+});

--- a/packages/extension/src/workers/shared/__tests__/oauth.test.js
+++ b/packages/extension/src/workers/shared/__tests__/oauth.test.js
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+function makeChrome({ responseUrl, throws, lastError = null } = {}) {
+    const calls = [];
+    globalThis.chrome = {
+        identity: {
+            launchWebAuthFlow: opts => {
+                calls.push(opts);
+                if (throws) return Promise.reject(throws);
+                return Promise.resolve(responseUrl);
+            },
+        },
+        runtime: {
+            get lastError() {
+                return lastError;
+            },
+        },
+    };
+    return calls;
+}
+
+const { handleLaunchWebAuthFlow } = await import('../oauth.js');
+
+test('handleLaunchWebAuthFlow: extracts code from the query string', async () => {
+    makeChrome({ responseUrl: 'https://app.example.com/callback?code=abc123&state=xyz' });
+    const result = await handleLaunchWebAuthFlow({ url: 'https://provider.example.com/authorize' });
+    assert.equal(result.code, 'abc123');
+    assert.equal(result.error, null);
+    assert.equal(result.errorDescription, null);
+    assert.equal(result.responseUrl, 'https://app.example.com/callback?code=abc123&state=xyz');
+});
+
+test('handleLaunchWebAuthFlow: passes the requested url and interactive:true to launchWebAuthFlow', async () => {
+    const calls = makeChrome({ responseUrl: 'https://app.example.com/callback?code=abc' });
+    await handleLaunchWebAuthFlow({ url: 'https://provider.example.com/authorize?x=1' });
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0], {
+        url: 'https://provider.example.com/authorize?x=1',
+        interactive: true,
+    });
+});
+
+test('handleLaunchWebAuthFlow: extracts code from the hash fragment when present there instead of the query', async () => {
+    makeChrome({ responseUrl: 'https://app.example.com/callback#code=hashcode789&state=xyz' });
+    const result = await handleLaunchWebAuthFlow({ url: 'https://provider.example.com/authorize' });
+    assert.equal(result.code, 'hashcode789');
+});
+
+test('handleLaunchWebAuthFlow: prefers a query-string code over a hash code when both are present', async () => {
+    makeChrome({
+        responseUrl: 'https://app.example.com/callback?code=queryCode#code=hashCode',
+    });
+    const result = await handleLaunchWebAuthFlow({ url: 'https://provider.example.com/authorize' });
+    assert.equal(result.code, 'queryCode');
+});
+
+test('handleLaunchWebAuthFlow: surfaces error and error_description from the query string', async () => {
+    makeChrome({
+        responseUrl:
+            'https://app.example.com/callback?error=access_denied&error_description=User%20declined',
+    });
+    const result = await handleLaunchWebAuthFlow({ url: 'https://provider.example.com/authorize' });
+    assert.equal(result.code, null);
+    assert.equal(result.error, 'access_denied');
+    assert.equal(result.errorDescription, 'User declined');
+});
+
+test('handleLaunchWebAuthFlow: surfaces error and error_description from the hash fragment', async () => {
+    makeChrome({
+        responseUrl:
+            'https://app.example.com/callback#error=server_error&error_description=Something%20broke',
+    });
+    const result = await handleLaunchWebAuthFlow({ url: 'https://provider.example.com/authorize' });
+    assert.equal(result.error, 'server_error');
+    assert.equal(result.errorDescription, 'Something broke');
+});
+
+test('handleLaunchWebAuthFlow: returns an "OAuth flow canceled" error when responseUrl is falsy (user closed popup)', async () => {
+    makeChrome({ responseUrl: undefined });
+    const result = await handleLaunchWebAuthFlow({ url: 'https://provider.example.com/authorize' });
+    assert.deepEqual(result, { error: 'OAuth flow canceled' });
+});
+
+test('handleLaunchWebAuthFlow: returns chrome.runtime.lastError.message when set, even if a responseUrl came back', async () => {
+    makeChrome({
+        responseUrl: 'https://app.example.com/callback?code=abc',
+        lastError: { message: 'Authorization page could not be loaded.' },
+    });
+    const result = await handleLaunchWebAuthFlow({ url: 'https://provider.example.com/authorize' });
+    assert.deepEqual(result, { error: 'Authorization page could not be loaded.' });
+});
+
+test('handleLaunchWebAuthFlow: propagates a rejected launchWebAuthFlow promise as a thrown error', async () => {
+    makeChrome({ throws: new Error('user closed the window') });
+    await assert.rejects(
+        handleLaunchWebAuthFlow({ url: 'https://provider.example.com/authorize' }),
+        /user closed the window/
+    );
+});

--- a/packages/extension/src/workers/shared/__tests__/sidePanel.test.js
+++ b/packages/extension/src/workers/shared/__tests__/sidePanel.test.js
@@ -1,0 +1,294 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+function makeChrome() {
+    const calls = { setOptions: [], open: [] };
+    globalThis.chrome = {
+        sidePanel: {
+            setOptions: opts => {
+                calls.setOptions.push(opts);
+                return Promise.resolve();
+            },
+            open: opts => {
+                calls.open.push(opts);
+                return Promise.resolve();
+            },
+        },
+    };
+    return calls;
+}
+
+function makePort(tabId) {
+    let disconnectListener = null;
+    return {
+        messages: [],
+        sender: { tab: { id: tabId } },
+        postMessage(msg) {
+            this.messages.push(msg);
+        },
+        onDisconnect: {
+            addListener(fn) {
+                disconnectListener = fn;
+            },
+        },
+        simulateDisconnect() {
+            if (disconnectListener) disconnectListener();
+        },
+    };
+}
+
+const { createSidePanelController } = await import('../sidePanel.js');
+
+test('openSideBar: enables the side panel via setOptions then opens it', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    await controller.openSideBar({ id: 7 });
+    assert.equal(calls.setOptions.length, 1);
+    assert.deepEqual(calls.setOptions[0], { tabId: 7, path: 'sidebar.html', enabled: true });
+    assert.equal(calls.open.length, 1);
+    assert.deepEqual(calls.open[0], { tabId: 7 });
+});
+
+test('openSideBar: no-ops when tab has no id', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    await controller.openSideBar({});
+    assert.equal(calls.setOptions.length, 0);
+    assert.equal(calls.open.length, 0);
+});
+
+test('closeSideBar: disables the side panel via setOptions, accepts a tab id or tab object', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    await controller.openSideBar({ id: 7 });
+    await controller.closeSideBar(7);
+    assert.equal(calls.setOptions.length, 2);
+    assert.deepEqual(calls.setOptions[1], { tabId: 7, path: 'sidebar.html', enabled: false });
+});
+
+test('closeSideBar: accepts a tab object as well as a raw id', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    await controller.closeSideBar({ id: 9 });
+    assert.deepEqual(calls.setOptions[0], { tabId: 9, path: 'sidebar.html', enabled: false });
+});
+
+test('closeSideBar: no-ops when given a non-integer tab id', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    await controller.closeSideBar(null);
+    await controller.closeSideBar({});
+    assert.equal(calls.setOptions.length, 0);
+});
+
+test('toggleSideBar: opens when there is no registered port for the tab', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    await controller.toggleSideBar({ id: 3 });
+    assert.equal(calls.open.length, 1);
+});
+
+test('toggleSideBar: closes when a port is already registered for the tab', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    const port = makePort(3);
+    controller.registerSidePanelPort(port);
+    await controller.toggleSideBar({ id: 3 });
+    assert.equal(calls.open.length, 0);
+    // last setOptions call should be the "disabled" close call
+    const last = calls.setOptions[calls.setOptions.length - 1];
+    assert.deepEqual(last, { tabId: 3, path: 'sidebar.html', enabled: false });
+});
+
+test('toggleSideBar: no-ops when tab has no id', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    await controller.toggleSideBar({});
+    assert.equal(calls.open.length, 0);
+    assert.equal(calls.setOptions.length, 0);
+});
+
+test('handleTabOpening: debounces a second call for the same tab+enabled state within 750ms', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    const origNow = Date.now;
+    let now = 1_000_000;
+    Date.now = () => now;
+    try {
+        await controller.handleTabOpening({ id: 4 });
+        assert.equal(calls.setOptions.length, 1);
+
+        now += 100; // well within 750ms window
+        await controller.handleTabOpening({ id: 4 });
+        assert.equal(calls.setOptions.length, 1, 'second call within window should be suppressed');
+    } finally {
+        Date.now = origNow;
+    }
+});
+
+test('handleTabOpening: proceeds again once the debounce window has elapsed', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    const origNow = Date.now;
+    let now = 2_000_000;
+    Date.now = () => now;
+    try {
+        await controller.handleTabOpening({ id: 5 });
+        assert.equal(calls.setOptions.length, 1);
+
+        now += 751; // past the 750ms debounce window
+        await controller.handleTabOpening({ id: 5 });
+        assert.equal(calls.setOptions.length, 2, 'call after window should proceed');
+    } finally {
+        Date.now = origNow;
+    }
+});
+
+test('handleTabOpening: stays debounced across an openSideBar call that records the same enabled state', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    const origNow = Date.now;
+    let now = 3_000_000;
+    Date.now = () => now;
+    try {
+        await controller.handleTabOpening({ id: 6 }); // enabled=false (not yet opened) -> writes once
+        assert.equal(calls.setOptions.length, 1);
+
+        // openSideBar marks tab 6 as opened and records {enabled: true, ts: now} itself,
+        // issuing its own setOptions + open calls.
+        await controller.openSideBar({ id: 6 });
+        assert.equal(calls.setOptions.length, 2);
+
+        // handleTabOpening now computes enabled=true, matching the state openSideBar just
+        // recorded at the same `now`, so within the 750ms window it is debounced and skipped.
+        now += 10;
+        await controller.handleTabOpening({ id: 6 });
+        assert.equal(calls.setOptions.length, 2, 'debounced call should not add a setOptions call');
+    } finally {
+        Date.now = origNow;
+    }
+});
+
+test('handleTabOpening: no-ops when tab has no id', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    await controller.handleTabOpening({});
+    await controller.handleTabOpening(null);
+    assert.equal(calls.setOptions.length, 0);
+});
+
+test('handleTabOpening: swallows errors from chrome.sidePanel.setOptions', async () => {
+    globalThis.chrome = {
+        sidePanel: {
+            setOptions: () => Promise.reject(new Error('boom')),
+            open: () => Promise.resolve(),
+        },
+    };
+    const controller = createSidePanelController('sidebar.html');
+    await assert.doesNotReject(controller.handleTabOpening({ id: 1 }));
+});
+
+test('registerSidePanelPort + sendMessageToSidePanelInTab: delivers a message to the matching port', () => {
+    makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    const portA = makePort(10);
+    const portB = makePort(20);
+    controller.registerSidePanelPort(portA);
+    controller.registerSidePanelPort(portB);
+
+    const sent = controller.sendMessageToSidePanelInTab(10, { hello: 'a' });
+    assert.equal(sent, true);
+    assert.deepEqual(portA.messages, [{ hello: 'a' }]);
+    assert.deepEqual(portB.messages, []);
+});
+
+test('sendMessageToSidePanelInTab: returns false when no port matches the tab', () => {
+    makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    const sent = controller.sendMessageToSidePanelInTab(999, { hello: 'x' });
+    assert.equal(sent, false);
+});
+
+test('broadcastMessageToAllSidePanelInstances: reaches every registered port', () => {
+    makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    const portA = makePort(10);
+    const portB = makePort(20);
+    controller.registerSidePanelPort(portA);
+    controller.registerSidePanelPort(portB);
+
+    controller.broadcastMessageToAllSidePanelInstances({ type: 'ping' });
+    assert.deepEqual(portA.messages, [{ type: 'ping' }]);
+    assert.deepEqual(portB.messages, [{ type: 'ping' }]);
+});
+
+test('broadcastMessageToAllSidePanelInstances: drops a port whose postMessage throws', () => {
+    makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    const goodPort = makePort(1);
+    const badPort = makePort(2);
+    badPort.postMessage = () => {
+        throw new Error('port closed');
+    };
+    controller.registerSidePanelPort(goodPort);
+    controller.registerSidePanelPort(badPort);
+
+    controller.broadcastMessageToAllSidePanelInstances({ type: 'ping' });
+    assert.deepEqual(goodPort.messages, [{ type: 'ping' }]);
+
+    // badPort should have been dropped from tracking; sending to its tab now fails.
+    const sent = controller.sendMessageToSidePanelInTab(2, { type: 'again' });
+    assert.equal(sent, false);
+});
+
+test('registerSidePanelPort onDisconnect: removes the port from tracking when disconnected', () => {
+    makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    const port = makePort(15);
+    controller.registerSidePanelPort(port);
+    assert.equal(controller.sendMessageToSidePanelInTab(15, { a: 1 }), true);
+
+    port.simulateDisconnect();
+
+    const sent = controller.sendMessageToSidePanelInTab(15, { a: 2 });
+    assert.equal(sent, false);
+});
+
+test('registerSidePanelPort: tracks ports without a sender tab id gracefully (broadcast only)', () => {
+    makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    const port = makePort(undefined);
+    port.sender = {};
+    controller.registerSidePanelPort(port);
+    controller.broadcastMessageToAllSidePanelInstances({ type: 'x' });
+    assert.deepEqual(port.messages, [{ type: 'x' }]);
+    // Port was never associated with a tab id, so it should not match any concrete tab id lookup.
+    assert.equal(controller.sendMessageToSidePanelInTab(15, { type: 'y' }), false);
+});
+
+test('handleTabRemoved: clears open tracking and last-options tracking for the tab', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    const origNow = Date.now;
+    let now = 5_000_000;
+    Date.now = () => now;
+    try {
+        await controller.openSideBar({ id: 42 });
+        assert.equal(calls.setOptions.length, 1);
+
+        controller.handleTabRemoved(42);
+
+        // Before removal, handleTabOpening would have been debounced (enabled=true matches the
+        // state openSideBar recorded). After removal, lastSidePanelOptionsByTabId no longer has
+        // an entry for tab 42, so the very next handleTabOpening call is NOT debounced and writes.
+        now += 10;
+        await controller.handleTabOpening({ id: 42 });
+        assert.equal(
+            calls.setOptions.length,
+            2,
+            'stale debounce state should have been cleared by handleTabRemoved'
+        );
+    } finally {
+        Date.now = origNow;
+    }
+});

--- a/packages/lwc/applications/accessAnalyzer/utils/__tests__/utils.test.ts
+++ b/packages/lwc/applications/accessAnalyzer/utils/__tests__/utils.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for the PDF-report table builder used by the Access Analyzer's
+ * "download as PDF" flow.
+ *
+ * Contract note: `fileFormatter` currently has no `return` statement and its
+ * `setFileContents(...)` call is commented out — it only mutates local
+ * `headers` / `rows` / `tableWidth` variables that are never exposed to the
+ * caller. There is therefore nothing externally observable about its
+ * result; these tests instead verify it does not throw across the row-type
+ * branches (`header`, `group`, `calc`, `row`) and defensive filtering paths
+ * (`x != null`) that `app.ts` relies on when exporting real report tables.
+ */
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { fileFormatter } from '../utils.ts';
+
+function makeHeaderColumn(overrides = {}) {
+    return {
+        value: 'Name',
+        width: 1,
+        height: 1,
+        depth: 1,
+        component: { _column: { width: 100 } },
+        ...overrides,
+    };
+}
+
+function makeRowColumn(overrides = {}) {
+    return {
+        value: 'foo',
+        width: 1,
+        height: 1,
+        component: { _column: { width: 100 } },
+        ...overrides,
+    };
+}
+
+test('empty list does not throw', () => {
+    assert.doesNotThrow(() => fileFormatter([], {}));
+});
+
+test('called with no options argument uses defaults and does not throw', () => {
+    assert.doesNotThrow(() => fileFormatter([]));
+});
+
+test('list with only a header row does not throw', () => {
+    const list = [
+        {
+            type: 'header',
+            columns: [
+                makeHeaderColumn(),
+                makeHeaderColumn({ value: 'Group', width: 2, height: 1 }),
+            ],
+        },
+    ];
+    assert.doesNotThrow(() => fileFormatter(list, {}));
+});
+
+test('header row with column width derived from nested component columns does not throw', () => {
+    const list = [
+        {
+            type: 'header',
+            columns: [
+                makeHeaderColumn({
+                    // no direct width — forces the `.columns.reduce(...)` fallback
+                    component: { _column: { columns: [{ width: 50 }, { width: 60 }] } },
+                }),
+            ],
+        },
+    ];
+    assert.doesNotThrow(() => fileFormatter(list, {}));
+});
+
+test('header row with height > 1 (multi-row header) does not throw', () => {
+    const list = [
+        {
+            type: 'header',
+            columns: [makeHeaderColumn({ height: 2 })],
+        },
+    ];
+    assert.doesNotThrow(() => fileFormatter(list, {}));
+});
+
+test('header row filters out null/undefined column entries', () => {
+    const list = [
+        {
+            type: 'header',
+            columns: [makeHeaderColumn(), null, undefined],
+        },
+    ];
+    assert.doesNotThrow(() => fileFormatter(list, {}));
+});
+
+test('header row filters non-depth-1 columns out of the width calculation but still renders them', () => {
+    const list = [
+        {
+            type: 'header',
+            columns: [makeHeaderColumn({ depth: 2 }), makeHeaderColumn({ depth: 1 })],
+        },
+    ];
+    assert.doesNotThrow(() => fileFormatter(list, {}));
+});
+
+test('group row type is a no-op branch and does not throw', () => {
+    const list = [{ type: 'group', columns: [] }];
+    assert.doesNotThrow(() => fileFormatter(list, {}));
+});
+
+test('calc row type is a no-op branch and does not throw', () => {
+    const list = [{ type: 'calc', columns: [] }];
+    assert.doesNotThrow(() => fileFormatter(list, {}));
+});
+
+test('unknown row type falls through the switch without throwing', () => {
+    const list = [{ type: 'unknown-type', columns: [] }];
+    assert.doesNotThrow(() => fileFormatter(list, {}));
+});
+
+test('data row with indent on the first column does not throw', () => {
+    const list = [
+        {
+            type: 'row',
+            indent: 1,
+            columns: [makeRowColumn(), makeRowColumn({ value: 'bar' })],
+        },
+    ];
+    assert.doesNotThrow(() => fileFormatter(list, {}));
+});
+
+test('data row with cell width derived from nested component columns does not throw', () => {
+    const list = [
+        {
+            type: 'row',
+            indent: 0,
+            columns: [
+                makeRowColumn({
+                    component: { _column: { columns: [{ width: 30 }, { width: 20 }] } },
+                }),
+            ],
+        },
+    ];
+    assert.doesNotThrow(() => fileFormatter(list, {}));
+});
+
+test('data row filters out null/undefined column entries', () => {
+    const list = [
+        {
+            type: 'row',
+            indent: 0,
+            columns: [makeRowColumn(), null, undefined],
+        },
+    ];
+    assert.doesNotThrow(() => fileFormatter(list, {}));
+});
+
+test('data row with undefined/null cell value falls back to empty string without throwing', () => {
+    const list = [
+        {
+            type: 'row',
+            indent: 0,
+            columns: [makeRowColumn({ value: undefined }), makeRowColumn({ value: null })],
+        },
+    ];
+    assert.doesNotThrow(() => fileFormatter(list, {}));
+});
+
+test('list ending in a row hits the last-row border-width mutation branch without throwing', () => {
+    const list = [
+        {
+            type: 'header',
+            columns: [makeHeaderColumn()],
+        },
+        {
+            type: 'row',
+            indent: 0,
+            columns: [makeRowColumn()],
+        },
+        {
+            type: 'row',
+            indent: 0,
+            columns: [makeRowColumn({ value: 'last' })],
+        },
+    ];
+    assert.doesNotThrow(() => fileFormatter(list, {}));
+});
+
+test('list with header, group, calc and row types mixed together does not throw', () => {
+    const list = [
+        { type: 'header', columns: [makeHeaderColumn()] },
+        { type: 'group', columns: [] },
+        { type: 'calc', columns: [] },
+        { type: 'row', indent: 0, columns: [makeRowColumn()] },
+    ];
+    assert.doesNotThrow(() => fileFormatter(list, {}));
+});
+
+test('respects custom leftCellAlignement option without throwing', () => {
+    const list = [
+        {
+            type: 'row',
+            indent: 0,
+            columns: [
+                makeRowColumn(),
+                makeRowColumn({ value: 'bar' }),
+                makeRowColumn({ value: 'baz' }),
+            ],
+        },
+    ];
+    assert.doesNotThrow(() =>
+        fileFormatter(list, {
+            leftCellAlignement: 1,
+            useImage: true,
+            title: 'Custom Title',
+            filename: 'custom.pdf',
+            report: 'someReport',
+            greenTreshold: 5,
+            orangeTreshold: 15,
+        })
+    );
+});
+
+test('setFileContents callback is accepted but never invoked (call is commented out in source)', () => {
+    let called = false;
+    const setFileContents = () => {
+        called = true;
+    };
+    const list = [{ type: 'row', indent: 0, columns: [makeRowColumn()] }];
+    fileFormatter(list, {}, setFileContents);
+    assert.equal(called, false);
+});

--- a/packages/lwc/applications/agentforce/dependencies/__tests__/graphAnalysis.test.ts
+++ b/packages/lwc/applications/agentforce/dependencies/__tests__/graphAnalysis.test.ts
@@ -150,6 +150,41 @@ test('computeCentrality: linear chain — middle node B is the bottleneck', () =
     assert.equal(c.get('B'), 1, 'centrality is normalized so the max is 1');
 });
 
+test('computeCentrality: star graph — hub mediates every spoke, so hub centrality dominates and spokes are 0', () => {
+    // Hub connects outward to 4 leaves; every leaf-to-leaf path (if any were
+    // requested) would have to route through the hub. With directed
+    // hub→leaf edges only there are no leaf-to-leaf paths at all, so this
+    // asserts the hub is the sole non-zero entry rather than a specific
+    // magnitude — the point is contrast with the linear-chain case above,
+    // where a downstream node (C) still has zero betweenness.
+    const star: GraphData = {
+        nodes: [node('hub'), node('l1'), node('l2'), node('l3'), node('l4')],
+        edges: [edge('hub', 'l1'), edge('hub', 'l2'), edge('hub', 'l3'), edge('hub', 'l4')],
+    };
+    const c = computeCentrality(star);
+    assert.equal(c.get('l1'), 0, 'leaf l1 has no betweenness');
+    assert.equal(c.get('l2'), 0, 'leaf l2 has no betweenness');
+    assert.equal(c.get('l3'), 0, 'leaf l3 has no betweenness');
+    assert.equal(c.get('l4'), 0, 'leaf l4 has no betweenness');
+    assert.equal(c.get('hub'), 0, 'hub has no betweenness either — it is a source, not a mediator');
+});
+
+test('computeCentrality: bidirectional star — hub mediates every leaf-to-leaf path and dominates centrality', () => {
+    // Making edges bidirectional means every leaf can reach every other leaf
+    // only via the hub, so the hub now mediates all those paths while
+    // leaves mediate none — the intended "star graph" contrast with a line.
+    const nodes = [node('hub'), node('l1'), node('l2'), node('l3'), node('l4')];
+    const edges: GraphEdge[] = [];
+    for (const leaf of ['l1', 'l2', 'l3', 'l4']) {
+        edges.push(edge('hub', leaf), edge(leaf, 'hub'));
+    }
+    const c = computeCentrality({ nodes, edges });
+    assert.equal(c.get('hub'), 1, 'hub is normalized to the max centrality');
+    for (const leaf of ['l1', 'l2', 'l3', 'l4']) {
+        assert.equal(c.get(leaf), 0, `leaf ${leaf} mediates no shortest paths`);
+    }
+});
+
 // ---------------------------------------------------------------------------
 // computeDiameter
 // ---------------------------------------------------------------------------

--- a/packages/lwc/applications/agentforce/inspector/search/__tests__/fuzzyMatch.test.ts
+++ b/packages/lwc/applications/agentforce/inspector/search/__tests__/fuzzyMatch.test.ts
@@ -89,6 +89,14 @@ test('fuzzyMatch: empty query returns null', () => {
     assert.equal(fuzzyMatch('   ', 'OrderLookup'), null);
 });
 
+test('fuzzyMatch: empty target returns null for a non-empty query', () => {
+    assert.equal(fuzzyMatch('order', ''), null);
+});
+
+test('fuzzyMatch: empty query against empty target returns null', () => {
+    assert.equal(fuzzyMatch('', ''), null);
+});
+
 test('fuzzyMatch: camelCase tokenization splits HTTPData correctly', () => {
     // 'HTTP' is one token, 'Data' is another
     const r = fuzzyMatch('Data', 'fetchHTTPData');

--- a/packages/lwc/applications/anonymousApex/slices/__tests__/apexHelpers.test.ts
+++ b/packages/lwc/applications/anonymousApex/slices/__tests__/apexHelpers.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Unit tests for the small pure/near-pure helper functions near the top of
+ * `../apex.ts` (`formatTab`, `enrichTab`, `enrichTabs`, `createInitialTabs`).
+ *
+ * Why we don't import `../apex.ts` directly
+ * -------------------------------------------
+ * `../apex.ts` imports `DOCUMENT` from `host-api/store` at module top-level.
+ * `host-api/store` transitively loads the full core store graph, including
+ * LWC components decorated with `@api`/`@wire` — invalid syntax under plain
+ * Node (this repo's test runner can only strip TypeScript types via
+ * `--experimental-strip-types`, it cannot parse LWC decorator syntax). Any
+ * module that imports `host-api/store`, even transitively, throws
+ * `SyntaxError: Invalid or unexpected token` when imported directly in a
+ * `node:test` file.
+ *
+ * Pragmatic alternative (same pattern as
+ * `packages/lwc/applications/agentforce/slices/__tests__/agents.test.ts`):
+ * faithfully re-implement the tiny helper functions here and pin their
+ * exact source via "source contract" regex assertions against the real
+ * `../apex.ts`. Any drift between this clone and the real file will fail
+ * the source-contract tests below and get caught in review.
+ *
+ * `guid`, `isNotUndefinedOrNull`, and `lowerCaseKey` are imported directly
+ * from `shared/utils` — that module does NOT import `host-api/store`, so it
+ * is safe to import in this plain-Node test environment.
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { guid, isNotUndefinedOrNull, lowerCaseKey } from 'shared/utils';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const apexSource = readFileSync(path.resolve(here, '../apex.ts'), 'utf8');
+
+// ---------------------------------------------------------------------------
+// Test rig: faithful clones of the helper functions defined near the top of
+// `../apex.ts`. MUST stay in sync with the real file — the source-contract
+// tests below catch drift.
+// ---------------------------------------------------------------------------
+
+function formatTab({ id, name, body, isDraft, fileId, fileBody }) {
+    return { id, name, body, isDraft, fileId, fileBody };
+}
+
+function enrichTab(tab, state, selector?) {
+    const file =
+        tab.fileId && selector ? selector.selectById(state, lowerCaseKey(tab.fileId)) : null;
+    const fileBody = file?.content || tab.fileBody;
+    return {
+        ...tab,
+        fileBody: fileBody,
+        isDraft: fileBody != tab.body && isNotUndefinedOrNull(tab.fileId),
+    };
+}
+
+function enrichTabs(tabs, state, selector?) {
+    return tabs.map(tab => enrichTab(tab, state, selector));
+}
+
+function createInitialTabs() {
+    return [enrichTab({ id: guid(), body: 'System.debug(System.now());' }, null)];
+}
+
+// ---------------------------------------------------------------------------
+// formatTab
+// ---------------------------------------------------------------------------
+
+test('formatTab: repacks the known fields and drops extras', () => {
+    const input = {
+        id: 't1',
+        name: 'Tab 1',
+        body: 'System.debug(1);',
+        isDraft: true,
+        fileId: '01p000000000001',
+        fileBody: 'saved content',
+        // Extra keys that should be dropped.
+        extraneous: 'should not appear',
+        createdDate: '2026-01-01',
+    };
+
+    const result = formatTab(input);
+
+    assert.deepEqual(result, {
+        id: 't1',
+        name: 'Tab 1',
+        body: 'System.debug(1);',
+        isDraft: true,
+        fileId: '01p000000000001',
+        fileBody: 'saved content',
+    });
+    assert.equal(
+        Object.prototype.hasOwnProperty.call(result, 'extraneous'),
+        false,
+        'extra keys not in the destructure list must be dropped'
+    );
+    assert.equal(Object.keys(result).length, 6, 'only the six known fields should be present');
+});
+
+// ---------------------------------------------------------------------------
+// enrichTab
+// ---------------------------------------------------------------------------
+
+test('enrichTab: no fileId -> passes through tab.fileBody, isDraft is always false', () => {
+    const tab = { id: 't1', body: 'System.debug(1);', fileBody: 'unrelated body' };
+
+    const result = enrichTab(tab, null, null);
+
+    assert.equal(result.fileBody, 'unrelated body', 'fileBody falls through to tab.fileBody');
+    assert.equal(
+        result.isDraft,
+        false,
+        'isDraft must be false when fileId is absent, regardless of body/fileBody mismatch'
+    );
+});
+
+test('enrichTab: no selector (even with fileId) -> file lookup skipped, fileBody passes through', () => {
+    const tab = {
+        id: 't1',
+        body: 'System.debug(1);',
+        fileId: '01p000000000001',
+        fileBody: 'unrelated body',
+    };
+
+    const result = enrichTab(tab, {}, null);
+
+    assert.equal(result.fileBody, 'unrelated body');
+    // fileBody ('unrelated body') != body ('System.debug(1);') AND fileId is
+    // present -> isDraft is true even though the selector was never
+    // consulted (the file lookup is short-circuited, not the isDraft calc).
+    assert.equal(result.isDraft, true);
+});
+
+test('enrichTab: fileId + selector resolving a file -> fileBody comes from file.content', () => {
+    const tab = {
+        id: 't1',
+        body: 'System.debug(1);',
+        fileId: '01p000000000001',
+        fileBody: 'stale local body',
+    };
+    const file = { content: 'System.debug(2);' };
+    const state = {};
+    const selector = {
+        selectById: (s, id) => {
+            assert.equal(s, state);
+            assert.equal(id, lowerCaseKey(tab.fileId));
+            return file;
+        },
+    };
+
+    const result = enrichTab(tab, state, selector);
+
+    assert.equal(result.fileBody, file.content, 'fileBody must come from file.content');
+    assert.equal(
+        result.isDraft,
+        true,
+        'isDraft is true when fileBody (from file.content) differs from tab.body and fileId is present'
+    );
+});
+
+test('enrichTab: fileId + selector resolving a file whose content matches body -> isDraft false', () => {
+    const tab = {
+        id: 't1',
+        body: 'System.debug(1);',
+        fileId: '01p000000000001',
+        fileBody: 'stale local body',
+    };
+    const file = { content: 'System.debug(1);' };
+    const selector = { selectById: () => file };
+
+    const result = enrichTab(tab, {}, selector);
+
+    assert.equal(result.fileBody, file.content);
+    assert.equal(result.isDraft, false, 'fileBody matches tab.body -> not a draft');
+});
+
+test('enrichTab: fileId + selector returning no file -> falls back to tab.fileBody', () => {
+    const tab = {
+        id: 't1',
+        body: 'System.debug(1);',
+        fileId: '01p000000000001',
+        fileBody: 'System.debug(1);',
+    };
+    const selector = { selectById: () => undefined };
+
+    const result = enrichTab(tab, {}, selector);
+
+    assert.equal(
+        result.fileBody,
+        tab.fileBody,
+        'no file found -> fileBody falls back to tab.fileBody'
+    );
+    assert.equal(result.isDraft, false, 'fileBody equals body -> not a draft');
+});
+
+test('enrichTab: preserves other tab fields via spread', () => {
+    const tab = { id: 't1', name: 'My Tab', body: 'x', fileId: null, fileBody: 'x' };
+    const result = enrichTab(tab, null, null);
+    assert.equal(result.id, 't1');
+    assert.equal(result.name, 'My Tab');
+});
+
+// ---------------------------------------------------------------------------
+// enrichTabs
+// ---------------------------------------------------------------------------
+
+test('enrichTabs: maps enrichTab over each tab in the array', () => {
+    const tabs = [
+        { id: 't1', body: 'a', fileId: '01p1', fileBody: 'a' },
+        { id: 't2', body: 'b', fileId: '01p2', fileBody: 'b' },
+        { id: 't3', body: 'c', fileBody: 'c' },
+    ];
+    const files = {
+        '01p1': { content: 'a-updated' },
+        '01p2': { content: 'b' },
+    };
+    const selector = {
+        selectById: (_state, id) => files[id],
+    };
+
+    const results = enrichTabs(tabs, {}, selector);
+
+    assert.equal(results.length, 3);
+    assert.equal(results[0].fileBody, 'a-updated');
+    assert.equal(results[0].isDraft, true, 'a-updated != a and fileId present');
+    assert.equal(results[1].fileBody, 'b');
+    assert.equal(results[1].isDraft, false, 'b == b');
+    assert.equal(results[2].fileBody, 'c', 'no fileId -> fileBody passes through tab.fileBody');
+    assert.equal(results[2].isDraft, false, 'no fileId -> isDraft always false');
+});
+
+test('enrichTabs: empty array returns empty array', () => {
+    assert.deepEqual(enrichTabs([], {}, null), []);
+});
+
+// ---------------------------------------------------------------------------
+// createInitialTabs
+// ---------------------------------------------------------------------------
+
+test('createInitialTabs: returns a single default tab with a guid id and default body', () => {
+    const tabs = createInitialTabs();
+
+    assert.equal(tabs.length, 1);
+    const [tab] = tabs;
+    assert.equal(typeof tab.id, 'string');
+    assert.ok(tab.id.length > 0, 'id must be a non-empty string');
+    assert.equal(tab.body, 'System.debug(System.now());');
+    // selector is null in createInitialTabs -> file lookup is skipped, so
+    // fileBody falls through to the input tab's fileBody, which was never
+    // provided (undefined). isDraft is false because fileId is absent.
+    assert.equal(tab.fileBody, undefined);
+    assert.equal(tab.isDraft, false);
+    assert.equal(tab.fileId, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Source contract — pin the cloned bodies against the real ../apex.ts so
+// drift in the source gets caught here instead of silently diverging.
+// ---------------------------------------------------------------------------
+
+test('source contract: formatTab destructures and repacks the six known fields', () => {
+    assert.match(
+        apexSource,
+        /function formatTab\(\{ id, name, body, isDraft, fileId, fileBody \}\) \{\s*return \{ id, name, body, isDraft, fileId, fileBody \};\s*\}/
+    );
+});
+
+test('source contract: enrichTab looks up file via selector.selectById(state, lowerCaseKey(tab.fileId))', () => {
+    assert.match(
+        apexSource,
+        /function enrichTab\(tab, state, selector\) \{\s*const file =\s*tab\.fileId && selector \? selector\.selectById\(state, lowerCaseKey\(tab\.fileId\)\) : null;/
+    );
+});
+
+test('source contract: enrichTab computes fileBody and isDraft exactly as cloned', () => {
+    assert.match(apexSource, /const fileBody = file\?\.content \|\| tab\.fileBody;/);
+    assert.match(
+        apexSource,
+        /isDraft: fileBody != tab\.body && isNotUndefinedOrNull\(tab\.fileId\),/
+    );
+});
+
+test('source contract: enrichTabs maps enrichTab over the tabs array', () => {
+    assert.match(
+        apexSource,
+        /function enrichTabs\(tabs, state, selector\) \{\s*return tabs\.map\(tab => enrichTab\(tab, state, selector\)\);\s*\}/
+    );
+});
+
+test('source contract: createInitialTabs seeds a single tab with the default Apex script', () => {
+    assert.match(
+        apexSource,
+        /createInitialTabs = \(\) => \{\s*return \[enrichTab\(\{ id: guid\(\), body: 'System\.debug\(System\.now\(\)\);' \}, null\)\];\s*\};/
+    );
+});

--- a/packages/lwc/applications/api/slices/__tests__/api.test.ts
+++ b/packages/lwc/applications/api/slices/__tests__/api.test.ts
@@ -1,0 +1,1224 @@
+/**
+ * Slice-behavior tests for the api application's `apiSlice` — focused on the
+ * synchronous `reducers` (tab management, cache settings, action-history
+ * navigation) and the entity-adapter `extraReducers` around
+ * `executeApiRequest`.
+ *
+ * Why we don't import `../api.ts` directly
+ * ------------------------------------------
+ * `../api.ts` imports `DOCUMENT`, `ERROR` from `host-api/store` and
+ * `getStore` from `core/store/storeRef` at module top-level. `host-api/store`
+ * transitively loads the full core store graph including LWC components
+ * decorated with `@api`/`@wire` — invalid syntax under plain Node, since
+ * this test runner (`--experimental-strip-types`) only strips TypeScript
+ * types and cannot parse LWC decorator syntax. Importing `../api.ts`
+ * directly throws `SyntaxError: Invalid or unexpected token`. Verified
+ * empirically:
+ *   node --experimental-strip-types --import=./tools/testing/register.mjs \
+ *     -e "import('./packages/lwc/applications/api/slices/api.ts')"
+ *   -> SyntaxError: Invalid or unexpected token
+ * This is the same constraint documented in
+ * `platformevent/slices/__tests__/platformEvent.test.ts` (the canonical
+ * precedent for this pattern) and `agentforce/slices/__tests__/agents.test.ts`
+ * (the original).
+ *
+ * Pragmatic alternative: re-construct the same reducers the slice uses as a
+ * "faithful clone" built with `createSlice`/`createEntityAdapter` from
+ * `@reduxjs/toolkit` (the same library the real slice uses), and pin the
+ * clone's fidelity with "source contract" tests that `readFileSync` the real
+ * `../api.ts` and `assert.match` key lines/policies. Any drift between the
+ * clone and the real file gets caught by those contract tests in review.
+ *
+ * `lowerCaseKey` and `isNotUndefinedOrNull` are imported directly from
+ * `shared/utils` — that module does NOT import `host-api/store`, so it is
+ * safe to import in this plain-Node test environment (same precedent as
+ * `anonymousApex/slices/__tests__/apexHelpers.test.ts`).
+ *
+ * The standalone top-level `loadCacheSettings(alias)` export (distinct from
+ * the same-named property inside `apiSlice.reducers`) is covered separately
+ * in `loadCacheSettings.test.ts`, imported indirectly via a small faithful
+ * clone of its own tiny body (see that file's header for why a direct
+ * import still isn't possible even though its own dependencies parse fine).
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import { createSlice, createEntityAdapter } from '@reduxjs/toolkit';
+
+import { lowerCaseKey, isNotUndefinedOrNull } from 'shared/utils';
+
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(path.resolve(here, '../api.ts'), 'utf8');
+
+// ---------------------------------------------------------------------------
+// Test rig: faithful clone of apiSlice's reducers + extraReducers. MUST stay
+// in sync with `../api.ts`. Each reducer below mirrors the real
+// implementation; the "source contract" tests at the bottom pin the real
+// source against regexes so drift is caught.
+// ---------------------------------------------------------------------------
+
+const testApiAdapter = createEntityAdapter();
+// Stand-in for `DOCUMENT.apiFileAdapter.getSelectors(s => s.apiFiles)`: an
+// entity-adapter selector set over a plain `{ apiFiles: EntityState }` shape,
+// used by `enrichTab`/`enrichTabs` to resolve a linked file's content.
+const testApiFileAdapter = createEntityAdapter();
+const apiFilesSelectors = testApiFileAdapter.getSelectors((s: any) => s.apiFiles);
+
+function formatTab({
+    id,
+    name,
+    header,
+    body,
+    bodyMode,
+    method,
+    endpoint,
+    isDraft,
+    fileId,
+    fileData,
+    actions,
+    actionPointer,
+}: any) {
+    return {
+        id,
+        name,
+        header,
+        body,
+        bodyMode: bodyMode || 'raw',
+        method,
+        endpoint,
+        isDraft,
+        fileId,
+        fileData,
+        actions,
+        actionPointer,
+    };
+}
+
+function enrichTabs(tabs: any[], state: any, selector: any) {
+    return tabs.map(tab => enrichTab(tab, state, selector));
+}
+
+const norm = (v: unknown): string => (v == null ? '' : String(v));
+
+function enrichTab(tab: any, state: any, selector: any) {
+    const file =
+        tab.fileId && selector ? selector.selectById(state, lowerCaseKey(tab.fileId)) : null;
+    const fileData = file?.extra || {};
+    const differs =
+        norm(fileData.body) !== norm(tab.body) ||
+        norm(fileData.bodyMode || 'raw') !== norm(tab.bodyMode || 'raw') ||
+        norm(fileData.header) !== norm(tab.header) ||
+        norm(fileData.method) !== norm(tab.method) ||
+        norm(fileData.endpoint) !== norm(tab.endpoint);
+    return {
+        ...tab,
+        isDraft: differs && isNotUndefinedOrNull(tab.fileId),
+    };
+}
+
+function assignNewApiData(item: any, value: any) {
+    Object.assign(item, {
+        header: value.header,
+        method: value.method,
+        endpoint: value.endpoint,
+        body: value.body,
+        bodyMode: value.bodyMode || 'raw',
+        actions: value.actions,
+        actionPointer: value.actionPointer,
+    });
+}
+
+function addAction({ state, tabId, request, response }: any) {
+    const tabIndex = state.tabs.findIndex((x: any) => x.id === tabId);
+    if (tabIndex > -1) {
+        let actions = state.tabs[tabIndex].actions || [];
+        const actionPointer = state.tabs[tabIndex].actionPointer || 0;
+
+        if (actions.length > 0 && actionPointer != actions.length - 1) {
+            actions = actions.slice(0, actionPointer + 1);
+        }
+        actions.push({ request, response });
+        Object.assign(state.tabs[tabIndex], {
+            actions,
+            actionPointer: actions.length - 1,
+        });
+        assignNewApiData(state, state.tabs[tabIndex]);
+    }
+}
+
+const DEFAULT_API_VERSION = '59.0';
+const DEFAULT_HEADER = 'Content-Type: application/json; charset=UTF-8\nAccept: application/json';
+
+function generateDefaultTab(version: string) {
+    return {
+        id: 'generated-id',
+        header: DEFAULT_HEADER,
+        endpoint: `/services/data/v${version}`,
+        body: '',
+        bodyMode: 'raw',
+        method: 'GET',
+        variables: '{}',
+        actions: [],
+        actionPointer: null,
+    };
+}
+
+function createInitialTabs(apiVersion: string, defaultHeader: string) {
+    const tab: any = generateDefaultTab(apiVersion);
+    if (defaultHeader) {
+        tab.header = defaultHeader;
+    }
+    return [enrichTab(tab, null, null)];
+}
+
+const DEFAULT_VARIABLES = `{
+    "id": "123",
+    "name": "John Doe"
+}`;
+
+// Simulated async thunk action-type strings (mirrors `executeApiRequest`'s
+// `createAsyncThunk('api/callRequest', ...)` auto-generated types).
+const PENDING = 'api/callRequest/pending';
+const FULFILLED = 'api/callRequest/fulfilled';
+const REJECTED = 'api/callRequest/rejected';
+
+const initialState = () => ({
+    viewerTab: 'Default',
+    requestTab: 'Default',
+    recentPanelToggled: false,
+    tabs: [] as any[],
+    currentTab: null as any,
+    api: testApiAdapter.getInitialState(),
+    body: null,
+    method: null,
+    endpoint: null,
+    variables: DEFAULT_VARIABLES,
+    header: null,
+    defaultHeader: DEFAULT_HEADER,
+    currentApiVersion: DEFAULT_API_VERSION,
+    abortingMap: {} as Record<string, any>,
+    isInitialized: false,
+    currentFileId: undefined as any,
+});
+
+const testSlice = createSlice({
+    name: 'apiTest',
+    initialState: initialState(),
+    reducers: {
+        loadCacheSettings: (state, action: any) => {
+            const { cachedConfig, apiFiles } = action.payload;
+            if (cachedConfig && !state.isInitialized) {
+                const { viewerTab, requestTab, recentPanelToggled, tabs, defaultHeader } =
+                    cachedConfig;
+                const cachedTabs =
+                    tabs && tabs.length > 0
+                        ? enrichTabs(tabs, { apiFiles }, apiFilesSelectors)
+                        : [];
+                const allTabs = [...cachedTabs, ...state.tabs];
+                Object.assign(state, {
+                    viewerTab,
+                    requestTab,
+                    recentPanelToggled,
+                    defaultHeader: defaultHeader || state.defaultHeader,
+                    tabs: allTabs,
+                    currentTab: allTabs.length > 0 ? allTabs[allTabs.length - 1] : null,
+                });
+            }
+            state.isInitialized = true;
+        },
+        updateViewerTab: (state, action: any) => {
+            const { value } = action.payload;
+            state.viewerTab = value;
+        },
+        updateRequestTab: (state, action: any) => {
+            const { value } = action.payload;
+            state.requestTab = value;
+        },
+        updateRequest: (state, action: any) => {
+            const { header, method, endpoint, body, bodyMode, tabId, isDraft } = action.payload;
+            const tabIndex = state.tabs.findIndex((x: any) => x.id === tabId);
+            if (tabIndex > -1) {
+                Object.assign(state.tabs[tabIndex], {
+                    header,
+                    method,
+                    endpoint,
+                    body,
+                    bodyMode: bodyMode || 'raw',
+                    isDraft,
+                });
+                assignNewApiData(state, state.tabs[tabIndex]);
+                state.currentTab = state.tabs[tabIndex];
+            }
+        },
+        updateDefaultHeader: (state, action: any) => {
+            const { header } = action.payload;
+            state.defaultHeader = header;
+        },
+        updateCurrentApiVersion: (state, action: any) => {
+            const { version } = action.payload;
+            state.currentApiVersion = version || DEFAULT_API_VERSION;
+        },
+        updateRecentPanel: (state, action: any) => {
+            const { value } = action.payload;
+            state.recentPanelToggled = value === true;
+        },
+        initTabs: (state, action: any) => {
+            const { apiFiles, reset } = action.payload;
+            if (reset || !state.tabs || state.tabs.length === 0) {
+                state.tabs = enrichTabs(
+                    createInitialTabs(state.currentApiVersion, state.defaultHeader),
+                    { apiFiles },
+                    apiFilesSelectors
+                );
+            } else {
+                state.tabs = enrichTabs(state.tabs.map(formatTab), { apiFiles }, apiFilesSelectors);
+            }
+            if (state.tabs.length > 0) {
+                const lastTabIndex = state.tabs.length - 1;
+                state.currentTab = state.tabs[lastTabIndex];
+                state.currentFileId = state.tabs[lastTabIndex].fileId;
+                assignNewApiData(state, state.tabs[lastTabIndex]);
+            }
+        },
+        resetTab: (state, action: any) => {
+            const { tabId, apiFiles } = action.payload;
+            const tabIndex = state.tabs.findIndex((x: any) => x.id === tabId);
+            if (tabIndex > -1) {
+                let enrichedTab: any;
+                const existingFileId = state.tabs[tabIndex].fileId;
+                if (existingFileId) {
+                    enrichedTab = enrichTab(
+                        formatTab({ ...state.tabs[tabIndex], fileId: existingFileId }),
+                        { apiFiles },
+                        apiFilesSelectors
+                    );
+                } else {
+                    enrichedTab = enrichTab(
+                        generateDefaultTab(state.currentApiVersion),
+                        null,
+                        null
+                    );
+                }
+                state.tabs[tabIndex] = enrichedTab;
+                state.currentTab = enrichedTab;
+                assignNewApiData(state, enrichedTab);
+            }
+        },
+        addTab: (state, action: any) => {
+            const { apiFiles, tab } = action.payload;
+            if (!tab.header || tab.header === DEFAULT_HEADER) {
+                tab.header = state.defaultHeader || DEFAULT_HEADER;
+            }
+            const enrichedTab = enrichTab(formatTab(tab), { apiFiles }, apiFilesSelectors);
+            state.tabs.push(enrichedTab);
+            state.currentTab = enrichedTab;
+            state.currentFileId = enrichedTab.fileId;
+            assignNewApiData(state, enrichedTab);
+        },
+        removeTab: (state, action: any) => {
+            const { id } = action.payload;
+            state.tabs = state.tabs.filter((x: any) => x.id != id);
+            if (state.tabs.length > 0 && state.currentTab.id == id) {
+                const lastTab = state.tabs[state.tabs.length - 1];
+                state.currentTab = lastTab;
+                assignNewApiData(state, lastTab);
+            }
+        },
+        selectionTab: (state, action: any) => {
+            const { id } = action.payload;
+            const tab = state.tabs.find((x: any) => x.id == id);
+            if (tab) {
+                state.currentTab = tab;
+                assignNewApiData(state, tab);
+            }
+        },
+        linkFileToTab: (state, action: any) => {
+            const { fileId, apiFiles } = action.payload;
+            const currentTabIndex = state.tabs.findIndex((x: any) => x.id == state.currentTab.id);
+            if (currentTabIndex > -1) {
+                const enrichedTab = enrichTab(
+                    formatTab({ ...state.tabs[currentTabIndex], fileId }),
+                    { apiFiles },
+                    apiFilesSelectors
+                );
+                state.tabs[currentTabIndex] = enrichedTab;
+                state.currentTab = enrichedTab;
+                assignNewApiData(state, enrichedTab);
+            }
+        },
+        increaseActionPointer: (state, action: any) => {
+            const { tabId } = action.payload;
+            const tabIndex = state.tabs.findIndex((x: any) => x.id === tabId);
+            if (tabIndex > -1) {
+                const actions = state.tabs[tabIndex].actions;
+                let actionPointer = state.tabs[tabIndex].actionPointer;
+                if (actions.length - 1 <= actionPointer) {
+                    actionPointer = actions.length - 1;
+                } else {
+                    actionPointer = actionPointer + 1;
+                }
+                Object.assign(state.tabs[tabIndex], { actionPointer });
+                assignNewApiData(state, state.tabs[tabIndex]);
+            }
+        },
+        decreaseActionPointer: (state, action: any) => {
+            const { tabId } = action.payload;
+            const tabIndex = state.tabs.findIndex((x: any) => x.id === tabId);
+            if (tabIndex > -1) {
+                let actionPointer = state.tabs[tabIndex].actionPointer;
+                if (actionPointer <= 0) {
+                    actionPointer = 0;
+                } else {
+                    actionPointer = actionPointer - 1;
+                }
+                Object.assign(state.tabs[tabIndex], { actionPointer });
+                assignNewApiData(state, state.tabs[tabIndex]);
+            }
+        },
+        setAbortingPromise: (state, action: any) => {
+            const { tabId, promise } = action.payload;
+            state.abortingMap = { ...state.abortingMap, [tabId]: promise };
+        },
+        resetAbortingPromise: (state, action: any) => {
+            const { tabId } = action.payload;
+            state.abortingMap = { ...state.abortingMap, [tabId]: null };
+        },
+        clearAbortingMap: (state: any) => {
+            state.abortingMap = {};
+        },
+        updateVariables: (state, action: any) => {
+            const { variables } = action.payload;
+            state.variables = variables;
+        },
+    },
+    extraReducers: builder => {
+        builder
+            .addCase(PENDING, (state: any, action: any) => {
+                const { tabId, createdDate } = action.meta.arg;
+                testApiAdapter.upsertOne(state.api, {
+                    id: lowerCaseKey(tabId),
+                    response: null,
+                    createdDate,
+                    isFetching: true,
+                    error: null,
+                });
+            })
+            .addCase(FULFILLED, (state: any, action: any) => {
+                const { response, request, formattedRequest } = action.payload;
+                const { tabId, createdDate } = action.meta.arg;
+                state.abortingMap = { ...state.abortingMap, [tabId]: null };
+                testApiAdapter.upsertOne(state.api, {
+                    id: lowerCaseKey(tabId),
+                    response,
+                    request,
+                    formattedRequest,
+                    isFetching: false,
+                    createdDate,
+                    error: null,
+                });
+                addAction({ state, tabId, request, response });
+            })
+            .addCase(REJECTED, (state: any, action: any) => {
+                const { error } = action;
+                const { tabId } = action.meta.arg;
+                state.abortingMap = { ...state.abortingMap, [tabId]: null };
+                testApiAdapter.upsertOne(state.api, {
+                    id: lowerCaseKey(tabId),
+                    isFetching: false,
+                    error: action.meta.aborted ? null : error,
+                });
+            });
+    },
+});
+
+function makeState(overrides: Partial<ReturnType<typeof initialState>> = {}) {
+    return { ...initialState(), ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// loadCacheSettings (the reducer, not the standalone exported function)
+// ---------------------------------------------------------------------------
+
+test('loadCacheSettings reducer: merges cached config into state and marks isInitialized', () => {
+    const before = makeState({ tabs: [{ id: 'existing' }] as any });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.loadCacheSettings({
+            cachedConfig: {
+                viewerTab: 'Pretty',
+                requestTab: 'Headers',
+                recentPanelToggled: true,
+                tabs: [],
+                defaultHeader: 'X-Custom: 1',
+            },
+            apiFiles: {},
+        })
+    );
+    assert.equal(next.viewerTab, 'Pretty');
+    assert.equal(next.requestTab, 'Headers');
+    assert.equal(next.recentPanelToggled, true);
+    assert.equal(next.defaultHeader, 'X-Custom: 1');
+    assert.equal(next.isInitialized, true);
+    // cachedTabs (empty) prepended to existing tabs -> existing tabs preserved
+    assert.deepEqual(next.tabs, [{ id: 'existing' }]);
+    assert.deepEqual(next.currentTab, { id: 'existing' });
+});
+
+test('loadCacheSettings reducer: is a no-op for state fields (besides isInitialized) once already initialized', () => {
+    const before = makeState({ isInitialized: true, viewerTab: 'Default' });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.loadCacheSettings({
+            cachedConfig: { viewerTab: 'Pretty' },
+            apiFiles: {},
+        })
+    );
+    assert.equal(next.viewerTab, 'Default', 'already-initialized state must not be overwritten');
+    assert.equal(next.isInitialized, true);
+});
+
+test('loadCacheSettings reducer: no cachedConfig -> only isInitialized flips', () => {
+    const before = makeState({ viewerTab: 'Default' });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.loadCacheSettings({ cachedConfig: null, apiFiles: {} })
+    );
+    assert.equal(next.viewerTab, 'Default');
+    assert.equal(next.isInitialized, true);
+});
+
+// ---------------------------------------------------------------------------
+// updateViewerTab / updateRequestTab / updateDefaultHeader / updateRecentPanel
+// / updateCurrentApiVersion / updateVariables — simple field setters
+// ---------------------------------------------------------------------------
+
+test('updateViewerTab: sets viewerTab', () => {
+    const next = testSlice.reducer(
+        makeState(),
+        testSlice.actions.updateViewerTab({ value: 'Raw' })
+    );
+    assert.equal(next.viewerTab, 'Raw');
+});
+
+test('updateRequestTab: sets requestTab', () => {
+    const next = testSlice.reducer(
+        makeState(),
+        testSlice.actions.updateRequestTab({ value: 'Variables' })
+    );
+    assert.equal(next.requestTab, 'Variables');
+});
+
+test('updateDefaultHeader: sets defaultHeader', () => {
+    const next = testSlice.reducer(
+        makeState(),
+        testSlice.actions.updateDefaultHeader({ header: 'X-Foo: bar' })
+    );
+    assert.equal(next.defaultHeader, 'X-Foo: bar');
+});
+
+test('updateCurrentApiVersion: sets version when provided', () => {
+    const next = testSlice.reducer(
+        makeState(),
+        testSlice.actions.updateCurrentApiVersion({ version: '60.0' })
+    );
+    assert.equal(next.currentApiVersion, '60.0');
+});
+
+test('updateCurrentApiVersion: falls back to DEFAULT_API_VERSION when version is falsy', () => {
+    const next = testSlice.reducer(
+        makeState({ currentApiVersion: '60.0' }),
+        testSlice.actions.updateCurrentApiVersion({ version: null })
+    );
+    assert.equal(next.currentApiVersion, DEFAULT_API_VERSION);
+});
+
+test('updateRecentPanel: coerces truthy/non-boolean values via strict `=== true`', () => {
+    const on = testSlice.reducer(makeState(), testSlice.actions.updateRecentPanel({ value: true }));
+    assert.equal(on.recentPanelToggled, true);
+
+    const truthyButNotBoolTrue = testSlice.reducer(
+        makeState(),
+        testSlice.actions.updateRecentPanel({ value: 1 })
+    );
+    assert.equal(
+        truthyButNotBoolTrue.recentPanelToggled,
+        false,
+        '`value === true` only accepts the literal boolean true'
+    );
+});
+
+test('updateVariables: sets variables verbatim', () => {
+    const next = testSlice.reducer(
+        makeState(),
+        testSlice.actions.updateVariables({ variables: '{"a":1}' })
+    );
+    assert.equal(next.variables, '{"a":1}');
+});
+
+// ---------------------------------------------------------------------------
+// updateRequest
+// ---------------------------------------------------------------------------
+
+test('updateRequest: updates the matching tab and mirrors it onto top-level state via assignNewApiData', () => {
+    const before = makeState({
+        tabs: [
+            {
+                id: 't1',
+                header: 'H',
+                method: 'GET',
+                endpoint: '/e',
+                body: '',
+                actions: [],
+                actionPointer: null,
+            },
+        ],
+    });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.updateRequest({
+            tabId: 't1',
+            header: 'H2',
+            method: 'POST',
+            endpoint: '/e2',
+            body: '{}',
+            bodyMode: 'raw',
+            isDraft: true,
+        })
+    );
+    assert.equal(next.tabs[0].method, 'POST');
+    assert.equal(next.tabs[0].isDraft, true);
+    assert.equal(next.method, 'POST', 'assignNewApiData mirrors tab fields to top-level state');
+    assert.deepEqual(next.currentTab, next.tabs[0]);
+});
+
+test('updateRequest: defaults bodyMode to "raw" when falsy', () => {
+    const before = makeState({
+        tabs: [
+            {
+                id: 't1',
+                header: 'H',
+                method: 'GET',
+                endpoint: '/e',
+                body: '',
+                actions: [],
+                actionPointer: null,
+            },
+        ],
+    });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.updateRequest({ tabId: 't1', bodyMode: undefined })
+    );
+    assert.equal(next.tabs[0].bodyMode, 'raw');
+});
+
+test('updateRequest: non-existent tabId is a no-op', () => {
+    const before = makeState({ tabs: [{ id: 't1' }] as any });
+    const next = testSlice.reducer(before, testSlice.actions.updateRequest({ tabId: 'nope' }));
+    assert.deepEqual(next.tabs, before.tabs);
+    assert.equal(next.currentTab, before.currentTab);
+});
+
+// ---------------------------------------------------------------------------
+// initTabs
+// ---------------------------------------------------------------------------
+
+test('initTabs: seeds a single default tab when state.tabs is empty', () => {
+    const next = testSlice.reducer(
+        makeState({ tabs: [] }),
+        testSlice.actions.initTabs({ apiFiles: {}, reset: false })
+    );
+    assert.equal(next.tabs.length, 1);
+    assert.equal(next.tabs[0].endpoint, `/services/data/v${DEFAULT_API_VERSION}`);
+    assert.equal(next.currentTab, next.tabs[0]);
+});
+
+test('initTabs: reset:true replaces existing tabs with a fresh default tab', () => {
+    const before = makeState({
+        tabs: [
+            {
+                id: 'old',
+                header: 'H',
+                method: 'GET',
+                endpoint: '/old',
+                body: '',
+                actions: [],
+                actionPointer: null,
+            },
+        ],
+    });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.initTabs({ apiFiles: {}, reset: true })
+    );
+    assert.equal(next.tabs.length, 1);
+    assert.notEqual(next.tabs[0].id, 'old');
+});
+
+test('initTabs: reset:false with existing tabs re-enriches (formatTab + enrichTab) rather than replacing', () => {
+    const before = makeState({
+        tabs: [
+            {
+                id: 'existing',
+                header: 'H',
+                method: 'GET',
+                endpoint: '/e',
+                body: 'x',
+                bodyMode: 'raw',
+                actions: [],
+                actionPointer: null,
+                extraJunkField: 'dropped-by-formatTab',
+            },
+        ] as any,
+    });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.initTabs({ apiFiles: {}, reset: false })
+    );
+    assert.equal(next.tabs.length, 1);
+    assert.equal(next.tabs[0].id, 'existing');
+    assert.equal(
+        Object.prototype.hasOwnProperty.call(next.tabs[0], 'extraJunkField'),
+        false,
+        'formatTab drops fields not in its destructure list'
+    );
+});
+
+// ---------------------------------------------------------------------------
+// resetTab
+// ---------------------------------------------------------------------------
+
+test('resetTab: without a linked file, replaces the tab with a fresh default tab', () => {
+    const before = makeState({
+        currentApiVersion: '61.0',
+        tabs: [
+            {
+                id: 't1',
+                header: 'stale',
+                method: 'POST',
+                endpoint: '/stale',
+                body: 'x',
+                actions: [{ a: 1 }],
+                actionPointer: 0,
+            },
+        ],
+    });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.resetTab({ tabId: 't1', apiFiles: {} })
+    );
+    assert.equal(next.tabs[0].method, 'GET');
+    assert.equal(next.tabs[0].endpoint, '/services/data/v61.0');
+    assert.equal(next.currentTab, next.tabs[0]);
+});
+
+test('resetTab: with a linked fileId, re-enriches the existing tab (keeps the fileId) instead of generating a default', () => {
+    const before = makeState({
+        tabs: [
+            {
+                id: 't1',
+                header: 'H',
+                method: 'POST',
+                endpoint: '/e',
+                body: 'x',
+                fileId: 'file-1',
+                actions: [],
+                actionPointer: null,
+            },
+        ] as any,
+    });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.resetTab({ tabId: 't1', apiFiles: testApiFileAdapter.getInitialState() })
+    );
+    assert.equal(
+        next.tabs[0].fileId,
+        'file-1',
+        'existing fileId is preserved when resetting a linked tab'
+    );
+});
+
+test('resetTab: non-existent tabId is a no-op', () => {
+    const before = makeState({ tabs: [{ id: 't1' }] as any });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.resetTab({ tabId: 'nope', apiFiles: {} })
+    );
+    assert.deepEqual(next.tabs, before.tabs);
+});
+
+// ---------------------------------------------------------------------------
+// addTab / removeTab / selectionTab
+// ---------------------------------------------------------------------------
+
+test('addTab: appends a tab, applying state.defaultHeader when the tab has no header', () => {
+    const before = makeState({ defaultHeader: 'X-Default: 1', tabs: [] });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.addTab({
+            apiFiles: {},
+            tab: {
+                id: 'new1',
+                method: 'GET',
+                endpoint: '/x',
+                body: '',
+                actions: [],
+                actionPointer: null,
+            },
+        })
+    );
+    assert.equal(next.tabs.length, 1);
+    assert.equal(next.tabs[0].header, 'X-Default: 1');
+    assert.equal(next.currentTab, next.tabs[0]);
+});
+
+test('addTab: keeps an explicit non-default header untouched', () => {
+    const before = makeState({ defaultHeader: 'X-Default: 1', tabs: [] });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.addTab({
+            apiFiles: {},
+            tab: {
+                id: 'new1',
+                header: 'X-Custom: yes',
+                method: 'GET',
+                endpoint: '/x',
+                body: '',
+                actions: [],
+                actionPointer: null,
+            },
+        })
+    );
+    assert.equal(next.tabs[0].header, 'X-Custom: yes');
+});
+
+test('addTab: header equal to the shared DEFAULT_HEADER constant is still replaced by state.defaultHeader', () => {
+    const before = makeState({ defaultHeader: 'X-Org-Default: 1', tabs: [] });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.addTab({
+            apiFiles: {},
+            tab: {
+                id: 'new1',
+                header: DEFAULT_HEADER,
+                method: 'GET',
+                endpoint: '/x',
+                body: '',
+                actions: [],
+                actionPointer: null,
+            },
+        })
+    );
+    assert.equal(next.tabs[0].header, 'X-Org-Default: 1');
+});
+
+test('removeTab: removes the tab and, if it was the current tab, falls back to the new last tab', () => {
+    const before = makeState({
+        tabs: [
+            { id: 't1', method: 'GET', endpoint: '/1', body: '', actions: [], actionPointer: null },
+            {
+                id: 't2',
+                method: 'POST',
+                endpoint: '/2',
+                body: '',
+                actions: [],
+                actionPointer: null,
+            },
+        ],
+        currentTab: { id: 't2' } as any,
+    });
+    const next = testSlice.reducer(before, testSlice.actions.removeTab({ id: 't2' }));
+    assert.equal(next.tabs.length, 1);
+    assert.equal(next.currentTab.id, 't1');
+});
+
+test('removeTab: removing a non-current tab leaves currentTab untouched', () => {
+    const currentTab = {
+        id: 't2',
+        method: 'POST',
+        endpoint: '/2',
+        body: '',
+        actions: [],
+        actionPointer: null,
+    };
+    const before = makeState({
+        tabs: [
+            { id: 't1', method: 'GET', endpoint: '/1', body: '', actions: [], actionPointer: null },
+            currentTab,
+        ],
+        currentTab,
+    });
+    const next = testSlice.reducer(before, testSlice.actions.removeTab({ id: 't1' }));
+    assert.equal(next.tabs.length, 1);
+    assert.equal(next.currentTab, currentTab);
+});
+
+test('selectionTab: switches currentTab and mirrors its fields to top-level state', () => {
+    const tab2 = {
+        id: 't2',
+        header: 'H2',
+        method: 'PUT',
+        endpoint: '/2',
+        body: 'b2',
+        actions: [],
+        actionPointer: null,
+    };
+    const before = makeState({
+        tabs: [
+            { id: 't1', method: 'GET', endpoint: '/1', body: '', actions: [], actionPointer: null },
+            tab2,
+        ],
+    });
+    const next = testSlice.reducer(before, testSlice.actions.selectionTab({ id: 't2' }));
+    assert.equal(next.currentTab, tab2);
+    assert.equal(next.method, 'PUT');
+});
+
+test('selectionTab: non-existent id is a no-op', () => {
+    const before = makeState({ tabs: [{ id: 't1' }] as any, currentTab: { id: 't1' } as any });
+    const next = testSlice.reducer(before, testSlice.actions.selectionTab({ id: 'nope' }));
+    assert.equal(next.currentTab, before.currentTab);
+});
+
+// ---------------------------------------------------------------------------
+// linkFileToTab
+// ---------------------------------------------------------------------------
+
+test('linkFileToTab: attaches fileId to the current tab and re-enriches it', () => {
+    const currentTab = {
+        id: 't1',
+        header: 'H',
+        method: 'GET',
+        endpoint: '/e',
+        body: '',
+        actions: [],
+        actionPointer: null,
+    };
+    const before = makeState({ tabs: [currentTab], currentTab });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.linkFileToTab({
+            fileId: 'file-9',
+            apiFiles: testApiFileAdapter.getInitialState(),
+        })
+    );
+    assert.equal(next.tabs[0].fileId, 'file-9');
+    assert.equal(next.currentTab.fileId, 'file-9');
+});
+
+// ---------------------------------------------------------------------------
+// increaseActionPointer / decreaseActionPointer
+// ---------------------------------------------------------------------------
+
+test('increaseActionPointer: advances the pointer up to the last action index', () => {
+    const before = makeState({
+        tabs: [
+            {
+                id: 't1',
+                actions: [{ a: 1 }, { a: 2 }, { a: 3 }],
+                actionPointer: 0,
+                method: 'GET',
+                endpoint: '/1',
+                body: '',
+                header: '',
+            },
+        ],
+    });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.increaseActionPointer({ tabId: 't1' })
+    );
+    assert.equal(next.tabs[0].actionPointer, 1);
+});
+
+test('increaseActionPointer: clamps at the last action index (does not overflow)', () => {
+    const before = makeState({
+        tabs: [
+            {
+                id: 't1',
+                actions: [{ a: 1 }, { a: 2 }],
+                actionPointer: 1,
+                method: 'GET',
+                endpoint: '/1',
+                body: '',
+                header: '',
+            },
+        ],
+    });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.increaseActionPointer({ tabId: 't1' })
+    );
+    assert.equal(next.tabs[0].actionPointer, 1, 'pointer must not exceed actions.length - 1');
+});
+
+test('decreaseActionPointer: moves the pointer back by one', () => {
+    const before = makeState({
+        tabs: [
+            {
+                id: 't1',
+                actions: [{ a: 1 }, { a: 2 }],
+                actionPointer: 1,
+                method: 'GET',
+                endpoint: '/1',
+                body: '',
+                header: '',
+            },
+        ],
+    });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.decreaseActionPointer({ tabId: 't1' })
+    );
+    assert.equal(next.tabs[0].actionPointer, 0);
+});
+
+test('decreaseActionPointer: clamps at 0 (does not go negative)', () => {
+    const before = makeState({
+        tabs: [
+            {
+                id: 't1',
+                actions: [{ a: 1 }],
+                actionPointer: 0,
+                method: 'GET',
+                endpoint: '/1',
+                body: '',
+                header: '',
+            },
+        ],
+    });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.decreaseActionPointer({ tabId: 't1' })
+    );
+    assert.equal(next.tabs[0].actionPointer, 0);
+});
+
+// ---------------------------------------------------------------------------
+// setAbortingPromise / resetAbortingPromise / clearAbortingMap
+// ---------------------------------------------------------------------------
+
+test('setAbortingPromise: stores a promise keyed by tabId without clobbering other entries', () => {
+    const p1 = Promise.resolve();
+    const before = makeState({ abortingMap: { other: 'x' } });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.setAbortingPromise({ tabId: 't1', promise: p1 })
+    );
+    assert.equal(next.abortingMap.t1, p1);
+    assert.equal(next.abortingMap.other, 'x');
+});
+
+test('resetAbortingPromise: nulls out a single tab entry, preserving siblings', () => {
+    const before = makeState({ abortingMap: { t1: 'promise', t2: 'promise2' } });
+    const next = testSlice.reducer(before, testSlice.actions.resetAbortingPromise({ tabId: 't1' }));
+    assert.equal(next.abortingMap.t1, null);
+    assert.equal(next.abortingMap.t2, 'promise2');
+});
+
+test('clearAbortingMap: wipes the whole map', () => {
+    const before = makeState({ abortingMap: { t1: 'x', t2: 'y' } });
+    const next = testSlice.reducer(before, testSlice.actions.clearAbortingMap());
+    assert.deepEqual(next.abortingMap, {});
+});
+
+// ---------------------------------------------------------------------------
+// extraReducers: executeApiRequest.pending / fulfilled / rejected
+// ---------------------------------------------------------------------------
+
+test('executeApiRequest.pending: upserts an isFetching entity keyed by lowercased tabId', () => {
+    const before = makeState();
+    const next = testSlice.reducer(before, {
+        type: PENDING,
+        meta: { arg: { tabId: 'TabABC', createdDate: '2026-01-01' } },
+    });
+    const entity = (next.api.entities as any)['tababc'];
+    assert.ok(entity);
+    assert.equal(entity.isFetching, true);
+    assert.equal(entity.error, null);
+    assert.equal(entity.response, null);
+});
+
+test('executeApiRequest.fulfilled: stores the response, clears abortingMap entry, and records an action in history', () => {
+    const before = makeState({
+        tabs: [
+            {
+                id: 'TabABC',
+                actions: [],
+                actionPointer: 0,
+                method: 'GET',
+                endpoint: '/1',
+                body: '',
+                header: '',
+            },
+        ],
+        abortingMap: { TabABC: 'some-promise' },
+    });
+    const next = testSlice.reducer(before, {
+        type: FULFILLED,
+        payload: {
+            response: { statusCode: 200 },
+            request: { method: 'GET' },
+            formattedRequest: { url: '/x' },
+        },
+        meta: { arg: { tabId: 'TabABC', createdDate: '2026-01-01' } },
+    });
+    const entity = (next.api.entities as any)['tababc'];
+    assert.equal(entity.isFetching, false);
+    assert.deepEqual(entity.response, { statusCode: 200 });
+    assert.equal(next.abortingMap.TabABC, null);
+    assert.equal(
+        next.tabs[0].actions.length,
+        1,
+        'addAction must push a history entry onto the matching tab'
+    );
+    assert.equal(next.tabs[0].actionPointer, 0);
+});
+
+test('executeApiRequest.fulfilled: addAction truncates redo history when a new action is dispatched mid-history', () => {
+    const before = makeState({
+        tabs: [
+            {
+                id: 'TabABC',
+                actions: [
+                    { request: 'r1', response: 'res1' },
+                    { request: 'r2', response: 'res2' },
+                ],
+                actionPointer: 0, // user had rewound to the first action
+                method: 'GET',
+                endpoint: '/1',
+                body: '',
+                header: '',
+            },
+        ],
+    });
+    const next = testSlice.reducer(before, {
+        type: FULFILLED,
+        payload: { response: 'res3', request: 'r3', formattedRequest: {} },
+        meta: { arg: { tabId: 'TabABC', createdDate: '2026-01-01' } },
+    });
+    assert.equal(next.tabs[0].actions.length, 2, 'the un-reached r2 action must be dropped');
+    assert.deepEqual(next.tabs[0].actions[1], { request: 'r3', response: 'res3' });
+    assert.equal(next.tabs[0].actionPointer, 1);
+});
+
+test('executeApiRequest.rejected: sets error and clears abortingMap entry unless the request was aborted', () => {
+    const before = makeState({ abortingMap: { TabABC: 'x' } });
+    const next = testSlice.reducer(before, {
+        type: REJECTED,
+        error: { message: 'Network error' },
+        meta: { arg: { tabId: 'TabABC' }, aborted: false },
+    });
+    const entity = (next.api.entities as any)['tababc'];
+    assert.equal(entity.isFetching, false);
+    assert.deepEqual(entity.error, { message: 'Network error' });
+    assert.equal(next.abortingMap.TabABC, null);
+});
+
+test('executeApiRequest.rejected: swallows the error (sets null) when the request was deliberately aborted', () => {
+    const before = makeState();
+    const next = testSlice.reducer(before, {
+        type: REJECTED,
+        error: { message: 'AbortError' },
+        meta: { arg: { tabId: 'TabABC' }, aborted: true },
+    });
+    const entity = (next.api.entities as any)['tababc'];
+    assert.equal(entity.error, null, 'aborted requests must not surface an error to the user');
+});
+
+// ---------------------------------------------------------------------------
+// Source contract tests — pin the real `../api.ts` against regexes so drift
+// between this clone and the real implementation is caught.
+// ---------------------------------------------------------------------------
+
+test('source contract: apiSlice reducers include the full expected set of names', () => {
+    const expectedReducers = [
+        'loadCacheSettings',
+        'saveCacheSettings',
+        'updateViewerTab',
+        'updateRequestTab',
+        'updateRequest',
+        'updateDefaultHeader',
+        'updateCurrentApiVersion',
+        'updateRecentPanel',
+        'initTabs',
+        'resetTab',
+        'addTab',
+        'removeTab',
+        'selectionTab',
+        'linkFileToTab',
+        'increaseActionPointer',
+        'decreaseActionPointer',
+        'setAbortingPromise',
+        'resetAbortingPromise',
+        'updateVariables',
+    ];
+    for (const name of expectedReducers) {
+        assert.match(
+            SRC,
+            new RegExp(`\\b${name}: \\(state`),
+            `expected reducer \`${name}\` to be defined as \`${name}: (state, ...) => {\``
+        );
+    }
+    // `clearAbortingMap` takes no `action` param, so its signature is
+    // `clearAbortingMap: state => {` (no parens around the single param).
+    assert.match(SRC, /\bclearAbortingMap: state => \{/);
+});
+
+test('source contract: entity-adapter upserts (pending/fulfilled/rejected) are keyed by lowerCaseKey(tabId)', () => {
+    assert.match(
+        SRC,
+        /addCase\(executeApiRequest\.pending, \(state, action\) => \{[\s\S]+?id: lowerCaseKey\(tabId\),/
+    );
+    assert.match(
+        SRC,
+        /addCase\(executeApiRequest\.fulfilled, \(state, action\) => \{[\s\S]+?id: lowerCaseKey\(tabId\),/
+    );
+    assert.match(
+        SRC,
+        /addCase\(executeApiRequest\.rejected, \(state, action\) => \{[\s\S]+?id: lowerCaseKey\(tabId\),/
+    );
+});
+
+test('source contract: rejected reducer swallows the error when the thunk was aborted', () => {
+    assert.match(SRC, /error: action\.meta\.aborted \? null : error,/);
+});
+
+test('source contract: addAction truncates the redo branch before pushing a new action', () => {
+    assert.match(
+        SRC,
+        /if \(actions\.length > 0 && actionPointer != actions\.length - 1\) \{\s*actions = actions\.slice\(0, actionPointer \+ 1\);\s*\}/
+    );
+});
+
+test('source contract: increaseActionPointer/decreaseActionPointer clamp at the array bounds', () => {
+    assert.match(
+        SRC,
+        /increaseActionPointer:[\s\S]+?if \(actions\.length - 1 <= actionPointer\) \{\s*actionPointer = actions\.length - 1;/
+    );
+    assert.match(
+        SRC,
+        /decreaseActionPointer:[\s\S]+?if \(actionPointer <= 0\) \{\s*actionPointer = 0;/
+    );
+});
+
+test('source contract: updateRecentPanel coerces via the strict `=== true` check', () => {
+    assert.match(SRC, /state\.recentPanelToggled = value === true;/);
+});
+
+test('source contract: addTab replaces a default/empty header with state.defaultHeader', () => {
+    assert.match(
+        SRC,
+        /addTab:[\s\S]+?if \(!tab\.header \|\| tab\.header === API\.DEFAULT\.HEADER\) \{\s*tab\.header = state\.defaultHeader \|\| API\.DEFAULT\.HEADER;/
+    );
+});
+
+test('source contract: apiFilesSelectors is built from DOCUMENT.apiFileAdapter.getSelectors keyed on state.apiFiles', () => {
+    assert.match(
+        SRC,
+        /const apiFilesSelectors = DOCUMENT\.apiFileAdapter\.getSelectors\(s => s\.apiFiles\);/
+    );
+});

--- a/packages/lwc/applications/api/slices/__tests__/loadCacheSettings.test.ts
+++ b/packages/lwc/applications/api/slices/__tests__/loadCacheSettings.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Direct-import tests for the standalone `loadCacheSettings(alias)` function
+ * exported from `../api.ts` (NOT the same-named reducer inside `apiSlice`,
+ * see `api.test.ts` for that one — the two share a name but live in
+ * different scopes: this one is a top-level `export async function`, the
+ * other is a property inside `apiSlice.reducers`).
+ *
+ * Why this one CAN be imported directly (unlike the rest of `../api.ts`)
+ * -----------------------------------------------------------------------
+ * `../api.ts` imports `DOCUMENT`/`ERROR` from `host-api/store` at module
+ * top-level, and `host-api/store` transitively loads LWC `@api`/`@wire`
+ * decorator syntax the plain `--experimental-strip-types` runner can't
+ * parse — so importing `../api.ts` itself always throws
+ * `SyntaxError: Invalid or unexpected token` (verified empirically; see the
+ * header comment in `api.test.ts` for the full explanation and the
+ * faithful-clone approach used there).
+ *
+ * However `loadCacheSettings` itself only depends on `shared/cacheManager`
+ * (`loadExtensionConfigFromCache`, `CACHE_CONFIG`) and `shared/utils`
+ * (`safeParseJson`), neither of which import `host-api/store`. Since the
+ * *module* fails to parse as a whole (not just this function), we can't
+ * `import { loadCacheSettings } from '../api.ts'` either — Node still has
+ * to parse the whole file before it can pick out one export. So this file
+ * re-implements `loadCacheSettings` verbatim (it's tiny — 8 lines) and
+ * exercises the REAL `shared/cacheManager` + `shared/utils` dependencies
+ * (no mocking of those), only stubbing `window.localStorage` (the actual
+ * browser API cacheManager bottoms out on) the same way
+ * `core/announcements/__tests__/announcements.test.ts` does.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+import {
+    loadExtensionConfigFromCache,
+    saveExtensionConfigToCache,
+    CACHE_CONFIG,
+} from 'shared/cacheManager';
+import { safeParseJson } from 'shared/utils';
+
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(path.resolve(here, '../api.ts'), 'utf8');
+
+function createLocalStorageMock(): Storage {
+    const store = new Map<string, string>();
+    return {
+        getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+        setItem: (key: string, value: string) => {
+            store.set(key, String(value));
+        },
+        removeItem: (key: string) => {
+            store.delete(key);
+        },
+        clear: () => store.clear(),
+        get length() {
+            return store.size;
+        },
+        key: (index: number) => Array.from(store.keys())[index] ?? null,
+    } as unknown as Storage;
+}
+
+// Faithful clone of `../api.ts`'s exported `loadCacheSettings`. MUST stay in
+// sync — the source-contract tests at the bottom pin the real file.
+const API_SETTINGS_KEY = 'API_SETTINGS_KEY';
+
+async function loadCacheSettings(alias: string) {
+    const key = `${alias}-${API_SETTINGS_KEY}`;
+    const arr = [key, CACHE_CONFIG.API_SPLITTER_IS_HORIZONTAL.key];
+    const configMap = await loadExtensionConfigFromCache(arr);
+    if (configMap && configMap.hasOwnProperty(key)) {
+        configMap[key] = safeParseJson(configMap[key] as string) || null;
+    }
+    return configMap;
+}
+
+test('loadCacheSettings: returns defaults (including API_SPLITTER_IS_HORIZONTAL) when nothing is cached', async () => {
+    globalThis.window = { localStorage: createLocalStorageMock() } as unknown as Window &
+        typeof globalThis;
+
+    const result = await loadCacheSettings('myorg');
+
+    assert.equal(result['myorg-API_SETTINGS_KEY'], null, 'uncached alias key defaults to null');
+    assert.equal(
+        result[CACHE_CONFIG.API_SPLITTER_IS_HORIZONTAL.key],
+        true,
+        'CACHE_CONFIG default value must be surfaced for a registered key'
+    );
+});
+
+test('loadCacheSettings: parses a previously cached settings blob for the given alias', async () => {
+    globalThis.window = { localStorage: createLocalStorageMock() } as unknown as Window &
+        typeof globalThis;
+
+    const key = 'myorg-API_SETTINGS_KEY';
+    const savedPayload = { viewerTab: 'Pretty', requestTab: 'Body', tabs: [] };
+    // Mirrors real call sites: the slice's local `saveCacheSettings` writes a
+    // JSON *string* as the cache value (see `api.test.ts` for that reducer),
+    // and cacheManager's storage layer independently JSON-encodes whatever
+    // value it's given — so the round trip through the real cache stack
+    // double-encodes/decodes exactly once each way.
+    await saveExtensionConfigToCache({ [key]: JSON.stringify(savedPayload) });
+
+    const result = await loadCacheSettings('myorg');
+
+    assert.deepEqual(result[key], savedPayload);
+});
+
+test('loadCacheSettings: different alias -> different, independent cache key', async () => {
+    globalThis.window = { localStorage: createLocalStorageMock() } as unknown as Window &
+        typeof globalThis;
+
+    await saveExtensionConfigToCache({ 'org-a-API_SETTINGS_KEY': JSON.stringify({ a: 1 }) });
+
+    const resultA = await loadCacheSettings('org-a');
+    const resultB = await loadCacheSettings('org-b');
+
+    assert.deepEqual(resultA['org-a-API_SETTINGS_KEY'], { a: 1 });
+    assert.equal(resultB['org-b-API_SETTINGS_KEY'], null, 'org-b has no cached value of its own');
+});
+
+test('loadCacheSettings: malformed cached JSON degrades to null (safeParseJson swallows the error)', async () => {
+    globalThis.window = { localStorage: createLocalStorageMock() } as unknown as Window &
+        typeof globalThis;
+
+    const key = 'broken-API_SETTINGS_KEY';
+    // Write a value that, once round-tripped through cacheManager's storage
+    // decode, is a string that is NOT valid JSON (so the second, explicit
+    // `safeParseJson` call inside `loadCacheSettings` fails and falls back).
+    await saveExtensionConfigToCache({ [key]: 'not-json-{{{' });
+
+    const result = await loadCacheSettings('broken');
+
+    assert.equal(result[key], null);
+});
+
+// ---------------------------------------------------------------------------
+// Source contract — pin the real `../api.ts` against regexes so drift
+// between this clone and the real implementation is caught in review.
+// ---------------------------------------------------------------------------
+
+test('source contract: loadCacheSettings builds the cache key as `${alias}-${API_SETTINGS_KEY}`', () => {
+    assert.match(SRC, /const API_SETTINGS_KEY = 'API_SETTINGS_KEY';/);
+    assert.match(
+        SRC,
+        /export async function loadCacheSettings\(alias\) \{\s*const key = `\$\{alias\}-\$\{API_SETTINGS_KEY\}`;/
+    );
+});
+
+test('source contract: loadCacheSettings queries CACHE_CONFIG.API_SPLITTER_IS_HORIZONTAL alongside the alias key', () => {
+    assert.match(SRC, /const arr = \[key, CACHE_CONFIG\.API_SPLITTER_IS_HORIZONTAL\.key\];/);
+});
+
+test('source contract: loadCacheSettings re-parses the alias value via hasOwnProperty + safeParseJson', () => {
+    assert.match(
+        SRC,
+        /if \(configMap && configMap\.hasOwnProperty\(key\)\) \{\s*configMap\[key\] = safeParseJson\(configMap\[key\]\) \|\| null;\s*\}/
+    );
+});

--- a/packages/lwc/applications/graphql/__tests__/shortcutsModal.test.ts
+++ b/packages/lwc/applications/graphql/__tests__/shortcutsModal.test.ts
@@ -22,6 +22,14 @@ test('graphql/shortcutsModal: detectIsMac reads userAgentData.platform and legac
     assert.equal(detectIsMac({}), false);
 });
 
+test('graphql/shortcutsModal: detectIsMac falls back to global navigator when called with no argument', () => {
+    // No override supplied: the function must tolerate a missing argument and
+    // fall back to the ambient `navigator` (or an empty object when absent)
+    // without throwing.
+    assert.doesNotThrow(() => detectIsMac());
+    assert.equal(typeof detectIsMac(), 'boolean');
+});
+
 test('graphql/shortcutsModal: buildShortcutRows flags disabled rows and formats per-platform', () => {
     const macRows = buildShortcutRows(true);
     const winRows = buildShortcutRows(false);

--- a/packages/lwc/applications/jobs/__tests__/tableUtils.test.ts
+++ b/packages/lwc/applications/jobs/__tests__/tableUtils.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { statusTone, statusBadgeClass, matchesFilter } from '../tableUtils.ts';
+import { FILTER_ALL } from '../constants.ts';
+
+test('statusTone: returns success for completed/jobcomplete/waiting/queued (case-insensitive)', () => {
+    assert.equal(statusTone('Completed'), 'success');
+    assert.equal(statusTone('JobComplete'), 'success');
+    assert.equal(statusTone('WAITING'), 'success');
+    assert.equal(statusTone('queued'), 'success');
+});
+
+test('statusTone: returns warning for processing/preparing/inprogress/holding/uploadcomplete (case-insensitive)', () => {
+    assert.equal(statusTone('Processing'), 'warning');
+    assert.equal(statusTone('PREPARING'), 'warning');
+    assert.equal(statusTone('InProgress'), 'warning');
+    assert.equal(statusTone('holding'), 'warning');
+    assert.equal(statusTone('UploadComplete'), 'warning');
+});
+
+test('statusTone: returns error for failed/aborted (case-insensitive)', () => {
+    assert.equal(statusTone('Failed'), 'error');
+    assert.equal(statusTone('ABORTED'), 'error');
+});
+
+test('statusTone: returns neutral for unknown status and default empty status', () => {
+    assert.equal(statusTone('SomethingElse'), 'neutral');
+    assert.equal(statusTone(), 'neutral');
+    assert.equal(statusTone(''), 'neutral');
+});
+
+test('statusBadgeClass: composes the badge class from statusTone', () => {
+    assert.equal(statusBadgeClass('Completed'), 'jobs-table-badge jobs-table-badge_success');
+    assert.equal(statusBadgeClass('Processing'), 'jobs-table-badge jobs-table-badge_warning');
+    assert.equal(statusBadgeClass('Failed'), 'jobs-table-badge jobs-table-badge_error');
+    assert.equal(statusBadgeClass('Unknown'), 'jobs-table-badge jobs-table-badge_neutral');
+    assert.equal(statusBadgeClass(), 'jobs-table-badge jobs-table-badge_neutral');
+});
+
+test('matchesFilter: returns true when filter is entirely undefined', () => {
+    assert.equal(matchesFilter(['Account', 'Cleanup'], 'WAITING', undefined), true);
+});
+
+test('matchesFilter: returns false when status filter does not match', () => {
+    const result = matchesFilter(['Account'], 'WAITING', { search: '', status: 'FAILED' });
+    assert.equal(result, false);
+});
+
+test('matchesFilter: returns true when status filter is FILTER_ALL regardless of status', () => {
+    const result = matchesFilter(['Account'], 'WAITING', { search: '', status: FILTER_ALL });
+    assert.equal(result, true);
+});
+
+test('matchesFilter: returns true when there is no search term', () => {
+    assert.equal(matchesFilter(['Account'], 'WAITING', { status: FILTER_ALL }), true);
+    assert.equal(
+        matchesFilter(['Account'], 'WAITING', { search: '   ', status: FILTER_ALL }),
+        true
+    );
+});
+
+test('matchesFilter: matches when any value includes the search term (case-insensitive)', () => {
+    const result = matchesFilter(['Account Cleanup', 'Some Other Job'], 'WAITING', {
+        search: 'CLEANUP',
+        status: FILTER_ALL,
+    });
+    assert.equal(result, true);
+});
+
+test('matchesFilter: does not match when no value includes the search term', () => {
+    const result = matchesFilter(['Account Cleanup', 'Some Other Job'], 'WAITING', {
+        search: 'zzz-not-found',
+        status: FILTER_ALL,
+    });
+    assert.equal(result, false);
+});
+
+test('matchesFilter: stringifies non-string values before matching', () => {
+    const result = matchesFilter([42, null, undefined, 'Job'], 'WAITING', {
+        search: '42',
+        status: FILTER_ALL,
+    });
+    assert.equal(result, true);
+});
+
+test('matchesFilter: combines status mismatch short-circuit with a search term present', () => {
+    const result = matchesFilter(['Account Cleanup'], 'WAITING', {
+        search: 'cleanup',
+        status: 'FAILED',
+    });
+    assert.equal(result, false);
+});

--- a/packages/lwc/applications/metadata/slices/__tests__/metadata.test.ts
+++ b/packages/lwc/applications/metadata/slices/__tests__/metadata.test.ts
@@ -1,0 +1,693 @@
+/**
+ * Slice-behavior tests for the metadata `metadataSlice` — focused on the
+ * synchronous `reducers: {...}` block (tab lifecycle, attribute assignment,
+ * cache persistence, sync job bookkeeping).
+ *
+ * Why we don't import `../metadata.ts` directly
+ * -----------------------------------------------
+ * The slice file imports `host-api/store` (for `DESCRIBE`, `BACKGROUNDJOB`,
+ * `ERROR`, `SOBJECT`) and `core/store/storeRef` (for `getStore`).
+ * `host-api/store` transitively loads the full core store graph, including
+ * LWC components decorated with `@api`/`@wire` — invalid syntax under plain
+ * Node, since this test runner only strips TypeScript types and cannot parse
+ * LWC decorator syntax. Importing the real module throws
+ * `SyntaxError: Invalid or unexpected token`. This has been verified
+ * empirically in this repo (see `platformevent/slices/__tests__/platformEvent.test.ts`
+ * and `recordviewer/slices/__tests__/recordViewer.test.ts`, which document
+ * the same constraint).
+ *
+ * Pragmatic alternative: re-construct the same reducers the slice uses as a
+ * "faithful clone" built with `createSlice` from `@reduxjs/toolkit` (the same
+ * library the real slice uses), and pin the clone's fidelity with "source
+ * contract" tests that `readFileSync` the real `../metadata.ts` and
+ * `assert.match` against regexes pinning reducer names and key logic (the
+ * `_setAttributes` whitelist, `_addTab`/`_updateTab` helpers, etc). Any drift
+ * between the clone and the real file gets caught by those contract tests.
+ *
+ * SCOPE: this file intentionally does NOT cover `extraReducers` (the
+ * `fetchGlobalMetadata`/`fetchSpecificMetadata`/`fetchMetadataRecord`/
+ * `startMetadataBackgroundSync`/`cancelMetadataBackgroundSync` pending/
+ * fulfilled/rejected cases) or the `createAsyncThunk` bodies themselves —
+ * those call the real Salesforce Metadata/Tooling API and worker code and
+ * aren't worth faithfully cloning/mocking for this pass. The pure standalone
+ * helpers (`getMetadataSyncJobId`, `getMetadataResultSummary`,
+ * `_auraNameMapping`, `normalizeMetadataTypes`, `shouldPersistMetadata`) are
+ * covered separately in `./metadataHelpers.test.ts`.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import { createSlice } from '@reduxjs/toolkit';
+
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(path.resolve(here, '../metadata.ts'), 'utf8');
+
+// ---------------------------------------------------------------------------
+// In-memory localStorage stub — plain Node has no `localStorage` global.
+// Only used by the loadCacheSettings/saveCacheSettings behavior tests.
+// ---------------------------------------------------------------------------
+
+function makeLocalStorageStub() {
+    const backing = new Map<string, string>();
+    return {
+        getItem(key: string) {
+            return backing.has(key) ? backing.get(key)! : null;
+        },
+        setItem(key: string, value: string) {
+            backing.set(key, value);
+        },
+        removeItem(key: string) {
+            backing.delete(key);
+        },
+        clear() {
+            backing.clear();
+        },
+        _backing: backing,
+    };
+}
+
+const METADATA_SETTINGS_KEY = 'METADATA_SETTINGS_KEY';
+
+function isNotUndefinedOrNull(value: unknown): boolean {
+    return value !== undefined && value !== null;
+}
+
+// Faithful clone of loadCacheSettings/saveCacheSettings from ../metadata.ts,
+// minus the ERROR.reduxSlice.actions.addError dispatch on failure (that
+// requires host-api/store, which we cannot import here — see file header).
+function loadCacheSettingsClone(alias: string) {
+    try {
+        const configText = (globalThis as any).localStorage.getItem(
+            `${alias}-${METADATA_SETTINGS_KEY}`
+        );
+        if (configText) return JSON.parse(configText);
+    } catch (e) {
+        // Real implementation dispatches an ERROR action here; omitted in the clone.
+    }
+    return null;
+}
+
+function saveCacheSettingsClone(alias: string, state: any) {
+    try {
+        const { tabs } = state;
+        (globalThis as any).localStorage.setItem(
+            `${alias}-${METADATA_SETTINGS_KEY}`,
+            JSON.stringify({ tabs })
+        );
+    } catch (e) {
+        // Real implementation dispatches an ERROR action here; omitted in the clone.
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test rig: faithful clone of the metadata slice's synchronous reducers.
+// MUST stay in sync with `../metadata.ts`. Each reducer below mirrors the
+// real implementation; the "source contract" tests at the bottom pin the
+// real source against regexes so drift is caught.
+// ---------------------------------------------------------------------------
+
+const VALID_ATTRIBUTE_PARAMS = [
+    'param1',
+    'param2',
+    'label1',
+    'label2',
+    'sobject',
+    'developerName',
+    'flowVersionOptions',
+    'flowVersionValue',
+    'selectedRecord',
+    'files',
+    'currentTabId',
+];
+
+function setAttributesClone(state: any, payload: Record<string, unknown>) {
+    VALID_ATTRIBUTE_PARAMS.forEach(key => {
+        if (key in payload && (payload as any)[key] !== undefined) {
+            state[key] = (payload as any)[key];
+        }
+    });
+}
+
+function addTabClone(state: any, { tab }: { tab: any }) {
+    state.tabs.push(tab);
+    state.currentTabId = tab.id;
+}
+
+function updateTabClone(state: any, { tab }: { tab: any }) {
+    const tabIndex = state.tabs.findIndex((x: any) => x.id == tab.id);
+    if (tabIndex > -1) {
+        state.tabs[tabIndex] = tab;
+        state.currentTabId = tab.id;
+    }
+}
+
+const initialState = {
+    tabs: [] as any[],
+    currentTab: null as any,
+    param1: null as any,
+    param2: null as any,
+    label1: null as any,
+    label2: null as any,
+    sobject: null as any,
+    developerName: null as any,
+    flowVersionOptions: [] as any[],
+    flowVersionValue: null as any,
+    metadata: [] as any,
+    isLoading: false,
+    isLoadingRecord: false,
+    loadingMessage: '',
+    error: null as any,
+    currentTabId: null as any,
+    files: null as any,
+    selectedRecord: null as any,
+    metadata_global: null as any,
+    metadata_records: null as any,
+    currentMetadata: null as any,
+    syncJob: {
+        jobId: null as any,
+        status: 'idle',
+        phase: null as any,
+        progress: null as any,
+        metadataType: null as any,
+        message: null as any,
+        error: null as any,
+        lastRun: null as any,
+        result: null as any,
+    },
+};
+
+const testSlice = createSlice({
+    name: 'metadataTest',
+    initialState,
+    reducers: {
+        loadCacheSettings: (state, action: { payload: { alias: string } }) => {
+            const { alias } = action.payload;
+            const cachedConfig = loadCacheSettingsClone(alias);
+            if (cachedConfig) {
+                const { tabs } = cachedConfig;
+                Object.assign(state, { tabs });
+            }
+        },
+        saveCacheSettings: (state, action: { payload: { alias?: string } }) => {
+            const { alias } = action.payload;
+            if (isNotUndefinedOrNull(alias)) {
+                saveCacheSettingsClone(alias as string, state);
+            }
+        },
+        setAttributes: (state, action: { payload: Record<string, unknown> }) => {
+            setAttributesClone(state, action.payload);
+        },
+        initTabs: (state, _action: { payload: unknown }) => {
+            if (state.tabs.length > 0) {
+                state.currentTabId = state.tabs[0].id;
+            }
+        },
+        addTab: (state, action: { payload: { tab: any } }) => {
+            addTabClone(state, action.payload);
+        },
+        updateTab: (state, action: { payload: { tab: any } }) => {
+            updateTabClone(state, action.payload);
+        },
+        removeTab: (state, action: { payload: { id: any; alias?: string } }) => {
+            const { id, alias } = action.payload;
+            state.tabs = state.tabs.filter((x: any) => x.id != id);
+            if (state.tabs.length > 0 && state.currentTabId == id) {
+                const lastTab = state.tabs[state.tabs.length - 1];
+                state.currentTabId = lastTab.id;
+                setAttributesClone(state, {
+                    ...lastTab.attributes,
+                    ...lastTab.data,
+                    ...lastTab.flowVersions,
+                });
+            }
+            if (state.tabs.length == 0) {
+                state.currentTabId = null;
+                state.selectedRecord = null;
+                state.files = null;
+            }
+            if (isNotUndefinedOrNull(alias)) {
+                saveCacheSettingsClone(alias as string, state);
+            }
+        },
+        selectionTab: (state, action: { payload: { id: any } }) => {
+            const { id } = action.payload;
+            const tab = state.tabs.find((x: any) => x.id == id);
+            if (tab) {
+                state.currentTabId = id;
+                setAttributesClone(state, {
+                    ...tab.attributes,
+                    ...tab.data,
+                    ...tab.flowVersions,
+                });
+            }
+        },
+        goBack: (state, _action: { payload: unknown }) => {
+            state.metadata_records = null;
+            state.currentMetadata = null;
+            state.param1 = null;
+            state.label1 = null;
+        },
+        updateMetadata: (state, action: { payload: { metadata: any } }) => {
+            const { metadata } = action.payload;
+            state.metadata = metadata;
+        },
+        updateSyncJob: (state, action: { payload: Record<string, unknown> }) => {
+            state.syncJob = {
+                ...state.syncJob,
+                ...action.payload,
+            };
+        },
+    },
+});
+
+function makeState(overrides: Partial<typeof initialState> = {}): typeof initialState {
+    return {
+        ...initialState,
+        ...overrides,
+        syncJob: { ...initialState.syncJob, ...overrides.syncJob },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// setAttributes
+// ---------------------------------------------------------------------------
+
+test('setAttributes: whitelist-copies only known keys', () => {
+    const before = makeState();
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.setAttributes({
+            param1: '001xx',
+            label1: 'Acme',
+            notWhitelisted: 'should be dropped',
+        })
+    );
+    assert.equal(next.param1, '001xx');
+    assert.equal(next.label1, 'Acme');
+    assert.ok(!('notWhitelisted' in next));
+});
+
+test('setAttributes: drops whitelisted keys whose value is undefined', () => {
+    const before = makeState({ param1: 'keep-me' });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.setAttributes({ param1: undefined, label1: 'Acme' })
+    );
+    assert.equal(
+        next.param1,
+        'keep-me',
+        'undefined-valued whitelisted key must not overwrite state'
+    );
+    assert.equal(next.label1, 'Acme');
+});
+
+test('setAttributes: allows explicit null to overwrite (only undefined is excluded)', () => {
+    const before = makeState({ param1: 'was-set' });
+    const next = testSlice.reducer(before, testSlice.actions.setAttributes({ param1: null }));
+    assert.equal(next.param1, null);
+});
+
+test('setAttributes: is a no-op when payload has no whitelisted keys', () => {
+    const before = makeState({ param1: 'unchanged' });
+    const next = testSlice.reducer(before, testSlice.actions.setAttributes({ foo: 'bar' }));
+    assert.equal(next.param1, 'unchanged');
+});
+
+// ---------------------------------------------------------------------------
+// initTabs
+// ---------------------------------------------------------------------------
+
+test('initTabs: sets currentTabId to the first tab when tabs exist', () => {
+    const before = makeState({ tabs: [{ id: 't1' }, { id: 't2' }] });
+    const next = testSlice.reducer(before, testSlice.actions.initTabs({}));
+    assert.equal(next.currentTabId, 't1');
+});
+
+test('initTabs: no-op when there are no tabs', () => {
+    const before = makeState({ tabs: [], currentTabId: 'sentinel' });
+    const next = testSlice.reducer(before, testSlice.actions.initTabs({}));
+    assert.equal(next.currentTabId, 'sentinel');
+});
+
+// ---------------------------------------------------------------------------
+// addTab / updateTab
+// ---------------------------------------------------------------------------
+
+test('addTab: appends the tab and sets it as currentTabId', () => {
+    const before = makeState();
+    const tab = { id: 't1', name: 'ApexClass' };
+    const next = testSlice.reducer(before, testSlice.actions.addTab({ tab }));
+    assert.deepEqual(next.tabs, [tab]);
+    assert.equal(next.currentTabId, 't1');
+});
+
+test('updateTab: replaces the tab in place by id and sets it as currentTabId', () => {
+    const existing = { id: 't1', name: 'Old' };
+    const before = makeState({ tabs: [existing], currentTabId: 'other' });
+    const updated = { id: 't1', name: 'New' };
+    const next = testSlice.reducer(before, testSlice.actions.updateTab({ tab: updated }));
+    assert.deepEqual(next.tabs, [updated]);
+    assert.equal(next.currentTabId, 't1');
+});
+
+test('updateTab: no-op when the tab id is not found', () => {
+    const existing = { id: 't1', name: 'Old' };
+    const before = makeState({ tabs: [existing], currentTabId: 't1' });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.updateTab({ tab: { id: 'missing', name: 'New' } })
+    );
+    assert.deepEqual(next.tabs, [existing]);
+    assert.equal(next.currentTabId, 't1', 'currentTabId must be untouched when tab is not found');
+});
+
+// ---------------------------------------------------------------------------
+// removeTab
+// ---------------------------------------------------------------------------
+
+test('removeTab: removing the current tab reassigns currentTabId to the new last tab and restores its attributes', () => {
+    const tabA = {
+        id: 'a',
+        attributes: { param1: 'A1', label1: 'LabelA', sobject: 'ApexClass', developerName: 'A' },
+        data: { selectedRecord: { Id: 'a' }, files: null },
+        flowVersions: { flowVersionOptions: [], flowVersionValue: null },
+    };
+    const tabB = { id: 'b', attributes: {}, data: {}, flowVersions: {} };
+    const before = makeState({
+        tabs: [tabA, tabB],
+        currentTabId: 'b',
+        param1: 'B1',
+    });
+
+    const next = testSlice.reducer(before, testSlice.actions.removeTab({ id: 'b' }));
+
+    assert.deepEqual(next.tabs, [tabA]);
+    assert.equal(next.currentTabId, 'a');
+    assert.equal(next.param1, 'A1', 'restored from lastTab.attributes');
+    assert.equal(next.label1, 'LabelA');
+    assert.deepEqual(next.selectedRecord, { Id: 'a' }, 'restored from lastTab.data');
+});
+
+test('removeTab: removing a non-current tab leaves currentTabId and attributes untouched', () => {
+    const tabA = { id: 'a' };
+    const tabB = { id: 'b' };
+    const before = makeState({ tabs: [tabA, tabB], currentTabId: 'b', param1: 'unchanged' });
+
+    const next = testSlice.reducer(before, testSlice.actions.removeTab({ id: 'a' }));
+
+    assert.deepEqual(next.tabs, [tabB]);
+    assert.equal(next.currentTabId, 'b');
+    assert.equal(next.param1, 'unchanged');
+});
+
+test('removeTab: clears currentTabId, selectedRecord, and files when tabs becomes empty', () => {
+    const tabA = { id: 'a' };
+    const before = makeState({
+        tabs: [tabA],
+        currentTabId: 'a',
+        selectedRecord: { Id: 'x' },
+        files: [{ name: 'Foo.cls' }],
+    });
+
+    const next = testSlice.reducer(before, testSlice.actions.removeTab({ id: 'a' }));
+
+    assert.deepEqual(next.tabs, []);
+    assert.equal(next.currentTabId, null);
+    assert.equal(next.selectedRecord, null);
+    assert.equal(next.files, null);
+});
+
+test('removeTab: persists to localStorage when an alias is provided', () => {
+    const originalLocalStorage = (globalThis as any).localStorage;
+    (globalThis as any).localStorage = makeLocalStorageStub();
+    try {
+        const tabA = { id: 'a' };
+        const tabB = { id: 'b' };
+        const before = makeState({ tabs: [tabA, tabB], currentTabId: 'b' });
+
+        testSlice.reducer(before, testSlice.actions.removeTab({ id: 'b', alias: 'myOrg' }));
+
+        const raw = (globalThis as any).localStorage.getItem(`myOrg-${METADATA_SETTINGS_KEY}`);
+        assert.ok(raw, 'removeTab with an alias must persist settings');
+        assert.deepEqual(JSON.parse(raw), { tabs: [tabA] });
+    } finally {
+        (globalThis as any).localStorage = originalLocalStorage;
+    }
+});
+
+// ---------------------------------------------------------------------------
+// selectionTab
+// ---------------------------------------------------------------------------
+
+test('selectionTab: switches currentTabId and restores attributes/data/flowVersions from the tab', () => {
+    const tabA = {
+        id: 'a',
+        attributes: { param1: 'A1', sobject: 'ApexClass' },
+        data: { selectedRecord: { Id: 'a' } },
+        flowVersions: {
+            flowVersionOptions: [{ value: 'v1', label: 'V1' }],
+            flowVersionValue: 'v1',
+        },
+    };
+    const before = makeState({ tabs: [tabA], currentTabId: null, param1: 'stale' });
+
+    const next = testSlice.reducer(before, testSlice.actions.selectionTab({ id: 'a' }));
+
+    assert.equal(next.currentTabId, 'a');
+    assert.equal(next.param1, 'A1');
+    assert.equal(next.sobject, 'ApexClass');
+    assert.deepEqual(next.selectedRecord, { Id: 'a' });
+    assert.equal(next.flowVersionValue, 'v1');
+});
+
+test('selectionTab: no-op when no tab matches the id', () => {
+    const before = makeState({ tabs: [{ id: 'a' }], currentTabId: 'a', param1: 'unchanged' });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.selectionTab({ id: 'does-not-exist' })
+    );
+    assert.equal(next.currentTabId, 'a');
+    assert.equal(next.param1, 'unchanged');
+});
+
+// ---------------------------------------------------------------------------
+// goBack
+// ---------------------------------------------------------------------------
+
+test('goBack: resets metadata_records, currentMetadata, param1, and label1', () => {
+    const before = makeState({
+        metadata_records: { records: [{ name: 'Foo' }], label: 'ApexClass' },
+        currentMetadata: 'ApexClass',
+        param1: '001xx',
+        label1: 'Foo',
+        // Fields NOT reset by goBack must survive untouched.
+        sobject: 'ApexClass',
+        metadata_global: { records: [], label: 'Metadata' },
+    });
+
+    const next = testSlice.reducer(before, testSlice.actions.goBack({}));
+
+    assert.equal(next.metadata_records, null);
+    assert.equal(next.currentMetadata, null);
+    assert.equal(next.param1, null);
+    assert.equal(next.label1, null);
+    assert.equal(next.sobject, 'ApexClass', 'goBack must not touch sobject');
+    assert.deepEqual(next.metadata_global, { records: [], label: 'Metadata' });
+});
+
+// ---------------------------------------------------------------------------
+// updateMetadata
+// ---------------------------------------------------------------------------
+
+test('updateMetadata: overwrites state.metadata with the payload', () => {
+    const before = makeState({ metadata: [] });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.updateMetadata({ metadata: { records: [{ name: 'Foo' }], label: 'X' } })
+    );
+    assert.deepEqual(next.metadata, { records: [{ name: 'Foo' }], label: 'X' });
+});
+
+// ---------------------------------------------------------------------------
+// updateSyncJob
+// ---------------------------------------------------------------------------
+
+test('updateSyncJob: shallow-merges the payload into state.syncJob, preserving untouched fields', () => {
+    const before = makeState({
+        syncJob: {
+            jobId: 'job-1',
+            status: 'running',
+            phase: 'init',
+            progress: { completed: 0, total: 10, percent: 0 },
+            metadataType: null,
+            message: 'starting',
+            error: null,
+            lastRun: 111,
+            result: null,
+        },
+    });
+
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.updateSyncJob({
+            status: 'running',
+            phase: 'fetching',
+            message: 'Fetching Flow',
+        })
+    );
+
+    assert.equal(next.syncJob.jobId, 'job-1', 'jobId must be preserved (not in payload)');
+    assert.equal(next.syncJob.phase, 'fetching');
+    assert.equal(next.syncJob.message, 'Fetching Flow');
+    assert.equal(next.syncJob.lastRun, 111, 'lastRun must be preserved');
+});
+
+// ---------------------------------------------------------------------------
+// loadCacheSettings / saveCacheSettings — exercised via a stubbed localStorage
+// ---------------------------------------------------------------------------
+
+test('saveCacheSettings then loadCacheSettings: persists and restores only tabs', () => {
+    const originalLocalStorage = (globalThis as any).localStorage;
+    (globalThis as any).localStorage = makeLocalStorageStub();
+    try {
+        const tabs = [{ id: 't1', name: 'ApexClass' }];
+        const before = makeState({ tabs, currentTabId: 't1' });
+
+        testSlice.reducer(before, testSlice.actions.saveCacheSettings({ alias: 'myOrg' }));
+
+        const raw = (globalThis as any).localStorage.getItem(`myOrg-${METADATA_SETTINGS_KEY}`);
+        assert.ok(raw, 'expected settings to be persisted to localStorage');
+        const parsed = JSON.parse(raw);
+        assert.deepEqual(parsed, { tabs });
+        assert.ok(!('currentTabId' in parsed), 'currentTabId must NOT be persisted');
+
+        const fresh = makeState({ tabs: [], currentTabId: 'sentinel' });
+        const afterLoad = testSlice.reducer(
+            fresh,
+            testSlice.actions.loadCacheSettings({ alias: 'myOrg' })
+        );
+
+        assert.deepEqual(afterLoad.tabs, tabs);
+        assert.equal(
+            afterLoad.currentTabId,
+            'sentinel',
+            'loadCacheSettings must not touch currentTabId (not part of the cached shape)'
+        );
+    } finally {
+        (globalThis as any).localStorage = originalLocalStorage;
+    }
+});
+
+test('loadCacheSettings: no-op when nothing cached for the alias', () => {
+    const originalLocalStorage = (globalThis as any).localStorage;
+    (globalThis as any).localStorage = makeLocalStorageStub();
+    try {
+        const before = makeState({ tabs: [{ id: 'keep-me' }] });
+        const next = testSlice.reducer(
+            before,
+            testSlice.actions.loadCacheSettings({ alias: 'unseen-alias' })
+        );
+        assert.deepEqual(
+            next.tabs,
+            [{ id: 'keep-me' }],
+            'state must be untouched when cache is empty'
+        );
+    } finally {
+        (globalThis as any).localStorage = originalLocalStorage;
+    }
+});
+
+test('saveCacheSettings: no-op (does not throw) when alias is undefined/null', () => {
+    const originalLocalStorage = (globalThis as any).localStorage;
+    (globalThis as any).localStorage = makeLocalStorageStub();
+    try {
+        const before = makeState({ tabs: [{ id: 't1' }] });
+        assert.doesNotThrow(() => {
+            testSlice.reducer(before, testSlice.actions.saveCacheSettings({}));
+        });
+        assert.equal(
+            (globalThis as any).localStorage.getItem(`undefined-${METADATA_SETTINGS_KEY}`),
+            null
+        );
+    } finally {
+        (globalThis as any).localStorage = originalLocalStorage;
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Source contract tests — pin the real `../metadata.ts` against regexes so
+// drift between this clone and the real implementation is caught.
+// ---------------------------------------------------------------------------
+
+test('source contract: _setAttributes whitelist matches the documented set of valid params', () => {
+    assert.match(
+        SRC,
+        /const validParams = \[\s*\n\s*'param1',\s*\n\s*'param2',\s*\n\s*'label1',\s*\n\s*'label2',\s*\n\s*'sobject',\s*\n\s*'developerName',\s*\n\s*'flowVersionOptions',\s*\n\s*'flowVersionValue',\s*\n\s*'selectedRecord',\s*\n\s*'files',\s*\n\s*'currentTabId',\s*\n\s*\];/
+    );
+    assert.match(SRC, /if \(key in payload && payload\[key\] !== undefined\)/);
+});
+
+test('source contract: _addTab pushes the tab and sets currentTabId', () => {
+    assert.match(
+        SRC,
+        /const _addTab = \(state, \{ tab \}\) => \{\s*\n\s*state\.tabs\.push\(tab\);[\s\S]+?state\.currentTabId = tab\.id;/
+    );
+});
+
+test('source contract: _updateTab replaces by id via findIndex, guarded by `tabIndex > -1`', () => {
+    assert.match(
+        SRC,
+        /const _updateTab = \(state, \{ tab \}\) => \{\s*\n\s*const tabIndex = state\.tabs\.findIndex\(x => x\.id == tab\.id\);[\s\S]+?if \(tabIndex > -1\) \{/
+    );
+});
+
+test('source contract: removeTab restores lastTab.attributes/data/flowVersions when the current tab is removed', () => {
+    assert.match(
+        SRC,
+        /removeTab: \(state, action\) => \{[\s\S]+?state\.tabs = state\.tabs\.filter\(x => x\.id != id\);[\s\S]+?if \(state\.tabs\.length > 0 && state\.currentTabId == id\) \{[\s\S]+?_setAttributes\(state, \{\s*\n\s*\.\.\.lastTab\.attributes,\s*\n\s*\.\.\.lastTab\.data,\s*\n\s*\.\.\.lastTab\.flowVersions,/
+    );
+    assert.match(
+        SRC,
+        /if \(state\.tabs\.length == 0\) \{\s*\n\s*state\.currentTabId = null;\s*\n\s*state\.selectedRecord = null;\s*\n\s*state\.files = null;/
+    );
+});
+
+test('source contract: selectionTab finds the tab with `==` and restores attributes/data/flowVersions', () => {
+    assert.match(
+        SRC,
+        /selectionTab: \(state, action\) => \{[\s\S]+?const tab = state\.tabs\.find\(x => x\.id == id\);[\s\S]+?if \(tab\) \{\s*\n\s*state\.currentTabId = id;\s*\n\s*_setAttributes\(state, \{\s*\n\s*\.\.\.tab\.attributes,\s*\n\s*\.\.\.tab\.data,\s*\n\s*\.\.\.tab\.flowVersions,/
+    );
+});
+
+test('source contract: goBack resets exactly metadata_records, currentMetadata, param1, label1', () => {
+    assert.match(
+        SRC,
+        /goBack: \(state, action\) => \{[\s\S]*?state\.metadata_records = null;\s*\n\s*state\.currentMetadata = null;\s*\n\s*state\.param1 = null;\s*\n\s*state\.label1 = null;\s*\n\s*\},/
+    );
+});
+
+test('source contract: updateSyncJob shallow-merges action.payload over state.syncJob', () => {
+    assert.match(
+        SRC,
+        /updateSyncJob: \(state, action\) => \{\s*\n\s*state\.syncJob = \{\s*\n\s*\.\.\.state\.syncJob,\s*\n\s*\.\.\.action\.payload,\s*\n\s*\};/
+    );
+});
+
+test('source contract: saveCacheSettings/loadCacheSettings key on `${alias}-${METADATA_SETTINGS_KEY}` and persist only `tabs`', () => {
+    assert.match(SRC, /const METADATA_SETTINGS_KEY = 'METADATA_SETTINGS_KEY';/);
+    assert.match(SRC, /localStorage\.getItem\(`\$\{alias\}-\$\{METADATA_SETTINGS_KEY\}`\)/);
+    assert.match(
+        SRC,
+        /const \{ tabs \} = state;[\s\S]+?localStorage\.setItem\(\s*\n\s*`\$\{alias\}-\$\{METADATA_SETTINGS_KEY\}`,\s*\n\s*JSON\.stringify\(\{\s*\n\s*tabs,\s*\n\s*\}\)/
+    );
+});
+
+test('source contract: initTabs sets currentTabId to the first tab when tabs is non-empty', () => {
+    assert.match(
+        SRC,
+        /initTabs: \(state, action\) => \{[\s\S]+?if \(state\.tabs\.length > 0\) \{\s*\n\s*state\.currentTabId = state\.tabs\[0\]\.id;/
+    );
+});

--- a/packages/lwc/applications/metadata/slices/__tests__/metadataHelpers.test.ts
+++ b/packages/lwc/applications/metadata/slices/__tests__/metadataHelpers.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Behavior tests for the pure, standalone helper functions defined at module
+ * scope in `../metadata.ts` (outside of `createSlice`/`createAsyncThunk`).
+ *
+ * Why we don't import `../metadata.ts` directly
+ * -----------------------------------------------
+ * The slice file imports `host-api/store` (for `DESCRIBE`, `BACKGROUNDJOB`,
+ * `ERROR`, `SOBJECT`) and `core/store/storeRef` (for `getStore`).
+ * `host-api/store` transitively loads the full core store graph, including
+ * LWC components decorated with `@api`/`@wire` — invalid syntax under plain
+ * Node, since this test runner only strips TypeScript types and cannot parse
+ * LWC decorator syntax. Importing the real module throws
+ * `SyntaxError: Invalid or unexpected token`. This has been verified
+ * empirically in this repo (see `platformevent/slices/__tests__/platformEvent.test.ts`
+ * and `agentforce/slices/__tests__/agents.test.ts`, which document the same
+ * constraint).
+ *
+ * Pragmatic alternative: re-implement each helper here as a "faithful clone"
+ * — copied verbatim from the real source — and pin fidelity with "source
+ * contract" tests that `readFileSync` the real `../metadata.ts` and
+ * `assert.match` against regexes covering the exact logic. Any drift between
+ * the clone and the real file is caught by those contract tests.
+ *
+ * `shared/cacheManager` (used by `shouldPersistMetadataClone`'s tests) is
+ * NOT LWC-coupled and imports cleanly under plain Node, so we import the
+ * real `CACHE_CONFIG` from there rather than hardcoding key strings.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import { CACHE_CONFIG } from 'shared/cacheManager';
+
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(path.resolve(here, '../metadata.ts'), 'utf8');
+
+// ---------------------------------------------------------------------------
+// Clones — copied verbatim from ../metadata.ts
+// ---------------------------------------------------------------------------
+
+const getMetadataSyncJobIdClone = (alias?: string | null, startedAt: number = Date.now()) =>
+    `metadata-sync-${alias || 'unknown'}-${startedAt}`;
+
+const getMetadataResultSummaryClone = (result: any) => {
+    if (!result || typeof result !== 'object') {
+        return null;
+    }
+    if (Number.isFinite(result.writtenCount)) {
+        return `Wrote ${result.writtenCount} entries`;
+    }
+    if (Number.isFinite(result.totalEntries)) {
+        return `Processed ${result.totalEntries} entries`;
+    }
+    return null;
+};
+
+const auraNameMappingClone = (name: string, type: string) => {
+    switch (type) {
+        case 'COMPONENT':
+            return `${name}.cmp`;
+        case 'CONTROLLER':
+            return `${name}Controller.js`;
+        case 'HELPER':
+            return `${name}Helper.js`;
+        case 'RENDERER':
+            return `${name}Renderer.js`;
+        case 'DOCUMENTATION':
+            return `${name}.auradoc`;
+        case 'DESIGN':
+            return `${name}.design`;
+        case 'SVG':
+            return `${name}.svg`;
+        default:
+            return name;
+    }
+};
+
+const normalizeMetadataTypesClone = (value: any): any[] => {
+    if (Array.isArray(value)) {
+        return value.filter(Boolean);
+    }
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) return [];
+        try {
+            const parsed = JSON.parse(trimmed);
+            if (Array.isArray(parsed)) {
+                return parsed.filter(Boolean);
+            }
+        } catch (_) {
+            // Ignore JSON parse errors and fallback to comma-separated parsing.
+        }
+        return trimmed
+            .split(',')
+            .map(item => item.trim())
+            .filter(Boolean);
+    }
+    if (value && typeof value === 'object') {
+        return Object.values(value).filter(Boolean);
+    }
+    return [];
+};
+
+const shouldPersistMetadataClone = (config: any, alias: any, metadataType: string) => {
+    if (!alias) return false;
+    if (!config?.[CACHE_CONFIG.METADATA_STORAGE_ENABLED.key]) return false;
+    const selectedTypes = Array.isArray(config?.[CACHE_CONFIG.METADATA_STORAGE_TYPES.key])
+        ? config[CACHE_CONFIG.METADATA_STORAGE_TYPES.key]
+        : [];
+    return selectedTypes.includes(metadataType);
+};
+
+// ---------------------------------------------------------------------------
+// getMetadataSyncJobId
+// ---------------------------------------------------------------------------
+
+test('getMetadataSyncJobId: builds a deterministic id from alias + startedAt', () => {
+    assert.equal(getMetadataSyncJobIdClone('myOrg', 12345), 'metadata-sync-myOrg-12345');
+});
+
+test('getMetadataSyncJobId: falls back to "unknown" when alias is falsy', () => {
+    assert.equal(getMetadataSyncJobIdClone(null, 1), 'metadata-sync-unknown-1');
+    assert.equal(getMetadataSyncJobIdClone(undefined, 1), 'metadata-sync-unknown-1');
+    assert.equal(getMetadataSyncJobIdClone('', 1), 'metadata-sync-unknown-1');
+});
+
+test('getMetadataSyncJobId: defaults startedAt to Date.now() when omitted', () => {
+    const id = getMetadataSyncJobIdClone('myOrg');
+    assert.match(id, /^metadata-sync-myOrg-\d+$/);
+});
+
+// ---------------------------------------------------------------------------
+// getMetadataResultSummary
+// ---------------------------------------------------------------------------
+
+test('getMetadataResultSummary: returns null for non-object input', () => {
+    assert.equal(getMetadataResultSummaryClone(null), null);
+    assert.equal(getMetadataResultSummaryClone(undefined), null);
+    assert.equal(getMetadataResultSummaryClone('a string'), null);
+    assert.equal(getMetadataResultSummaryClone(42), null);
+});
+
+test('getMetadataResultSummary: prefers writtenCount when finite', () => {
+    assert.equal(getMetadataResultSummaryClone({ writtenCount: 7 }), 'Wrote 7 entries');
+});
+
+test('getMetadataResultSummary: falls back to totalEntries when writtenCount is absent/non-finite', () => {
+    assert.equal(getMetadataResultSummaryClone({ totalEntries: 42 }), 'Processed 42 entries');
+    assert.equal(
+        getMetadataResultSummaryClone({ writtenCount: NaN, totalEntries: 3 }),
+        'Processed 3 entries'
+    );
+});
+
+test('getMetadataResultSummary: writtenCount takes precedence over totalEntries when both are present', () => {
+    assert.equal(
+        getMetadataResultSummaryClone({ writtenCount: 5, totalEntries: 100 }),
+        'Wrote 5 entries'
+    );
+});
+
+test('getMetadataResultSummary: returns null when neither field is a finite number', () => {
+    assert.equal(getMetadataResultSummaryClone({}), null);
+    assert.equal(getMetadataResultSummaryClone({ writtenCount: 'nope', totalEntries: null }), null);
+});
+
+test('getMetadataResultSummary: writtenCount of 0 is finite and takes the "Wrote" branch', () => {
+    assert.equal(getMetadataResultSummaryClone({ writtenCount: 0 }), 'Wrote 0 entries');
+});
+
+// ---------------------------------------------------------------------------
+// _auraNameMapping
+// ---------------------------------------------------------------------------
+
+test('_auraNameMapping: maps each known DefType to its file suffix', () => {
+    assert.equal(auraNameMappingClone('Foo', 'COMPONENT'), 'Foo.cmp');
+    assert.equal(auraNameMappingClone('Foo', 'CONTROLLER'), 'FooController.js');
+    assert.equal(auraNameMappingClone('Foo', 'HELPER'), 'FooHelper.js');
+    assert.equal(auraNameMappingClone('Foo', 'RENDERER'), 'FooRenderer.js');
+    assert.equal(auraNameMappingClone('Foo', 'DOCUMENTATION'), 'Foo.auradoc');
+    assert.equal(auraNameMappingClone('Foo', 'DESIGN'), 'Foo.design');
+    assert.equal(auraNameMappingClone('Foo', 'SVG'), 'Foo.svg');
+});
+
+test('_auraNameMapping: returns the bare name for an unrecognized type', () => {
+    assert.equal(auraNameMappingClone('Foo', 'STYLE'), 'Foo');
+    assert.equal(auraNameMappingClone('Foo', 'UNKNOWN_TYPE'), 'Foo');
+});
+
+// ---------------------------------------------------------------------------
+// normalizeMetadataTypes
+// ---------------------------------------------------------------------------
+
+test('normalizeMetadataTypes: passes through arrays, dropping falsy entries', () => {
+    assert.deepEqual(normalizeMetadataTypesClone(['ApexClass', '', null, 'Flow', 0]), [
+        'ApexClass',
+        'Flow',
+    ]);
+});
+
+test('normalizeMetadataTypes: parses a JSON array string', () => {
+    assert.deepEqual(normalizeMetadataTypesClone('["ApexClass","Flow"]'), ['ApexClass', 'Flow']);
+});
+
+test('normalizeMetadataTypes: falls back to comma-separated parsing when JSON.parse yields a non-array', () => {
+    // '"ApexClass"' parses as valid JSON (a string), not an array, so the
+    // comma-split fallback path is taken, producing a single-element array.
+    assert.deepEqual(normalizeMetadataTypesClone('"ApexClass"'), ['"ApexClass"']);
+});
+
+test('normalizeMetadataTypes: falls back to comma-separated parsing on invalid JSON', () => {
+    assert.deepEqual(normalizeMetadataTypesClone('ApexClass, Flow ,  CustomObject'), [
+        'ApexClass',
+        'Flow',
+        'CustomObject',
+    ]);
+});
+
+test('normalizeMetadataTypes: returns [] for an empty/whitespace-only string', () => {
+    assert.deepEqual(normalizeMetadataTypesClone(''), []);
+    assert.deepEqual(normalizeMetadataTypesClone('   '), []);
+});
+
+test('normalizeMetadataTypes: extracts values from a plain object', () => {
+    assert.deepEqual(normalizeMetadataTypesClone({ a: 'ApexClass', b: null, c: 'Flow' }), [
+        'ApexClass',
+        'Flow',
+    ]);
+});
+
+test('normalizeMetadataTypes: returns [] for null, undefined, numbers, booleans', () => {
+    assert.deepEqual(normalizeMetadataTypesClone(null), []);
+    assert.deepEqual(normalizeMetadataTypesClone(undefined), []);
+    assert.deepEqual(normalizeMetadataTypesClone(42), []);
+    assert.deepEqual(normalizeMetadataTypesClone(true), []);
+});
+
+// ---------------------------------------------------------------------------
+// shouldPersistMetadata
+// ---------------------------------------------------------------------------
+
+test('shouldPersistMetadata: false when alias is falsy', () => {
+    const config = {
+        [CACHE_CONFIG.METADATA_STORAGE_ENABLED.key]: true,
+        [CACHE_CONFIG.METADATA_STORAGE_TYPES.key]: ['ApexClass'],
+    };
+    assert.equal(shouldPersistMetadataClone(config, null, 'ApexClass'), false);
+    assert.equal(shouldPersistMetadataClone(config, '', 'ApexClass'), false);
+});
+
+test('shouldPersistMetadata: false when storage is disabled in config', () => {
+    const config = {
+        [CACHE_CONFIG.METADATA_STORAGE_ENABLED.key]: false,
+        [CACHE_CONFIG.METADATA_STORAGE_TYPES.key]: ['ApexClass'],
+    };
+    assert.equal(shouldPersistMetadataClone(config, 'myOrg', 'ApexClass'), false);
+});
+
+test('shouldPersistMetadata: false when config is null/undefined', () => {
+    assert.equal(shouldPersistMetadataClone(null, 'myOrg', 'ApexClass'), false);
+    assert.equal(shouldPersistMetadataClone(undefined, 'myOrg', 'ApexClass'), false);
+});
+
+test('shouldPersistMetadata: false when METADATA_STORAGE_TYPES is not an array', () => {
+    const config = {
+        [CACHE_CONFIG.METADATA_STORAGE_ENABLED.key]: true,
+        [CACHE_CONFIG.METADATA_STORAGE_TYPES.key]: 'ApexClass',
+    };
+    assert.equal(shouldPersistMetadataClone(config, 'myOrg', 'ApexClass'), false);
+});
+
+test('shouldPersistMetadata: true only when alias, enabled flag, and matching type are all present', () => {
+    const config = {
+        [CACHE_CONFIG.METADATA_STORAGE_ENABLED.key]: true,
+        [CACHE_CONFIG.METADATA_STORAGE_TYPES.key]: ['ApexClass', 'Flow'],
+    };
+    assert.equal(shouldPersistMetadataClone(config, 'myOrg', 'ApexClass'), true);
+    assert.equal(shouldPersistMetadataClone(config, 'myOrg', 'Flow'), true);
+    assert.equal(
+        shouldPersistMetadataClone(config, 'myOrg', 'CustomObject'),
+        false,
+        'type not in selected list must be rejected'
+    );
+});
+
+// ---------------------------------------------------------------------------
+// Source contract tests — pin the real `../metadata.ts` against regexes so
+// drift between these clones and the real implementation is caught.
+// ---------------------------------------------------------------------------
+
+test('source contract: getMetadataSyncJobId builds `metadata-sync-${alias || "unknown"}-${startedAt}`', () => {
+    assert.match(
+        SRC,
+        /getMetadataSyncJobId = \(alias, startedAt = Date\.now\(\)\) =>\s*\n\s*`metadata-sync-\$\{alias \|\| 'unknown'\}-\$\{startedAt\}`/
+    );
+});
+
+test('source contract: getMetadataResultSummary checks writtenCount before totalEntries via Number.isFinite', () => {
+    assert.match(
+        SRC,
+        /getMetadataResultSummary = result => \{[\s\S]+?if \(Number\.isFinite\(result\.writtenCount\)\) \{[\s\S]+?Wrote \$\{result\.writtenCount\} entries[\s\S]+?if \(Number\.isFinite\(result\.totalEntries\)\) \{[\s\S]+?Processed \$\{result\.totalEntries\} entries/
+    );
+});
+
+test('source contract: _auraNameMapping switches on all seven known AuraDefinition DefTypes', () => {
+    for (const [type, suffix] of [
+        ['COMPONENT', '.cmp'],
+        ['CONTROLLER', 'Controller.js'],
+        ['HELPER', 'Helper.js'],
+        ['RENDERER', 'Renderer.js'],
+        ['DOCUMENTATION', '.auradoc'],
+        ['DESIGN', '.design'],
+        ['SVG', '.svg'],
+    ]) {
+        assert.match(
+            SRC,
+            new RegExp(
+                `case '${type}':\\s*\\n\\s*return \\\`\\$\\{name\\}${suffix.replace('.', '\\.')}\\\`;`
+            )
+        );
+    }
+});
+
+test('source contract: normalizeMetadataTypes tries JSON.parse before comma-splitting a string', () => {
+    assert.match(
+        SRC,
+        /if \(typeof value === 'string'\) \{[\s\S]+?try \{[\s\S]+?const parsed = JSON\.parse\(trimmed\);[\s\S]+?catch[\s\S]+?trimmed\s*\n\s*\.split\(','\)/
+    );
+});
+
+test('source contract: shouldPersistMetadata gates on alias, METADATA_STORAGE_ENABLED, then selectedTypes.includes(metadataType)', () => {
+    assert.match(
+        SRC,
+        /shouldPersistMetadata = \(config, alias, metadataType\) => \{\s*\n\s*if \(!alias\) return false;\s*\n\s*if \(!config\?\.\[CACHE_CONFIG\.METADATA_STORAGE_ENABLED\.key\]\) return false;/
+    );
+    assert.match(SRC, /return selectedTypes\.includes\(metadataType\);/);
+});

--- a/packages/lwc/applications/object/__tests__/sessionCallOptions.test.ts
+++ b/packages/lwc/applications/object/__tests__/sessionCallOptions.test.ts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { cacheManager, CACHE_SESSION_CONFIG } from 'shared/cacheManager';
+
+import { ensureSessionClientCallOption } from '../sessionCallOptions.ts';
+
+// cacheManager is a real singleton (no DI point in the function under test),
+// so we monkey-patch loadOrgData directly for the duration of each test and
+// restore it afterward.
+const withLoadOrgData = async (impl: (...args: unknown[]) => unknown, run: () => Promise<void>) => {
+    const original = cacheManager.loadOrgData;
+    let calls = 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (cacheManager as any).loadOrgData = async (...args: unknown[]) => {
+        calls++;
+        return impl(...args);
+    };
+    try {
+        await run();
+    } finally {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (cacheManager as any).loadOrgData = original;
+    }
+    return calls;
+};
+
+test('no-op when connector is null/undefined', async () => {
+    const calls = await withLoadOrgData(
+        () => {
+            throw new Error('should not be called');
+        },
+        async () => {
+            await ensureSessionClientCallOption(null);
+            await ensureSessionClientCallOption(undefined);
+        }
+    );
+    assert.equal(calls, 0);
+});
+
+test('no-op when connector.conn is missing', async () => {
+    const connector = { configuration: { alias: 'myOrg' } };
+    const calls = await withLoadOrgData(
+        () => {
+            throw new Error('should not be called');
+        },
+        async () => {
+            await ensureSessionClientCallOption(connector);
+        }
+    );
+    assert.equal(calls, 0);
+});
+
+test('no-op when configuration.alias is missing or blank', async () => {
+    const connectorNoAlias = { conn: { _callOptions: {} }, configuration: {} };
+    const connectorBlankAlias = { conn: { _callOptions: {} }, configuration: { alias: '   ' } };
+    const calls = await withLoadOrgData(
+        () => {
+            throw new Error('should not be called');
+        },
+        async () => {
+            await ensureSessionClientCallOption(connectorNoAlias);
+            await ensureSessionClientCallOption(connectorBlankAlias);
+        }
+    );
+    assert.equal(calls, 0);
+});
+
+test('no-op when connection already has a non-empty client id', async () => {
+    const connection = { _callOptions: { client: 'existing-client', other: 'keep-me' } };
+    const connector = { conn: connection, configuration: { alias: 'myOrg' } };
+    const calls = await withLoadOrgData(
+        () => {
+            throw new Error('should not be called');
+        },
+        async () => {
+            await ensureSessionClientCallOption(connector);
+        }
+    );
+    assert.equal(calls, 0);
+    assert.deepEqual(connection._callOptions, { client: 'existing-client', other: 'keep-me' });
+});
+
+test('happy path: merges client id from cacheManager, preserving existing _callOptions keys', async () => {
+    const connection: { _callOptions?: Record<string, unknown> } = {
+        _callOptions: { other: 'keep-me' },
+    };
+    const connector = { conn: connection, configuration: { alias: 'myOrg' } };
+
+    let receivedArgs: unknown[] = [];
+    const calls = await withLoadOrgData(
+        (...args: unknown[]) => {
+            receivedArgs = args;
+            return { [CACHE_SESSION_CONFIG.CLIENT_ID.key]: 'session-client-123' };
+        },
+        async () => {
+            await ensureSessionClientCallOption(connector);
+        }
+    );
+
+    assert.equal(calls, 1);
+    assert.deepEqual(receivedArgs, ['myOrg', 'session_settings']);
+    assert.deepEqual(connection._callOptions, {
+        other: 'keep-me',
+        client: 'session-client-123',
+    });
+});
+
+test('happy path: works even when connection has no pre-existing _callOptions', async () => {
+    const connection: { _callOptions?: Record<string, unknown> } = {};
+    const connector = { conn: connection, configuration: { alias: 'myOrg' } };
+
+    await withLoadOrgData(
+        () => ({ [CACHE_SESSION_CONFIG.CLIENT_ID.key]: 'session-client-456' }),
+        async () => {
+            await ensureSessionClientCallOption(connector);
+        }
+    );
+
+    assert.deepEqual(connection._callOptions, { client: 'session-client-456' });
+});
+
+test('no mutation when cacheManager returns no session settings', async () => {
+    const connection: { _callOptions?: Record<string, unknown> } = {
+        _callOptions: { other: 'keep-me' },
+    };
+    const connector = { conn: connection, configuration: { alias: 'myOrg' } };
+
+    await withLoadOrgData(
+        () => undefined,
+        async () => {
+            await ensureSessionClientCallOption(connector);
+        }
+    );
+
+    assert.deepEqual(connection._callOptions, { other: 'keep-me' });
+});
+
+test('no mutation when cacheManager returns an empty/blank client id', async () => {
+    const connection: { _callOptions?: Record<string, unknown> } = {
+        _callOptions: { other: 'keep-me' },
+    };
+    const connector = { conn: connection, configuration: { alias: 'myOrg' } };
+
+    await withLoadOrgData(
+        () => ({ [CACHE_SESSION_CONFIG.CLIENT_ID.key]: '   ' }),
+        async () => {
+            await ensureSessionClientCallOption(connector);
+        }
+    );
+
+    assert.deepEqual(connection._callOptions, { other: 'keep-me' });
+});
+
+test('no mutation when cacheManager returns a non-string client id', async () => {
+    const connection: { _callOptions?: Record<string, unknown> } = {
+        _callOptions: { other: 'keep-me' },
+    };
+    const connector = { conn: connection, configuration: { alias: 'myOrg' } };
+
+    await withLoadOrgData(
+        () => ({ [CACHE_SESSION_CONFIG.CLIENT_ID.key]: 12345 }),
+        async () => {
+            await ensureSessionClientCallOption(connector);
+        }
+    );
+
+    assert.deepEqual(connection._callOptions, { other: 'keep-me' });
+});

--- a/packages/lwc/applications/object/slices/__tests__/sobjectExplorer.test.ts
+++ b/packages/lwc/applications/object/slices/__tests__/sobjectExplorer.test.ts
@@ -1,0 +1,530 @@
+/**
+ * Slice-behavior tests for the object app's sobjectExplorer slice.
+ *
+ * Why we don't import `../sobjectExplorer.ts` directly
+ * ------------------------------------------------------
+ * The slice file imports `host-api/store` (for `ERROR.reduxSlice.actions.addError`),
+ * which transitively loads the full core store graph including LWC components
+ * decorated with `@api`/`@wire` (invalid syntax under plain Node — the test
+ * runner can only strip TypeScript types, not parse LWC decorators). Any
+ * module that imports `host-api/store`, directly or transitively, throws
+ * `SyntaxError: Invalid or unexpected token` when loaded by this harness.
+ * Stubbing `host-api/store` via an ESM resolver hook from the test file is
+ * unreliable because `module.register()` and dynamic-import scheduling race
+ * with the existing tsconfig-paths resolver.
+ *
+ * Pragmatic alternative: re-construct the slice's reducers (including the
+ * plain `formatTab` helper) locally with `createSlice`, and pin the policy
+ * contract here. Any drift between this clone and `../sobjectExplorer.ts`
+ * will be caught by the "source contract" tests below, which `readFileSync`
+ * the real source and `assert.match` against the exact lines that encode
+ * the policy. This mirrors the pattern established in
+ * `packages/lwc/applications/agentforce/slices/__tests__/agents.test.ts`.
+ */
+
+import assert from 'node:assert/strict';
+import { test, beforeEach, afterEach } from 'node:test';
+import { createSlice } from '@reduxjs/toolkit';
+
+// ---------------------------------------------------------------------------
+// In-memory localStorage stub. Plain Node has no `localStorage` global; the
+// real slice reads/writes it directly (via the module-scoped `localStorage`
+// identifier), so we install a minimal getItem/setItem/removeItem mock on
+// `globalThis` before each test and tear it down after.
+// ---------------------------------------------------------------------------
+
+function installLocalStorageMock() {
+    const backing = new Map<string, string>();
+    const mock = {
+        getItem: (key: string) => (backing.has(key) ? backing.get(key)! : null),
+        setItem: (key: string, value: string) => {
+            backing.set(key, String(value));
+        },
+        removeItem: (key: string) => {
+            backing.delete(key);
+        },
+        clear: () => backing.clear(),
+        _backing: backing,
+    };
+    (globalThis as unknown as { localStorage: typeof mock }).localStorage = mock;
+    return mock;
+}
+
+function uninstallLocalStorageMock() {
+    delete (globalThis as unknown as { localStorage?: unknown }).localStorage;
+}
+
+let localStorageMock: ReturnType<typeof installLocalStorageMock>;
+// Records attempted error dispatches from the catch branches of the clone's
+// loadCacheSettings/saveCacheSettings helpers, standing in for
+// `ERROR.reduxSlice.actions.addError` (which we can't import — see header).
+let dispatchedErrors: Array<{ message: string; details: string }>;
+
+beforeEach(() => {
+    localStorageMock = installLocalStorageMock();
+    dispatchedErrors = [];
+});
+
+afterEach(() => {
+    uninstallLocalStorageMock();
+});
+
+// ---------------------------------------------------------------------------
+// Test rig: faithful clone of `../sobjectExplorer.ts`.
+// MUST stay in sync with the slice — the source contract tests below catch
+// drift.
+// ---------------------------------------------------------------------------
+
+const SOBJECTEXPLORER_SETTINGS_KEY = 'SOBJECTEXPLORER_SETTINGS_KEY';
+
+type Tab = {
+    id: string;
+    label?: string;
+    details?: unknown;
+    rawName?: string;
+    useToolingApi?: boolean;
+    source?: string;
+    [key: string]: unknown;
+};
+
+type SobjectExplorerState = {
+    tabs: Tab[];
+    currentTab: Tab | null;
+};
+
+// Faithful clone of the exported `formatTab` pure function.
+export const formatTab = (payload: Record<string, unknown>): Tab => {
+    const validParams = ['id', 'label', 'details', 'rawName', 'useToolingApi', 'source'];
+    const tab: Record<string, unknown> = {};
+    validParams.forEach(key => {
+        if (key in payload && payload[key] !== undefined) {
+            tab[key] = payload[key];
+        }
+    });
+    return tab as Tab;
+};
+
+function loadCacheSettingsLocal(alias: string) {
+    try {
+        const configText = localStorage.getItem(`${alias}-${SOBJECTEXPLORER_SETTINGS_KEY}`);
+        if (configText) return JSON.parse(configText);
+    } catch (e) {
+        dispatchedErrors.push({
+            message: 'Failed to load CONFIG from localStorage',
+            details: (e as Error).message,
+        });
+    }
+    return null;
+}
+
+function saveCacheSettingsLocal(alias: string, state: SobjectExplorerState) {
+    try {
+        const { tabs } = state;
+        localStorage.setItem(`${alias}-${SOBJECTEXPLORER_SETTINGS_KEY}`, JSON.stringify({ tabs }));
+    } catch (e) {
+        dispatchedErrors.push({
+            message: 'Failed to save CONFIG to localstorage',
+            details: (e as Error).message,
+        });
+    }
+}
+
+function isNotUndefinedOrNull<T>(value: T): value is NonNullable<T> {
+    return value !== null && value !== undefined;
+}
+
+const initialState: SobjectExplorerState = {
+    tabs: [],
+    currentTab: null,
+};
+
+const testSlice = createSlice({
+    name: 'sobjectExplorerTest',
+    initialState,
+    reducers: {
+        loadCacheSettings: (state, action: { payload: { alias: string } }) => {
+            const { alias } = action.payload;
+            const cachedConfig = loadCacheSettingsLocal(alias);
+            if (cachedConfig) {
+                const { tabs } = cachedConfig;
+                Object.assign(state, { tabs });
+            }
+        },
+        saveCacheSettings: (state, action: { payload: { alias?: string | null } }) => {
+            const { alias } = action.payload;
+            if (isNotUndefinedOrNull(alias)) {
+                saveCacheSettingsLocal(alias, state);
+            }
+        },
+        upsertTab: (state, action: { payload: { tab: Tab } }) => {
+            const { tab } = action.payload;
+            const indexTab = state.tabs.findIndex(x => x.id === tab.id);
+            if (indexTab < 0) {
+                state.tabs.push(tab);
+                state.currentTab = tab;
+            } else {
+                const originalTab = state.tabs.find(x => x.id === tab.id)!;
+                const newTab = Object.assign(originalTab, tab);
+                state.tabs[indexTab] = newTab;
+                state.currentTab = newTab;
+            }
+        },
+        removeTab: (state, action: { payload: { id: string; alias?: string | null } }) => {
+            const { id, alias } = action.payload;
+            state.tabs = state.tabs.filter(x => x.id != id);
+            if (state.tabs.length > 0 && state.currentTab && state.currentTab.id == id) {
+                const lastTab = state.tabs[state.tabs.length - 1];
+                state.currentTab = lastTab;
+            }
+            if (state.tabs.length == 0) {
+                state.currentTab = null;
+            }
+            if (isNotUndefinedOrNull(alias)) {
+                saveCacheSettingsLocal(alias, state);
+            }
+        },
+        selectTab: (state, action: { payload: { id: string } }) => {
+            const { id } = action.payload;
+            const tab = state.tabs.find(x => x.id == id);
+            if (tab) {
+                state.currentTab = tab;
+            }
+        },
+    },
+});
+
+function makeState(overrides: Partial<SobjectExplorerState> = {}): SobjectExplorerState {
+    return { tabs: [], currentTab: null, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+test('initial state: empty tabs and no currentTab', () => {
+    assert.deepEqual(testSlice.reducer(undefined, { type: '@@init' }), {
+        tabs: [],
+        currentTab: null,
+    });
+});
+
+// ---------------------------------------------------------------------------
+// formatTab — whitelist field copy
+// ---------------------------------------------------------------------------
+
+test('formatTab: copies only whitelisted keys that are defined', () => {
+    const tab = formatTab({
+        id: '1',
+        label: 'Account',
+        details: { foo: 'bar' },
+        rawName: 'Account',
+        useToolingApi: true,
+        source: 'tree',
+        extraneous: 'should not appear',
+        somethingElse: 42,
+    });
+
+    assert.deepEqual(tab, {
+        id: '1',
+        label: 'Account',
+        details: { foo: 'bar' },
+        rawName: 'Account',
+        useToolingApi: true,
+        source: 'tree',
+    });
+    assert.equal('extraneous' in tab, false);
+    assert.equal('somethingElse' in tab, false);
+});
+
+test('formatTab: omits whitelisted keys that are missing or undefined', () => {
+    const tab = formatTab({ id: '2', label: undefined, rawName: 'Contact' });
+    assert.deepEqual(tab, { id: '2', rawName: 'Contact' });
+    assert.equal('label' in tab, false);
+    assert.equal('details' in tab, false);
+    assert.equal('useToolingApi' in tab, false);
+    assert.equal('source' in tab, false);
+});
+
+test('formatTab: returns empty object for empty payload', () => {
+    assert.deepEqual(formatTab({}), {});
+});
+
+// ---------------------------------------------------------------------------
+// upsertTab — insert vs update-merge
+// ---------------------------------------------------------------------------
+
+test('upsertTab: inserts a new tab and sets it as currentTab', () => {
+    const before = makeState();
+    const tab: Tab = { id: 'A', label: 'Account' };
+
+    const next = testSlice.reducer(before, testSlice.actions.upsertTab({ tab }));
+
+    assert.deepEqual(next.tabs, [tab]);
+    assert.deepEqual(next.currentTab, tab);
+});
+
+test('upsertTab: appends subsequent new tabs and updates currentTab', () => {
+    const before = makeState({
+        tabs: [{ id: 'A', label: 'Account' }],
+        currentTab: { id: 'A', label: 'Account' },
+    });
+    const tab: Tab = { id: 'B', label: 'Contact' };
+
+    const next = testSlice.reducer(before, testSlice.actions.upsertTab({ tab }));
+
+    assert.equal(next.tabs.length, 2);
+    assert.deepEqual(next.tabs[1], tab);
+    assert.deepEqual(next.currentTab, tab);
+});
+
+test('upsertTab: MERGES fields into the existing tab rather than replacing it', () => {
+    const before = makeState({
+        tabs: [{ id: 'A', label: 'Account', rawName: 'Account', source: 'tree' }],
+        currentTab: null,
+    });
+
+    // Partial update — only `label` provided, other original fields must survive.
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.upsertTab({ tab: { id: 'A', label: 'Account (renamed)' } })
+    );
+
+    assert.equal(next.tabs.length, 1, 'update must not add a duplicate tab');
+    assert.deepEqual(next.tabs[0], {
+        id: 'A',
+        label: 'Account (renamed)',
+        rawName: 'Account',
+        source: 'tree',
+    });
+    assert.deepEqual(next.currentTab, next.tabs[0], 'currentTab must be updated to the merged tab');
+});
+
+// ---------------------------------------------------------------------------
+// removeTab — currentTab reassignment
+// ---------------------------------------------------------------------------
+
+test('removeTab: reassigns currentTab to the new last tab when the removed tab was current', () => {
+    const tabA: Tab = { id: 'A' };
+    const tabB: Tab = { id: 'B' };
+    const tabC: Tab = { id: 'C' };
+    const before = makeState({ tabs: [tabA, tabB, tabC], currentTab: tabC });
+
+    const next = testSlice.reducer(before, testSlice.actions.removeTab({ id: 'C' }));
+
+    assert.deepEqual(next.tabs, [tabA, tabB]);
+    assert.deepEqual(next.currentTab, tabB, 'currentTab must become the new last tab');
+});
+
+test('removeTab: sets currentTab to null when the last tab is removed', () => {
+    const tabA: Tab = { id: 'A' };
+    const before = makeState({ tabs: [tabA], currentTab: tabA });
+
+    const next = testSlice.reducer(before, testSlice.actions.removeTab({ id: 'A' }));
+
+    assert.deepEqual(next.tabs, []);
+    assert.equal(next.currentTab, null);
+});
+
+test('removeTab: leaves currentTab untouched when removing a non-current tab', () => {
+    const tabA: Tab = { id: 'A' };
+    const tabB: Tab = { id: 'B' };
+    const before = makeState({ tabs: [tabA, tabB], currentTab: tabB });
+
+    const next = testSlice.reducer(before, testSlice.actions.removeTab({ id: 'A' }));
+
+    assert.deepEqual(next.tabs, [tabB]);
+    assert.deepEqual(next.currentTab, tabB, 'currentTab must remain the tab that was not removed');
+});
+
+test('removeTab: persists via saveCacheSettings when alias is provided', () => {
+    const tabA: Tab = { id: 'A' };
+    const tabB: Tab = { id: 'B' };
+    const before = makeState({ tabs: [tabA, tabB], currentTab: tabB });
+
+    testSlice.reducer(before, testSlice.actions.removeTab({ id: 'B', alias: 'myorg' }));
+
+    const raw = localStorageMock.getItem('myorg-SOBJECTEXPLORER_SETTINGS_KEY');
+    assert.ok(raw, 'removeTab with an alias must write to localStorage');
+    assert.deepEqual(JSON.parse(raw!), { tabs: [tabA] });
+});
+
+// ---------------------------------------------------------------------------
+// selectTab — found / not found
+// ---------------------------------------------------------------------------
+
+test('selectTab: sets currentTab when the id is found', () => {
+    const tabA: Tab = { id: 'A' };
+    const tabB: Tab = { id: 'B' };
+    const before = makeState({ tabs: [tabA, tabB], currentTab: tabA });
+
+    const next = testSlice.reducer(before, testSlice.actions.selectTab({ id: 'B' }));
+
+    assert.deepEqual(next.currentTab, tabB);
+});
+
+test('selectTab: leaves currentTab unchanged when the id is not found', () => {
+    const tabA: Tab = { id: 'A' };
+    const before = makeState({ tabs: [tabA], currentTab: tabA });
+
+    const next = testSlice.reducer(before, testSlice.actions.selectTab({ id: 'does-not-exist' }));
+
+    assert.deepEqual(next.currentTab, tabA);
+});
+
+// ---------------------------------------------------------------------------
+// loadCacheSettings / saveCacheSettings — localStorage round-trip
+// ---------------------------------------------------------------------------
+
+test('saveCacheSettings: writes only {tabs} to localStorage (currentTab NOT persisted)', () => {
+    const tabA: Tab = { id: 'A', label: 'Account' };
+    const before = makeState({ tabs: [tabA], currentTab: tabA });
+
+    testSlice.reducer(before, testSlice.actions.saveCacheSettings({ alias: 'myorg' }));
+
+    const raw = localStorageMock.getItem('myorg-SOBJECTEXPLORER_SETTINGS_KEY');
+    assert.ok(raw);
+    const parsed = JSON.parse(raw!);
+    assert.deepEqual(parsed, { tabs: [tabA] });
+    assert.equal('currentTab' in parsed, false, 'currentTab must not be persisted');
+});
+
+test('saveCacheSettings: no-ops when alias is null/undefined', () => {
+    const before = makeState({ tabs: [{ id: 'A' }], currentTab: null });
+
+    testSlice.reducer(before, testSlice.actions.saveCacheSettings({ alias: null }));
+    testSlice.reducer(before, testSlice.actions.saveCacheSettings({ alias: undefined }));
+
+    assert.equal(localStorageMock._backing.size, 0, 'nothing should be written without an alias');
+});
+
+test('loadCacheSettings: merges persisted tabs into state, currentTab untouched', () => {
+    const persistedTabs: Tab[] = [{ id: 'X', label: 'Persisted' }];
+    localStorageMock.setItem(
+        'myorg-SOBJECTEXPLORER_SETTINGS_KEY',
+        JSON.stringify({ tabs: persistedTabs })
+    );
+
+    const before = makeState({ tabs: [{ id: 'STALE' }], currentTab: { id: 'STALE' } });
+    const next = testSlice.reducer(before, testSlice.actions.loadCacheSettings({ alias: 'myorg' }));
+
+    assert.deepEqual(next.tabs, persistedTabs);
+    assert.deepEqual(
+        next.currentTab,
+        { id: 'STALE' },
+        'loadCacheSettings must not touch currentTab'
+    );
+});
+
+test('loadCacheSettings: no-ops when nothing is cached for the alias', () => {
+    const before = makeState({ tabs: [{ id: 'KEEP' }], currentTab: null });
+
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.loadCacheSettings({ alias: 'unknown-org' })
+    );
+
+    assert.deepEqual(next.tabs, [{ id: 'KEEP' }]);
+});
+
+test('loadCacheSettings + saveCacheSettings: full round-trip preserves tab shape', () => {
+    const tabs: Tab[] = [
+        { id: '1', label: 'Account', rawName: 'Account', useToolingApi: false, source: 'tree' },
+        { id: '2', label: 'Contact', source: 'search' },
+    ];
+    const saved = makeState({ tabs, currentTab: tabs[1] });
+
+    testSlice.reducer(saved, testSlice.actions.saveCacheSettings({ alias: 'roundtrip' }));
+
+    const loadedInto = makeState();
+    const loaded = testSlice.reducer(
+        loadedInto,
+        testSlice.actions.loadCacheSettings({ alias: 'roundtrip' })
+    );
+
+    assert.deepEqual(loaded.tabs, tabs);
+    assert.equal(loaded.currentTab, null, 'currentTab is never persisted, so it stays as-is');
+});
+
+test('loadCacheSettings: a malformed cache entry is caught and reported, state unchanged', () => {
+    localStorageMock.setItem('bad-org-SOBJECTEXPLORER_SETTINGS_KEY', '{not valid json');
+    const before = makeState({ tabs: [{ id: 'KEEP' }], currentTab: null });
+
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.loadCacheSettings({ alias: 'bad-org' })
+    );
+
+    assert.deepEqual(next.tabs, [{ id: 'KEEP' }], 'state must be left untouched on parse failure');
+    assert.equal(dispatchedErrors.length, 1);
+    assert.equal(dispatchedErrors[0].message, 'Failed to load CONFIG from localStorage');
+});
+
+// ---------------------------------------------------------------------------
+// Source contract — pin the real file's policy so drift is caught.
+// ---------------------------------------------------------------------------
+
+test('source contract: formatTab whitelists the same six keys', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const src = fs.readFileSync(path.resolve(here, '../sobjectExplorer.ts'), 'utf8');
+
+    assert.match(
+        src,
+        /const validParams = \[\s*'id',\s*'label',\s*'details',\s*'rawName',\s*'useToolingApi',\s*'source',?\s*\];/,
+        'formatTab whitelist must stay in sync with the clone'
+    );
+});
+
+test('source contract: initialState is {tabs: [], currentTab: null}', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const src = fs.readFileSync(path.resolve(here, '../sobjectExplorer.ts'), 'utf8');
+
+    assert.match(src, /initialState:\s*\{\s*tabs:\s*\[\],\s*currentTab:\s*null,?\s*\}/);
+});
+
+test('source contract: saveCacheSettings persists only {tabs}, not currentTab', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const src = fs.readFileSync(path.resolve(here, '../sobjectExplorer.ts'), 'utf8');
+
+    assert.match(
+        src,
+        /function saveCacheSettings\(alias, state\)[\s\S]+?const \{ tabs \} = state;[\s\S]+?JSON\.stringify\(\s*\{\s*tabs,?\s*\}\s*\)/,
+        'saveCacheSettings must only persist the tabs field'
+    );
+});
+
+test('source contract: removeTab reassigns currentTab to last tab, or null when empty', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const src = fs.readFileSync(path.resolve(here, '../sobjectExplorer.ts'), 'utf8');
+
+    assert.match(
+        src,
+        /removeTab:[\s\S]+?state\.tabs = state\.tabs\.filter\(x => x\.id != id\);[\s\S]+?state\.currentTab = lastTab;[\s\S]+?state\.currentTab = null;/,
+        'removeTab must reassign currentTab to the new last tab, falling back to null when tabs is empty'
+    );
+});
+
+test('source contract: upsertTab merges into the existing tab on update (not a plain replace)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const src = fs.readFileSync(path.resolve(here, '../sobjectExplorer.ts'), 'utf8');
+
+    assert.match(
+        src,
+        /upsertTab:[\s\S]+?Object\.assign\(originalTab, tab\)/,
+        'upsertTab must merge fields via Object.assign, not overwrite the tab wholesale'
+    );
+});

--- a/packages/lwc/applications/package/slices/__tests__/package.test.ts
+++ b/packages/lwc/applications/package/slices/__tests__/package.test.ts
@@ -1,0 +1,649 @@
+/**
+ * Slice-behavior tests for the package application's `packageSlice` —
+ * focused on the synchronous `reducers` (cache settings, deployment-job
+ * clearing, metadata-menu navigation) and the `extraReducers` around
+ * `executePackageDeploy`, `executePackageRetrieve`,
+ * `fetchMenuGlobalMetadata`, and `fetchMenuSpecificMetadata`.
+ *
+ * Why we don't import `../package.ts` directly
+ * -----------------------------------------------
+ * `../package.ts` imports `BACKGROUNDJOB`, `DESCRIBE`, `ERROR` from
+ * `host-api/store` and `getStore` from `core/store/storeRef` at module
+ * top-level, and also imports `loadSpecificMetadata`,
+ * `loadSpecificMetadataException` from `metadata/slices/metadata`.
+ * `host-api/store` transitively loads the full core store graph including
+ * LWC components decorated with `@api`/`@wire` — invalid syntax under plain
+ * Node, since this test runner (`--experimental-strip-types`) only strips
+ * TypeScript types and cannot parse LWC decorator syntax. Importing
+ * `../package.ts` directly throws `SyntaxError: Invalid or unexpected
+ * token`. Verified empirically:
+ *   node --experimental-strip-types --import=./tools/testing/register.mjs \
+ *     -e "import('./packages/lwc/applications/package/slices/package.ts')"
+ *   -> SyntaxError: Invalid or unexpected token
+ * This is the same constraint documented in
+ * `platformevent/slices/__tests__/platformEvent.test.ts` (the canonical
+ * precedent for this pattern) and `agentforce/slices/__tests__/agents.test.ts`
+ * (the original).
+ *
+ * Pragmatic alternative: re-construct the same `reducers`/`extraReducers`
+ * the slice uses as a "faithful clone" built with `createSlice` from
+ * `@reduxjs/toolkit` (the same library the real slice uses), and pin the
+ * clone's fidelity with "source contract" tests that `readFileSync` the
+ * real `../package.ts` and `assert.match` key lines/policies. Any drift
+ * between the clone and the real file gets caught by those contract tests
+ * in review.
+ *
+ * `isNotUndefinedOrNull` is imported directly from `shared/utils` — that
+ * module does NOT import `host-api/store`, so it is safe to import in this
+ * plain-Node test environment (same precedent as
+ * `anonymousApex/slices/__tests__/apexHelpers.test.ts`). `lowerCaseKey` and
+ * `guid` are imported into the real source but are NOT actually invoked
+ * anywhere in `packageSlice`'s synchronous reducers/extraReducers (verified
+ * by grep — see the "source contract" test at the bottom that pins this),
+ * so this clone does not need stand-ins for them.
+ *
+ * `executePackageDeploy`, `executePackageRetrieve`, `fetchMenuGlobalMetadata`,
+ * and `fetchMenuSpecificMetadata` are async thunks that call a real
+ * Salesforce connector (`connector.conn.metadata.deploy/retrieve`) or
+ * dispatch other slices' thunks (`DESCRIBE.describeSObjects`,
+ * `DESCRIBE.describeVersion`) — out of scope here; only their
+ * `extraReducers` (pending/fulfilled/rejected) cases are cloned and tested,
+ * using synthetic action objects that mimic what `createAsyncThunk` would
+ * dispatch.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import { createSlice } from '@reduxjs/toolkit';
+
+import { isNotUndefinedOrNull } from 'shared/utils';
+
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(path.resolve(here, '../package.ts'), 'utf8');
+
+// ---------------------------------------------------------------------------
+// Test rig: faithful clone of packageSlice's local `loadCacheSettings` /
+// `saveCacheSettings` helpers (backed by `localStorage`) plus the slice's
+// reducers + extraReducers. MUST stay in sync with `../package.ts`. Each
+// piece mirrors the real implementation; the "source contract" tests at the
+// bottom pin the real source against regexes so drift is caught.
+// ---------------------------------------------------------------------------
+
+const PACKAGE_SETTINGS_KEY = 'PACKAGE_SETTINGS_KEY';
+
+function loadCacheSettingsHelper(alias: string) {
+    try {
+        const configText = localStorage.getItem(`${alias}-${PACKAGE_SETTINGS_KEY}`);
+        if (configText) return JSON.parse(configText);
+    } catch (e) {
+        console.error('Failed to load CONFIG from localStorage', e);
+    }
+    return null;
+}
+
+function saveCacheSettingsHelper(alias: string, state: any) {
+    try {
+        const { currentMethod, leftPanelToggled } = state;
+        localStorage.setItem(
+            `${alias}-${PACKAGE_SETTINGS_KEY}`,
+            JSON.stringify({ currentMethod, leftPanelToggled })
+        );
+    } catch (e) {
+        console.error('Failed to save CONFIG to localstorage', e);
+    }
+}
+
+// Simulated async-thunk action-type strings (mirrors `createAsyncThunk`'s
+// auto-generated `<typePrefix>/pending|fulfilled|rejected` types).
+const DEPLOY_PENDING = 'package/deploy/pending';
+const DEPLOY_FULFILLED = 'package/deploy/fulfilled';
+const DEPLOY_REJECTED = 'package/deploy/rejected';
+const RETRIEVE_PENDING = 'package/retrieve/pending';
+const RETRIEVE_FULFILLED = 'package/retrieve/fulfilled';
+const RETRIEVE_REJECTED = 'package/retrieve/rejected';
+const MENU_GLOBAL_PENDING = 'package/menu/fetchGlobalMetadata/pending';
+const MENU_GLOBAL_FULFILLED = 'package/menu/fetchGlobalMetadata/fulfilled';
+const MENU_GLOBAL_REJECTED = 'package/menu/fetchGlobalMetadata/rejected';
+const MENU_SPECIFIC_PENDING = 'package/menu/fetchSpecificMetadata/pending';
+const MENU_SPECIFIC_FULFILLED = 'package/menu/fetchSpecificMetadata/fulfilled';
+const MENU_SPECIFIC_REJECTED = 'package/menu/fetchSpecificMetadata/rejected';
+
+const initialState = () => ({
+    leftPanelToggled: false,
+    currentMethod: null as string | null,
+    currentDeploymentJob: null as any,
+    currentRetrieveJob: null as any,
+    menu_isLoading: false,
+    menu_loadingMessage: '',
+    menu_currentMetadata: null as string | null,
+    menu_metadata_global: null as any,
+    menu_metadata_records: null as any,
+    menu_param1: null as any,
+    menu_label1: null as any,
+    menu_sobject: null as any,
+});
+
+const testSlice = createSlice({
+    name: 'packageTest',
+    initialState: initialState(),
+    reducers: {
+        loadCacheSettings: (state, action: any) => {
+            const { alias } = action.payload;
+            const cachedConfig = loadCacheSettingsHelper(alias);
+            if (cachedConfig) {
+                const { currentMethod } = cachedConfig;
+                Object.assign(state, { currentMethod });
+            }
+        },
+        saveCacheSettings: (state, action: any) => {
+            const { alias } = action.payload;
+            if (isNotUndefinedOrNull(alias)) {
+                saveCacheSettingsHelper(alias, state);
+            }
+        },
+        updateCurrentMethodPanel: (state, action: any) => {
+            const { value, alias } = action.payload;
+            state.currentMethod = value;
+            if (isNotUndefinedOrNull(alias)) {
+                saveCacheSettingsHelper(alias, state);
+            }
+        },
+        updateLeftPanel: (state, action: any) => {
+            const { value, alias } = action.payload;
+            state.leftPanelToggled = value === true;
+            if (isNotUndefinedOrNull(alias)) {
+                saveCacheSettingsHelper(alias, state);
+            }
+        },
+        clearCurrentDeploymentJob: (state: any) => {
+            state.currentDeploymentJob = null;
+        },
+        clearCurrentRetrieveJob: (state: any) => {
+            state.currentRetrieveJob = null;
+        },
+        setMenuAttributes: (state, action: any) => {
+            const { sobject, param1, label1 } = action.payload || {};
+            if (sobject !== undefined) state.menu_sobject = sobject;
+            if (param1 !== undefined) state.menu_param1 = param1;
+            if (label1 !== undefined) state.menu_label1 = label1;
+        },
+        menuGoBack: (state: any) => {
+            state.menu_metadata_records = null;
+            state.menu_currentMetadata = null;
+            state.menu_param1 = null;
+            state.menu_label1 = null;
+        },
+    },
+    extraReducers: builder => {
+        builder
+            .addCase(DEPLOY_PENDING, (state: any, action: any) => {
+                const { createdDate } = action.meta.arg;
+                state.currentDeploymentJob = { isFetching: true, error: null, createdDate };
+            })
+            .addCase(DEPLOY_FULFILLED, (state: any, action: any) => {
+                Object.assign(state.currentDeploymentJob, {
+                    isFetching: false,
+                    data: action.payload,
+                });
+            })
+            .addCase(DEPLOY_REJECTED, (state: any, action: any) => {
+                const { error } = action;
+                Object.assign(state.currentDeploymentJob, { isFetching: false, error });
+            })
+            .addCase(RETRIEVE_PENDING, (state: any, action: any) => {
+                const { createdDate } = action.meta.arg;
+                state.currentRetrieveJob = { isFetching: true, error: null, createdDate };
+            })
+            .addCase(RETRIEVE_FULFILLED, (state: any, action: any) => {
+                Object.assign(state.currentRetrieveJob, {
+                    isFetching: false,
+                    data: action.payload.data,
+                });
+            })
+            .addCase(RETRIEVE_REJECTED, (state: any, action: any) => {
+                const { error } = action;
+                Object.assign(state.currentRetrieveJob, { isFetching: false, error });
+            })
+            .addCase(MENU_GLOBAL_PENDING, (state: any) => {
+                state.menu_isLoading = true;
+                state.menu_loadingMessage = 'Loading All Metadata';
+            })
+            .addCase(MENU_GLOBAL_FULFILLED, (state: any, action: any) => {
+                state.menu_isLoading = false;
+                state.menu_metadata_global = action.payload;
+            })
+            .addCase(MENU_GLOBAL_REJECTED, (state: any) => {
+                state.menu_isLoading = false;
+            })
+            .addCase(MENU_SPECIFIC_PENDING, (state: any) => {
+                state.menu_isLoading = true;
+                state.menu_loadingMessage = 'Loading Records';
+            })
+            .addCase(MENU_SPECIFIC_FULFILLED, (state: any, action: any) => {
+                state.menu_isLoading = false;
+                state.menu_metadata_records = action.payload.metadata;
+                state.menu_currentMetadata = action.payload.currentMetadata;
+            })
+            .addCase(MENU_SPECIFIC_REJECTED, (state: any) => {
+                state.menu_isLoading = false;
+            });
+    },
+});
+
+function makeState(overrides: Partial<ReturnType<typeof initialState>> = {}) {
+    return { ...initialState(), ...overrides };
+}
+
+function ensureLocalStorage() {
+    // `loadCacheSettingsHelper`/`saveCacheSettingsHelper` call the bare global
+    // `localStorage` (not `window.localStorage`), matching the real source
+    // (`../package.ts` also calls the bare global). Install a fresh
+    // in-memory stand-in per test so state doesn't leak across tests.
+    const store = new Map<string, string>();
+    (globalThis as any).localStorage = {
+        getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+        setItem: (key: string, value: string) => {
+            store.set(key, String(value));
+        },
+        removeItem: (key: string) => {
+            store.delete(key);
+        },
+        clear: () => store.clear(),
+    };
+    return store;
+}
+
+// ---------------------------------------------------------------------------
+// loadCacheSettings / saveCacheSettings
+// ---------------------------------------------------------------------------
+
+test('loadCacheSettings: restores currentMethod from a previously cached blob', () => {
+    ensureLocalStorage();
+    localStorage.setItem(
+        'myalias-PACKAGE_SETTINGS_KEY',
+        JSON.stringify({ currentMethod: 'deploy', leftPanelToggled: true })
+    );
+    const next = testSlice.reducer(
+        makeState(),
+        testSlice.actions.loadCacheSettings({ alias: 'myalias' })
+    );
+    assert.equal(next.currentMethod, 'deploy');
+    // NOTE: the real reducer only destructures+assigns `currentMethod` from
+    // the cached config, even though `saveCacheSettings` persists
+    // `leftPanelToggled` too — `leftPanelToggled` is intentionally NOT
+    // restored by `loadCacheSettings`. This test pins that asymmetry.
+    assert.equal(
+        next.leftPanelToggled,
+        false,
+        'leftPanelToggled is never restored by loadCacheSettings'
+    );
+});
+
+test('loadCacheSettings: no cached config -> state is untouched', () => {
+    ensureLocalStorage();
+    const before = makeState({ currentMethod: 'retrieve' });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.loadCacheSettings({ alias: 'unknown-alias' })
+    );
+    assert.equal(next.currentMethod, 'retrieve');
+});
+
+test('saveCacheSettings: persists currentMethod + leftPanelToggled under the alias-scoped key', () => {
+    ensureLocalStorage();
+    const state = makeState({ currentMethod: 'deploy', leftPanelToggled: true });
+    testSlice.reducer(state, testSlice.actions.saveCacheSettings({ alias: 'org1' }));
+    const raw = localStorage.getItem('org1-PACKAGE_SETTINGS_KEY');
+    assert.deepEqual(JSON.parse(raw as string), {
+        currentMethod: 'deploy',
+        leftPanelToggled: true,
+    });
+});
+
+test('saveCacheSettings: does nothing when alias is null/undefined', () => {
+    const store = ensureLocalStorage();
+    testSlice.reducer(makeState(), testSlice.actions.saveCacheSettings({ alias: null }));
+    assert.equal(store.size, 0, 'no cache write should happen without an alias');
+});
+
+// ---------------------------------------------------------------------------
+// updateCurrentMethodPanel / updateLeftPanel
+// ---------------------------------------------------------------------------
+
+test('updateCurrentMethodPanel: sets currentMethod and persists when alias is provided', () => {
+    ensureLocalStorage();
+    const next = testSlice.reducer(
+        makeState(),
+        testSlice.actions.updateCurrentMethodPanel({ value: 'retrieve', alias: 'org2' })
+    );
+    assert.equal(next.currentMethod, 'retrieve');
+    assert.ok(
+        localStorage.getItem('org2-PACKAGE_SETTINGS_KEY'),
+        'saveCacheSettings must be triggered'
+    );
+});
+
+test('updateCurrentMethodPanel: sets currentMethod without persisting when alias is absent', () => {
+    const store = ensureLocalStorage();
+    const next = testSlice.reducer(
+        makeState(),
+        testSlice.actions.updateCurrentMethodPanel({ value: 'deploy', alias: null })
+    );
+    assert.equal(next.currentMethod, 'deploy');
+    assert.equal(store.size, 0);
+});
+
+test('updateLeftPanel: coerces via strict `=== true` (non-boolean truthy values do not toggle it on)', () => {
+    ensureLocalStorage();
+    const on = testSlice.reducer(
+        makeState(),
+        testSlice.actions.updateLeftPanel({ value: true, alias: null })
+    );
+    assert.equal(on.leftPanelToggled, true);
+
+    const truthyNotBool = testSlice.reducer(
+        makeState(),
+        testSlice.actions.updateLeftPanel({ value: 'yes', alias: null })
+    );
+    assert.equal(
+        truthyNotBool.leftPanelToggled,
+        false,
+        'only the literal boolean true toggles the panel on'
+    );
+});
+
+// ---------------------------------------------------------------------------
+// clearCurrentDeploymentJob / clearCurrentRetrieveJob
+// ---------------------------------------------------------------------------
+
+test('clearCurrentDeploymentJob: nulls out currentDeploymentJob', () => {
+    const before = makeState({ currentDeploymentJob: { isFetching: false, data: {} } });
+    const next = testSlice.reducer(before, testSlice.actions.clearCurrentDeploymentJob());
+    assert.equal(next.currentDeploymentJob, null);
+});
+
+test('clearCurrentRetrieveJob: nulls out currentRetrieveJob', () => {
+    const before = makeState({ currentRetrieveJob: { isFetching: false, data: {} } });
+    const next = testSlice.reducer(before, testSlice.actions.clearCurrentRetrieveJob());
+    assert.equal(next.currentRetrieveJob, null);
+});
+
+// ---------------------------------------------------------------------------
+// setMenuAttributes / menuGoBack
+// ---------------------------------------------------------------------------
+
+test('setMenuAttributes: only overwrites fields explicitly present (undefined leaves existing value untouched)', () => {
+    const before = makeState({ menu_sobject: 'Account', menu_param1: 'p1', menu_label1: 'L1' });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.setMenuAttributes({ sobject: 'Contact' })
+    );
+    assert.equal(next.menu_sobject, 'Contact');
+    assert.equal(next.menu_param1, 'p1', 'param1 not present in payload -> untouched');
+    assert.equal(next.menu_label1, 'L1', 'label1 not present in payload -> untouched');
+});
+
+test('setMenuAttributes: explicit null values DO overwrite (only `undefined` is skipped)', () => {
+    const before = makeState({ menu_sobject: 'Account', menu_param1: 'p1' });
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.setMenuAttributes({ sobject: null, param1: null })
+    );
+    assert.equal(next.menu_sobject, null);
+    assert.equal(next.menu_param1, null);
+});
+
+test('setMenuAttributes: missing payload entirely is a no-op (falls back to `{}`)', () => {
+    const before = makeState({ menu_sobject: 'Account' });
+    const next = testSlice.reducer(before, testSlice.actions.setMenuAttributes(undefined));
+    assert.equal(next.menu_sobject, 'Account');
+});
+
+test('menuGoBack: clears metadata records, current metadata, param1, and label1', () => {
+    const before = makeState({
+        menu_metadata_records: [{ name: 'Account' }],
+        menu_currentMetadata: 'Account',
+        menu_param1: 'p1',
+        menu_label1: 'L1',
+        menu_sobject: 'Account',
+    });
+    const next = testSlice.reducer(before, testSlice.actions.menuGoBack());
+    assert.equal(next.menu_metadata_records, null);
+    assert.equal(next.menu_currentMetadata, null);
+    assert.equal(next.menu_param1, null);
+    assert.equal(next.menu_label1, null);
+    assert.equal(next.menu_sobject, 'Account', 'menuGoBack does NOT clear menu_sobject');
+});
+
+// ---------------------------------------------------------------------------
+// extraReducers: executePackageDeploy
+// ---------------------------------------------------------------------------
+
+test('executePackageDeploy.pending: seeds currentDeploymentJob as fetching', () => {
+    const next = testSlice.reducer(makeState(), {
+        type: DEPLOY_PENDING,
+        meta: { arg: { createdDate: '2026-01-01' } },
+    });
+    assert.deepEqual(next.currentDeploymentJob, {
+        isFetching: true,
+        error: null,
+        createdDate: '2026-01-01',
+    });
+});
+
+test('executePackageDeploy.fulfilled: marks job done and stores the deploy result payload', () => {
+    const before = makeState({
+        currentDeploymentJob: { isFetching: true, error: null, createdDate: '2026-01-01' },
+    });
+    const next = testSlice.reducer(before, {
+        type: DEPLOY_FULFILLED,
+        payload: { status: 'Succeeded' },
+    });
+    assert.equal(next.currentDeploymentJob.isFetching, false);
+    assert.deepEqual(next.currentDeploymentJob.data, { status: 'Succeeded' });
+});
+
+test('executePackageDeploy.rejected: marks job failed and records the error', () => {
+    const before = makeState({
+        currentDeploymentJob: { isFetching: true, error: null, createdDate: '2026-01-01' },
+    });
+    const next = testSlice.reducer(before, {
+        type: DEPLOY_REJECTED,
+        error: { message: 'INVALID_SESSION_ID' },
+    });
+    assert.equal(next.currentDeploymentJob.isFetching, false);
+    assert.deepEqual(next.currentDeploymentJob.error, { message: 'INVALID_SESSION_ID' });
+});
+
+// ---------------------------------------------------------------------------
+// extraReducers: executePackageRetrieve
+// ---------------------------------------------------------------------------
+
+test('executePackageRetrieve.pending: seeds currentRetrieveJob as fetching', () => {
+    const next = testSlice.reducer(makeState(), {
+        type: RETRIEVE_PENDING,
+        meta: { arg: { createdDate: '2026-02-01' } },
+    });
+    assert.deepEqual(next.currentRetrieveJob, {
+        isFetching: true,
+        error: null,
+        createdDate: '2026-02-01',
+    });
+});
+
+test('executePackageRetrieve.fulfilled: marks job done and stores payload.data (not the whole payload)', () => {
+    const before = makeState({
+        currentRetrieveJob: { isFetching: true, error: null, createdDate: '2026-02-01' },
+    });
+    const next = testSlice.reducer(before, {
+        type: RETRIEVE_FULFILLED,
+        payload: { data: { zipFile: 'base64...', id: '09S1' } },
+    });
+    assert.equal(next.currentRetrieveJob.isFetching, false);
+    assert.deepEqual(next.currentRetrieveJob.data, { zipFile: 'base64...', id: '09S1' });
+});
+
+test('executePackageRetrieve.rejected: marks job failed and records the error', () => {
+    const before = makeState({
+        currentRetrieveJob: { isFetching: true, error: null, createdDate: '2026-02-01' },
+    });
+    const next = testSlice.reducer(before, {
+        type: RETRIEVE_REJECTED,
+        error: { message: 'Retrieve timed out' },
+    });
+    assert.equal(next.currentRetrieveJob.isFetching, false);
+    assert.deepEqual(next.currentRetrieveJob.error, { message: 'Retrieve timed out' });
+});
+
+// ---------------------------------------------------------------------------
+// extraReducers: fetchMenuGlobalMetadata / fetchMenuSpecificMetadata
+// ---------------------------------------------------------------------------
+
+test('fetchMenuGlobalMetadata.pending: sets loading + a "Loading All Metadata" message', () => {
+    const next = testSlice.reducer(makeState(), { type: MENU_GLOBAL_PENDING });
+    assert.equal(next.menu_isLoading, true);
+    assert.equal(next.menu_loadingMessage, 'Loading All Metadata');
+});
+
+test('fetchMenuGlobalMetadata.fulfilled: stores the payload as menu_metadata_global and clears loading', () => {
+    const before = makeState({ menu_isLoading: true });
+    const next = testSlice.reducer(before, {
+        type: MENU_GLOBAL_FULFILLED,
+        payload: { records: [{ name: 'CustomObject' }], label: 'Metadata' },
+    });
+    assert.equal(next.menu_isLoading, false);
+    assert.deepEqual(next.menu_metadata_global, {
+        records: [{ name: 'CustomObject' }],
+        label: 'Metadata',
+    });
+});
+
+test('fetchMenuGlobalMetadata.rejected: only clears loading (does not touch menu_metadata_global)', () => {
+    const before = makeState({
+        menu_isLoading: true,
+        menu_metadata_global: { records: ['stale'] },
+    });
+    const next = testSlice.reducer(before, { type: MENU_GLOBAL_REJECTED });
+    assert.equal(next.menu_isLoading, false);
+    assert.deepEqual(
+        next.menu_metadata_global,
+        { records: ['stale'] },
+        'rejected does not clear previously loaded global metadata'
+    );
+});
+
+test('fetchMenuSpecificMetadata.pending: sets loading + a "Loading Records" message', () => {
+    const next = testSlice.reducer(makeState(), { type: MENU_SPECIFIC_PENDING });
+    assert.equal(next.menu_isLoading, true);
+    assert.equal(next.menu_loadingMessage, 'Loading Records');
+});
+
+test('fetchMenuSpecificMetadata.fulfilled: stores metadata + currentMetadata from the payload', () => {
+    const before = makeState({ menu_isLoading: true });
+    const next = testSlice.reducer(before, {
+        type: MENU_SPECIFIC_FULFILLED,
+        payload: { currentMetadata: 'CustomObject', metadata: [{ fullName: 'Foo__c' }] },
+    });
+    assert.equal(next.menu_isLoading, false);
+    assert.equal(next.menu_currentMetadata, 'CustomObject');
+    assert.deepEqual(next.menu_metadata_records, [{ fullName: 'Foo__c' }]);
+});
+
+test('fetchMenuSpecificMetadata.rejected: only clears loading (does not touch cached records)', () => {
+    const before = makeState({
+        menu_isLoading: true,
+        menu_metadata_records: [{ fullName: 'stale' }],
+        menu_currentMetadata: 'StaleType',
+    });
+    const next = testSlice.reducer(before, { type: MENU_SPECIFIC_REJECTED });
+    assert.equal(next.menu_isLoading, false);
+    assert.deepEqual(next.menu_metadata_records, [{ fullName: 'stale' }]);
+    assert.equal(next.menu_currentMetadata, 'StaleType');
+});
+
+// ---------------------------------------------------------------------------
+// Source contract tests — pin the real `../package.ts` against regexes so
+// drift between this clone and the real implementation is caught.
+// ---------------------------------------------------------------------------
+
+test('source contract: packageSlice reducers include the full expected set of names', () => {
+    const expectedReducers = [
+        'loadCacheSettings',
+        'saveCacheSettings',
+        'updateCurrentMethodPanel',
+        'updateLeftPanel',
+        'clearCurrentDeploymentJob',
+        'clearCurrentRetrieveJob',
+        'setMenuAttributes',
+        'menuGoBack',
+    ];
+    for (const name of expectedReducers) {
+        assert.match(
+            SRC,
+            new RegExp(`\\b${name}: \\(?state`),
+            `expected reducer \`${name}\` to be defined with a \`state\` first param`
+        );
+    }
+});
+
+test('source contract: loadCacheSettings only restores currentMethod from the cached config', () => {
+    assert.match(
+        SRC,
+        /loadCacheSettings: \(state, action\) => \{\s*const \{ alias \} = action\.payload;\s*const cachedConfig = loadCacheSettings\(alias\);\s*if \(cachedConfig\) \{\s*const \{ currentMethod \} = cachedConfig;\s*Object\.assign\(state, \{\s*currentMethod,\s*\}\);/
+    );
+});
+
+test('source contract: updateLeftPanel coerces via the strict `=== true` check', () => {
+    assert.match(SRC, /state\.leftPanelToggled = value === true;/);
+});
+
+test('source contract: setMenuAttributes only skips fields that are `undefined`', () => {
+    assert.match(SRC, /if \(sobject !== undefined\) state\.menu_sobject = sobject;/);
+    assert.match(SRC, /if \(param1 !== undefined\) state\.menu_param1 = param1;/);
+    assert.match(SRC, /if \(label1 !== undefined\) state\.menu_label1 = label1;/);
+});
+
+test('source contract: menuGoBack clears records/currentMetadata/param1/label1 but not menu_sobject', () => {
+    assert.match(
+        SRC,
+        /menuGoBack: state => \{\s*state\.menu_metadata_records = null;\s*state\.menu_currentMetadata = null;\s*state\.menu_param1 = null;\s*state\.menu_label1 = null;\s*\},/
+    );
+});
+
+test('source contract: executePackageRetrieve.fulfilled stores payload.data (not the raw payload)', () => {
+    assert.match(
+        SRC,
+        /addCase\(executePackageRetrieve\.fulfilled, \(state, action\) => \{\s*Object\.assign\(state\.currentRetrieveJob, \{\s*isFetching: false,\s*data: action\.payload\.data,/
+    );
+});
+
+test('source contract: fetchMenuGlobalMetadata/fetchMenuSpecificMetadata rejected cases only clear menu_isLoading', () => {
+    assert.match(
+        SRC,
+        /addCase\(fetchMenuGlobalMetadata\.rejected, state => \{\s*state\.menu_isLoading = false;\s*\}\)/
+    );
+    assert.match(
+        SRC,
+        /addCase\(fetchMenuSpecificMetadata\.rejected, state => \{\s*state\.menu_isLoading = false;\s*\}\);/
+    );
+});
+
+test('source contract: lowerCaseKey and guid are imported but not invoked anywhere in the slice body', () => {
+    // Guards against silent drift: if a future change starts actually using
+    // these helpers inside packageSlice's reducers/extraReducers, this test
+    // rig would need matching stand-ins added (it currently has none).
+    assert.match(SRC, /import \{ lowerCaseKey, guid, isNotUndefinedOrNull,/);
+    assert.equal(
+        (SRC.match(/\blowerCaseKey\(/g) || []).length,
+        0,
+        'lowerCaseKey is imported but must not be called anywhere in package.ts'
+    );
+    assert.equal(
+        (SRC.match(/\bguid\(/g) || []).length,
+        0,
+        'guid is imported but must not be called anywhere in package.ts'
+    );
+});

--- a/packages/lwc/applications/package/utils/__tests__/utils.test.ts
+++ b/packages/lwc/applications/package/utils/__tests__/utils.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { TEMPLATE } from '../utils.ts';
+
+test('TEMPLATE.BASIC is a string', () => {
+    assert.equal(typeof TEMPLATE.BASIC, 'string');
+});
+
+test('TEMPLATE.BASIC contains the {0} api version placeholder', () => {
+    assert.ok(TEMPLATE.BASIC.includes('{0}'));
+});
+
+test('TEMPLATE.BASIC contains the ApexClass metadata type name', () => {
+    assert.ok(TEMPLATE.BASIC.includes('<name>ApexClass</name>'));
+});
+
+test('TEMPLATE.BASIC is shaped like valid package.xml content', () => {
+    assert.match(TEMPLATE.BASIC, /<Package[ >]/);
+    assert.match(TEMPLATE.BASIC, /<\/Package>\s*$/);
+
+    const openCount = (TEMPLATE.BASIC.match(/</g) ?? []).length;
+    const closeCount = (TEMPLATE.BASIC.match(/>/g) ?? []).length;
+    assert.equal(openCount, closeCount);
+});

--- a/packages/lwc/applications/platformevent/slices/__tests__/platformEvent.test.ts
+++ b/packages/lwc/applications/platformevent/slices/__tests__/platformEvent.test.ts
@@ -1,0 +1,701 @@
+/**
+ * Slice-behavior tests for the platformevent `platformEvent` slice — focused
+ * on the entity-adapter reducers that manage per-channel subscriptions and
+ * their buffered messages.
+ *
+ * Why we don't import `../platformEvent.ts` directly
+ * ----------------------------------------------------
+ * The slice file imports `host-api/store` (for `ERROR`) and `core/store/storeRef`
+ * (for `getStore`). `host-api/store` transitively loads the full core store
+ * graph including LWC components decorated with `@api`/`@wire` — invalid
+ * syntax under plain Node, since this test runner only strips TypeScript
+ * types and cannot parse LWC decorator syntax. Importing the real module
+ * throws `SyntaxError: Invalid or unexpected token`. This has been verified
+ * empirically in this repo (see `agentforce/slices/__tests__/agents.test.ts`,
+ * which documents the same constraint).
+ *
+ * Pragmatic alternative: re-construct the same reducers the slice uses as a
+ * "faithful clone" built with `createSlice`/`createEntityAdapter` from
+ * `@reduxjs/toolkit` (the same library the real slice uses), and pin the
+ * clone's fidelity with "source contract" tests that `readFileSync` the real
+ * `../platformEvent.ts` and `assert.match` key lines/policies. Any drift
+ * between the clone and the real file gets caught by those contract tests.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import { createSlice, createEntityAdapter } from '@reduxjs/toolkit';
+
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(path.resolve(here, '../platformEvent.ts'), 'utf8');
+
+// ---------------------------------------------------------------------------
+// Test rig: faithful clone of the platformEvent slice's entity-adapter
+// reducers. MUST stay in sync with `../platformEvent.ts`. Each reducer below
+// mirrors the real implementation line-for-line; the "source contract" tests
+// at the bottom pin the real source against regexes so drift is caught.
+// ---------------------------------------------------------------------------
+
+// Minimal stand-in for `lowerCaseKey` from `shared/utils` (pure, no store dep).
+function lowerCaseKey(key: string | null | undefined): string | null {
+    return key != null ? key.toLowerCase() : null;
+}
+
+const testAdapter = createEntityAdapter();
+
+const initialState = {
+    recentPanelToggled: false,
+    viewerTab: 'Default',
+    maxMessagesPerChannel: 500,
+    subscriptions: testAdapter.getInitialState(),
+    currentChannel: null as string | null,
+};
+
+const testSlice = createSlice({
+    name: 'platformEventTest',
+    initialState,
+    reducers: {
+        updateMaxMessagesPerChannel: (
+            state,
+            action: { payload: { value: unknown; alias?: string } }
+        ) => {
+            const { value } = action.payload;
+            const parsed = parseInt(value as string, 10);
+            state.maxMessagesPerChannel = Number.isFinite(parsed) && parsed > 0 ? parsed : 500;
+        },
+        createSubscription: (
+            state,
+            action: {
+                payload: {
+                    channel: string;
+                    status?: string;
+                    name?: string;
+                    replayId?: number;
+                    type?: string;
+                };
+            }
+        ) => {
+            const { channel, status, name, replayId, type } = action.payload;
+            testAdapter.upsertOne(state.subscriptions, {
+                id: lowerCaseKey(channel),
+                name: name || channel,
+                type,
+                replayId,
+                error: null,
+                messages: [],
+                status,
+            });
+        },
+        deleteSubscription: (state, action: { payload: { channel: string } }) => {
+            const { channel } = action.payload;
+            // NOTE: unlike every sibling reducer, the real slice does NOT run
+            // `channel` through `lowerCaseKey` here — it removes by the raw
+            // value. In practice callers (app.ts) always pass an
+            // already-lowercased id (derived from `activeSubscriptions` keys,
+            // themselves built via `lowerCaseKey`), so this is safe today but
+            // is a latent inconsistency if a caller ever passes mixed case.
+            testAdapter.removeOne(state.subscriptions, channel);
+        },
+        updateSubscriptionStatus: (
+            state,
+            action: { payload: { channel: string; status?: string } }
+        ) => {
+            const { channel, status } = action.payload;
+            const existing =
+                (state.subscriptions.entities as any)[lowerCaseKey(channel) as string]?.messages ||
+                [];
+            testAdapter.upsertOne(state.subscriptions, {
+                id: lowerCaseKey(channel),
+                error: null,
+                messages: existing,
+                status,
+            });
+        },
+        cleanMessages: (state, action: { payload: { channel: string } }) => {
+            const { channel } = action.payload;
+            testAdapter.upsertOne(state.subscriptions, {
+                id: lowerCaseKey(channel),
+                error: null,
+                messages: [],
+            });
+        },
+        updateReadStatusOnSpecificMessage: (
+            state,
+            action: { payload: { channel: string; messageId: string } }
+        ) => {
+            const { channel, messageId } = action.payload;
+            const _messages = (state.subscriptions.entities as any)[lowerCaseKey(channel) as string]
+                .messages;
+            const _index = _messages.findIndex((x: any) => x.id === messageId);
+            if (_index > -1) {
+                _messages[_index].isRead = true;
+            }
+            testAdapter.upsertOne(state.subscriptions, {
+                id: lowerCaseKey(channel),
+                error: null,
+                messages: _messages,
+            });
+        },
+        upsertSubscriptionMessages: (
+            state,
+            action: { payload: { channel: string; messages: any[] } }
+        ) => {
+            const { channel, messages } = action.payload;
+            const cap = state.maxMessagesPerChannel || 500;
+
+            const existing =
+                (state.subscriptions.entities as any)[lowerCaseKey(channel) as string]?.messages ||
+                [];
+
+            const enrich = (m: any) => {
+                if (m && m._searchText) return m;
+                try {
+                    const content = m?.content || m;
+                    const replayId = content?.data?.event?.replayId ?? m?.id ?? '';
+                    const uuid = content?.data?.event?.EventUuid ?? '';
+                    const ch = content?.channel ?? channel ?? '';
+                    const json = JSON.stringify(content);
+                    const cappedJson = json.length > 10000 ? `${json.slice(0, 10000)}…` : json;
+                    return {
+                        ...m,
+                        _searchText: `${replayId} ${uuid} ${ch} ${cappedJson}`,
+                    };
+                } catch {
+                    return { ...m, _searchText: `${m?.id ?? ''} ${channel ?? ''}` };
+                }
+            };
+
+            testAdapter.upsertOne(state.subscriptions, {
+                id: lowerCaseKey(channel),
+                error: null,
+                lastModifiedDate: new Date(),
+                messages:
+                    cap > 0
+                        ? [...existing, ...messages.map(enrich)].slice(-cap)
+                        : [...existing, ...messages.map(enrich)],
+            });
+        },
+    },
+});
+
+function makeState(overrides: Partial<typeof initialState> = {}): typeof initialState {
+    return { ...initialState, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// updateMaxMessagesPerChannel
+// ---------------------------------------------------------------------------
+
+test('updateMaxMessagesPerChannel: accepts a valid positive numeric string', () => {
+    const before = makeState();
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.updateMaxMessagesPerChannel({ value: '1000' })
+    );
+    assert.equal(next.maxMessagesPerChannel, 1000);
+});
+
+test('updateMaxMessagesPerChannel: accepts a numeric value with trailing junk (parseInt semantics)', () => {
+    const before = makeState();
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.updateMaxMessagesPerChannel({ value: '250abc' })
+    );
+    assert.equal(next.maxMessagesPerChannel, 250);
+});
+
+for (const bad of ['-5', '0', 'not-a-number', '', null, undefined, NaN]) {
+    test(`updateMaxMessagesPerChannel: falls back to 500 for invalid input ${JSON.stringify(bad)}`, () => {
+        const before = makeState({ maxMessagesPerChannel: 42 });
+        const next = testSlice.reducer(
+            before,
+            testSlice.actions.updateMaxMessagesPerChannel({ value: bad as any })
+        );
+        assert.equal(next.maxMessagesPerChannel, 500);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// createSubscription
+// ---------------------------------------------------------------------------
+
+test('createSubscription: creates entity keyed by lowercased channel, with empty messages + null error', () => {
+    const before = makeState();
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.createSubscription({
+            channel: 'MyChannel',
+            status: 'SUBSCRIBED',
+            name: 'My Channel',
+            replayId: -1,
+            type: 'standard',
+        })
+    );
+    const entity = (next.subscriptions.entities as any)['mychannel'];
+    assert.ok(entity, 'entity must be keyed by lowercase channel id');
+    assert.deepEqual(entity.messages, []);
+    assert.equal(entity.error, null);
+    assert.equal(entity.status, 'SUBSCRIBED');
+    assert.equal(entity.name, 'My Channel');
+});
+
+test('createSubscription: channel is used as the name fallback when name is not provided', () => {
+    const before = makeState();
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.createSubscription({ channel: '/event/Foo__e', status: 'PENDING' })
+    );
+    const entity = (next.subscriptions.entities as any)['/event/foo__e'];
+    assert.equal(entity.name, '/event/Foo__e');
+});
+
+test('createSubscription: case-insensitive channel ids collide to the same entity', () => {
+    let state = makeState();
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'MyChannel', status: 'A' })
+    );
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'mychannel', status: 'B' })
+    );
+    assert.equal(
+        state.subscriptions.ids.length,
+        1,
+        'MyChannel and mychannel must resolve to a single entity'
+    );
+    assert.equal((state.subscriptions.entities as any)['mychannel'].status, 'B');
+});
+
+// ---------------------------------------------------------------------------
+// deleteSubscription
+// ---------------------------------------------------------------------------
+
+test('deleteSubscription: removes the entity when passed the already-lowercased id (matching real call sites)', () => {
+    let state = makeState();
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'ChannelX', status: 'SUBSCRIBED' })
+    );
+    assert.equal(state.subscriptions.ids.length, 1);
+
+    // createSubscription stored the entity under the lowercased id ('channelx').
+    // deleteSubscription does NOT lowercase its input (see reducer note above),
+    // so callers must pass the id already normalized — which is what app.ts does.
+    state = testSlice.reducer(state, testSlice.actions.deleteSubscription({ channel: 'channelx' }));
+    assert.equal(state.subscriptions.ids.length, 0);
+    assert.equal((state.subscriptions.entities as any)['channelx'], undefined);
+});
+
+test('deleteSubscription: does NOT remove the entity if passed a differently-cased channel (documents the missing lowerCaseKey call)', () => {
+    let state = makeState();
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'ChannelX', status: 'SUBSCRIBED' })
+    );
+    assert.equal(state.subscriptions.ids.length, 1);
+
+    // Unlike createSubscription/updateSubscriptionStatus/etc., deleteSubscription
+    // removes by the raw payload value. Passing mixed case here is a no-op,
+    // which would leak a subscription if a caller ever passed unnormalized input.
+    state = testSlice.reducer(state, testSlice.actions.deleteSubscription({ channel: 'CHANNELX' }));
+    assert.equal(
+        state.subscriptions.ids.length,
+        1,
+        'entity survives because the real reducer removes by raw (non-lowercased) channel'
+    );
+});
+
+// ---------------------------------------------------------------------------
+// updateSubscriptionStatus
+// ---------------------------------------------------------------------------
+
+test('updateSubscriptionStatus: preserves existing messages while updating status', () => {
+    let state = makeState();
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'ChannelY', status: 'PENDING' })
+    );
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.upsertSubscriptionMessages({
+            channel: 'ChannelY',
+            messages: [{ id: 'm1', content: { channel: '/event/Y' } }],
+        })
+    );
+    assert.equal((state.subscriptions.entities as any)['channely'].messages.length, 1);
+
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.updateSubscriptionStatus({ channel: 'ChannelY', status: 'SUBSCRIBED' })
+    );
+
+    const entity = (state.subscriptions.entities as any)['channely'];
+    assert.equal(entity.status, 'SUBSCRIBED');
+    assert.equal(entity.messages.length, 1, 'messages must NOT be wiped when only status changes');
+    assert.equal(entity.messages[0].id, 'm1');
+});
+
+test('updateSubscriptionStatus: defaults to empty messages when subscription did not previously exist', () => {
+    const before = makeState();
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.updateSubscriptionStatus({ channel: 'NewChannel', status: 'SUBSCRIBED' })
+    );
+    const entity = (next.subscriptions.entities as any)['newchannel'];
+    assert.deepEqual(entity.messages, []);
+    assert.equal(entity.status, 'SUBSCRIBED');
+});
+
+// ---------------------------------------------------------------------------
+// cleanMessages
+// ---------------------------------------------------------------------------
+
+test('cleanMessages: clears messages without deleting the subscription entity', () => {
+    let state = makeState();
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'ChannelZ', status: 'SUBSCRIBED' })
+    );
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.upsertSubscriptionMessages({
+            channel: 'ChannelZ',
+            messages: [{ id: 'm1' }, { id: 'm2' }],
+        })
+    );
+    assert.equal((state.subscriptions.entities as any)['channelz'].messages.length, 2);
+
+    state = testSlice.reducer(state, testSlice.actions.cleanMessages({ channel: 'ChannelZ' }));
+
+    assert.equal(state.subscriptions.ids.length, 1, 'entity must still exist');
+    assert.deepEqual((state.subscriptions.entities as any)['channelz'].messages, []);
+});
+
+// ---------------------------------------------------------------------------
+// updateReadStatusOnSpecificMessage
+// ---------------------------------------------------------------------------
+
+test('updateReadStatusOnSpecificMessage: marks the matching message as read', () => {
+    let state = makeState();
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'ChannelR', status: 'SUBSCRIBED' })
+    );
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.upsertSubscriptionMessages({
+            channel: 'ChannelR',
+            messages: [
+                { id: 'm1', isRead: false },
+                { id: 'm2', isRead: false },
+            ],
+        })
+    );
+
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.updateReadStatusOnSpecificMessage({
+            channel: 'ChannelR',
+            messageId: 'm2',
+        })
+    );
+
+    const messages = (state.subscriptions.entities as any)['channelr'].messages;
+    assert.equal(messages.find((m: any) => m.id === 'm1').isRead, false);
+    assert.equal(messages.find((m: any) => m.id === 'm2').isRead, true);
+});
+
+test('updateReadStatusOnSpecificMessage: leaves messages unmutated (and does not throw) when messageId is not found', () => {
+    let state = makeState();
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'ChannelR2', status: 'SUBSCRIBED' })
+    );
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.upsertSubscriptionMessages({
+            channel: 'ChannelR2',
+            messages: [{ id: 'm1', isRead: false }],
+        })
+    );
+
+    assert.doesNotThrow(() => {
+        state = testSlice.reducer(
+            state,
+            testSlice.actions.updateReadStatusOnSpecificMessage({
+                channel: 'ChannelR2',
+                messageId: 'does-not-exist',
+            })
+        );
+    });
+
+    const messages = (state.subscriptions.entities as any)['channelr2'].messages;
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].isRead, false, 'unmatched lookup must not mutate the message array');
+});
+
+// ---------------------------------------------------------------------------
+// upsertSubscriptionMessages
+// ---------------------------------------------------------------------------
+
+test('upsertSubscriptionMessages: appends enriched messages with a _searchText field', () => {
+    let state = makeState();
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'ChannelE', status: 'SUBSCRIBED' })
+    );
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.upsertSubscriptionMessages({
+            channel: 'ChannelE',
+            messages: [
+                {
+                    id: 'm1',
+                    content: {
+                        channel: '/event/Foo__e',
+                        data: { event: { replayId: 5, EventUuid: 'uuid-1' } },
+                    },
+                },
+            ],
+        })
+    );
+    const entity = (state.subscriptions.entities as any)['channele'];
+    assert.equal(entity.messages.length, 1);
+    assert.match(entity.messages[0]._searchText, /5 uuid-1 \/event\/Foo__e/);
+});
+
+test('upsertSubscriptionMessages: skips re-enrichment when a message already has _searchText', () => {
+    let state = makeState();
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'ChannelE2', status: 'SUBSCRIBED' })
+    );
+    const preEnriched = { id: 'm1', _searchText: 'already-enriched' };
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.upsertSubscriptionMessages({
+            channel: 'ChannelE2',
+            messages: [preEnriched],
+        })
+    );
+    const entity = (state.subscriptions.entities as any)['channele2'];
+    assert.equal(entity.messages[0]._searchText, 'already-enriched');
+});
+
+test('upsertSubscriptionMessages: truncates _searchText JSON payload at 10000 chars', () => {
+    let state = makeState();
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'ChannelBig', status: 'SUBSCRIBED' })
+    );
+    const bigPayload = { channel: '/event/Big__e', huge: 'x'.repeat(20000) };
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.upsertSubscriptionMessages({
+            channel: 'ChannelBig',
+            messages: [{ id: 'm1', content: bigPayload }],
+        })
+    );
+    const entity = (state.subscriptions.entities as any)['channelbig'];
+    // '…' is appended after truncation, so total length is 10000 (json slice) + 1 + surrounding fields.
+    assert.ok(
+        entity.messages[0]._searchText.includes('…'),
+        'truncated payload must be capped and marked with an ellipsis'
+    );
+});
+
+test('upsertSubscriptionMessages: enrich falls back gracefully if JSON.stringify throws (circular content)', () => {
+    let state = makeState();
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'ChannelCirc', status: 'SUBSCRIBED' })
+    );
+    const circular: any = { id: 'm1' };
+    circular.content = circular; // content.content === content -> circular via `content = m?.content || m`
+    circular.self = circular;
+
+    assert.doesNotThrow(() => {
+        state = testSlice.reducer(
+            state,
+            testSlice.actions.upsertSubscriptionMessages({
+                channel: 'ChannelCirc',
+                messages: [circular],
+            })
+        );
+    });
+    const entity = (state.subscriptions.entities as any)['channelcirc'];
+    assert.equal(entity.messages.length, 1);
+    assert.match(entity.messages[0]._searchText, /m1 ChannelCirc/);
+});
+
+test('upsertSubscriptionMessages: caps stored messages at maxMessagesPerChannel, dropping the OLDEST first', () => {
+    let state = makeState({ maxMessagesPerChannel: 3 });
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'ChannelCap', status: 'SUBSCRIBED' })
+    );
+
+    for (let i = 1; i <= 5; i++) {
+        state = testSlice.reducer(
+            state,
+            testSlice.actions.upsertSubscriptionMessages({
+                channel: 'ChannelCap',
+                messages: [{ id: `m${i}` }],
+            })
+        );
+    }
+
+    const entity = (state.subscriptions.entities as any)['channelcap'];
+    assert.equal(entity.messages.length, 3, 'must cap at maxMessagesPerChannel');
+    assert.deepEqual(
+        entity.messages.map((m: any) => m.id),
+        ['m3', 'm4', 'm5'],
+        'oldest messages (m1, m2) must be dropped, newest 3 retained'
+    );
+});
+
+test('upsertSubscriptionMessages: cap <= 0 means "no cap" (all messages retained)', () => {
+    let state = makeState({ maxMessagesPerChannel: 0 });
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'ChannelNoCap', status: 'SUBSCRIBED' })
+    );
+
+    for (let i = 1; i <= 10; i++) {
+        state = testSlice.reducer(
+            state,
+            testSlice.actions.upsertSubscriptionMessages({
+                channel: 'ChannelNoCap',
+                messages: [{ id: `m${i}` }],
+            })
+        );
+    }
+
+    const entity = (state.subscriptions.entities as any)['channelnocap'];
+    // Note: `cap = state.maxMessagesPerChannel || 500` means a *falsy* 0 becomes
+    // 500 in the real reducer (not "no cap") — this test rig mirrors that
+    // exactly. All 10 messages fit comfortably under 500, so all are retained.
+    assert.equal(entity.messages.length, 10, 'with cap falling back to 500, all 10 fit uncapped');
+});
+
+test('upsertSubscriptionMessages: negative cap falls back to 500 via `|| 500` (not treated as "no cap")', () => {
+    // `state.maxMessagesPerChannel || 500` only falls back on falsy (0/null/undefined),
+    // so a negative value survives as `cap`, and `cap > 0` is false -> "no cap" branch.
+    let state = makeState({ maxMessagesPerChannel: -1 });
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'ChannelNeg', status: 'SUBSCRIBED' })
+    );
+    for (let i = 1; i <= 4; i++) {
+        state = testSlice.reducer(
+            state,
+            testSlice.actions.upsertSubscriptionMessages({
+                channel: 'ChannelNeg',
+                messages: [{ id: `m${i}` }],
+            })
+        );
+    }
+    const entity = (state.subscriptions.entities as any)['channelneg'];
+    assert.equal(
+        entity.messages.length,
+        4,
+        'negative cap takes the `cap > 0` false branch (no slicing), so all messages are retained'
+    );
+});
+
+test('upsertSubscriptionMessages: appends onto existing messages from a prior dispatch (does not overwrite)', () => {
+    let state = makeState({ maxMessagesPerChannel: 500 });
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.createSubscription({ channel: 'ChannelAppend', status: 'SUBSCRIBED' })
+    );
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.upsertSubscriptionMessages({
+            channel: 'ChannelAppend',
+            messages: [{ id: 'm1' }],
+        })
+    );
+    state = testSlice.reducer(
+        state,
+        testSlice.actions.upsertSubscriptionMessages({
+            channel: 'ChannelAppend',
+            messages: [{ id: 'm2' }],
+        })
+    );
+    const entity = (state.subscriptions.entities as any)['channelappend'];
+    assert.deepEqual(
+        entity.messages.map((m: any) => m.id),
+        ['m1', 'm2']
+    );
+});
+
+// ---------------------------------------------------------------------------
+// Source contract tests — pin the real `../platformEvent.ts` against regexes
+// so drift between this clone and the real implementation is caught.
+// ---------------------------------------------------------------------------
+
+test('source contract: updateMaxMessagesPerChannel parses with parseInt and falls back to 500', () => {
+    assert.match(
+        SRC,
+        /updateMaxMessagesPerChannel:[\s\S]+?parseInt\(value, 10\)[\s\S]+?Number\.isFinite\(parsed\) && parsed > 0 \? parsed : 500/
+    );
+});
+
+test('source contract: createSubscription upserts keyed by lowerCaseKey(channel) with empty messages + null error', () => {
+    assert.match(
+        SRC,
+        /createSubscription:[\s\S]+?upsertOne\(state\.subscriptions, \{[\s\S]+?id: lowerCaseKey\(channel\)[\s\S]+?error: null,\s*\n\s*messages: \[\],/
+    );
+});
+
+test('source contract: deleteSubscription removes by the raw channel (NOT lowerCaseKey) — pins the current asymmetry vs. sibling reducers', () => {
+    // Every other entity-adapter reducer in this slice keys via
+    // `lowerCaseKey(channel)`. deleteSubscription is the one exception —
+    // it removes by the raw payload value. This test pins that fact so a
+    // future "fix" (adding lowerCaseKey here) is a deliberate, reviewed
+    // change rather than accidental drift, since callers today rely on
+    // pre-normalized ids.
+    assert.match(SRC, /deleteSubscription:[\s\S]+?removeOne\(state\.subscriptions, channel\);/);
+});
+
+test('source contract: updateSubscriptionStatus preserves existing messages before upserting', () => {
+    assert.match(
+        SRC,
+        /updateSubscriptionStatus:[\s\S]+?const existing = state\.subscriptions\.entities\[lowerCaseKey\(channel\)\]\?\.messages \|\| \[\];[\s\S]+?messages: existing,/
+    );
+});
+
+test('source contract: cleanMessages upserts with an empty messages array', () => {
+    assert.match(
+        SRC,
+        /cleanMessages:[\s\S]+?upsertOne\(state\.subscriptions, \{[\s\S]+?messages: \[\],/
+    );
+});
+
+test('source contract: updateReadStatusOnSpecificMessage uses findIndex + `_index > -1` guard', () => {
+    assert.match(
+        SRC,
+        /updateReadStatusOnSpecificMessage:[\s\S]+?findIndex\(x => x\.id === messageId\);\s*\n\s*if \(_index > -1\) \{\s*\n\s*_messages\[_index\]\.isRead = true;/
+    );
+});
+
+test('source contract: upsertSubscriptionMessages caps via `cap > 0 ? ... .slice(-cap) : ...` ternary', () => {
+    assert.match(
+        SRC,
+        /cap > 0\s*\n\s*\? \[\.\.\.existing, \.\.\.messages\.map\(enrich\)\]\.slice\(-cap\)\s*\n\s*: \[\.\.\.existing, \.\.\.messages\.map\(enrich\)\]/
+    );
+});
+
+test('source contract: upsertSubscriptionMessages derives cap via `state.maxMessagesPerChannel || 500`', () => {
+    assert.match(SRC, /const cap = state\.maxMessagesPerChannel \|\| 500;/);
+});
+
+test('source contract: enrich caps _searchText JSON payload at 10000 chars and wraps in try/catch', () => {
+    assert.match(SRC, /json\.length > 10000 \? `\$\{json\.slice\(0, 10000\)\}…` : json/);
+    assert.match(SRC, /const enrich = m => \{[\s\S]+?try \{[\s\S]+?\} catch \{/);
+});

--- a/packages/lwc/applications/recordviewer/slices/__tests__/recordViewer.test.ts
+++ b/packages/lwc/applications/recordviewer/slices/__tests__/recordViewer.test.ts
@@ -1,0 +1,484 @@
+/**
+ * Slice-behavior tests for the recordviewer `recordViewer` slice.
+ *
+ * Why we don't import `../recordViewer.ts` directly
+ * -------------------------------------------
+ * The slice file imports `host-api/store`, which transitively loads the
+ * full core store graph including LWC components decorated with `@api`
+ * (invalid syntax under plain Node — the test runner can't parse them).
+ * Stubbing `host-api/store` via an ESM resolver hook from the test file
+ * is unreliable because `module.register()` and dynamic-import scheduling
+ * race with the existing tsconfig-paths resolver.
+ *
+ * Pragmatic alternative: re-construct the same `reducers` the slice uses
+ * (a faithful clone built with `createSlice`), and pin the behavior
+ * contract here. Any drift between this test and `../recordViewer.ts` will
+ * be caught in code review AND by the "source contract" tests below, which
+ * `readFileSync` the real source and regex-match key lines. This mirrors
+ * the pattern established in
+ * `packages/lwc/applications/agentforce/slices/__tests__/agents.test.ts`.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createSlice } from '@reduxjs/toolkit';
+
+// ---------------------------------------------------------------------------
+// In-memory localStorage stub — plain Node has no `localStorage` global.
+// Only used by the loadCacheSettings/saveCacheSettings behavior tests.
+// ---------------------------------------------------------------------------
+
+function makeLocalStorageStub() {
+    const backing = new Map<string, string>();
+    return {
+        getItem(key: string) {
+            return backing.has(key) ? backing.get(key)! : null;
+        },
+        setItem(key: string, value: string) {
+            backing.set(key, value);
+        },
+        removeItem(key: string) {
+            backing.delete(key);
+        },
+        clear() {
+            backing.clear();
+        },
+        _backing: backing,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Test rig: faithful clone of the recordviewer slice.
+// MUST stay in sync with `slices/recordViewer.ts`. The "source contract"
+// tests below pin the real source text so drift is caught.
+// ---------------------------------------------------------------------------
+
+const RECORDVIEWER_SETTINGS_KEY = 'RECORDVIEWER_SETTINGS_KEY';
+
+function isNotUndefinedOrNull(value: unknown): boolean {
+    return value !== undefined && value !== null;
+}
+
+function loadCacheSettingsClone(alias: string) {
+    try {
+        const configText = (globalThis as any).localStorage.getItem(
+            `${alias}-${RECORDVIEWER_SETTINGS_KEY}`
+        );
+        if (configText) return JSON.parse(configText);
+    } catch (e) {
+        // Real slice dispatches ERROR.reduxSlice.actions.addError here — omitted
+        // in the clone since we can't import host-api/store (see file header).
+    }
+    return null;
+}
+
+function saveCacheSettingsClone(alias: string, state: any) {
+    try {
+        const { tabs, recentPanelToggled } = state;
+        (globalThis as any).localStorage.setItem(
+            `${alias}-${RECORDVIEWER_SETTINGS_KEY}`,
+            JSON.stringify({ tabs, recentPanelToggled })
+        );
+    } catch (e) {
+        // Real slice dispatches ERROR.reduxSlice.actions.addError here — omitted
+        // in the clone since we can't import host-api/store (see file header).
+    }
+}
+
+export const formatTabClone = (payload: Record<string, unknown>) => {
+    const validParams = ['id', 'refreshedDate', 'record', 'recordType'];
+    const tab: Record<string, unknown> = {};
+    validParams.forEach(key => {
+        if (key in payload && payload[key] !== undefined) {
+            tab[key] = payload[key];
+        }
+    });
+    return tab;
+};
+
+const initialState = {
+    tabs: [] as any[],
+    currentTab: null as any,
+    recentPanelToggled: false,
+};
+
+const testSlice = createSlice({
+    name: 'recordViewerTest',
+    initialState,
+    reducers: {
+        loadCacheSettings: (state, action: { payload: { alias: string } }) => {
+            const { alias } = action.payload;
+            const cachedConfig = loadCacheSettingsClone(alias);
+            if (cachedConfig) {
+                const { tabs, recentPanelToggled } = cachedConfig;
+                Object.assign(state, { tabs, recentPanelToggled });
+            }
+        },
+        saveCacheSettings: (state, action: { payload: { alias?: string } }) => {
+            const { alias } = action.payload;
+            if (isNotUndefinedOrNull(alias)) {
+                saveCacheSettingsClone(alias as string, state);
+            }
+        },
+        updateRecentPanel: (state, action: { payload: { value: unknown; alias?: string } }) => {
+            const { value, alias } = action.payload;
+            state.recentPanelToggled = value === true;
+            if (isNotUndefinedOrNull(alias)) {
+                saveCacheSettingsClone(alias as string, state);
+            }
+        },
+        upsertTab: (state, action: { payload: { tab: any } }) => {
+            const { tab } = action.payload;
+            const indexTab = state.tabs.findIndex(x => x.id === tab.id);
+            if (indexTab < 0) {
+                state.tabs.push(tab);
+                state.currentTab = tab;
+            } else {
+                const originalTab = state.tabs.find(x => x.id === tab.id);
+                const newTab = Object.assign(originalTab, tab);
+                state.tabs[indexTab] = newTab;
+                state.currentTab = newTab;
+            }
+        },
+        removeTab: (state, action: { payload: { id: any; alias?: string } }) => {
+            const { id, alias } = action.payload;
+            state.tabs = state.tabs.filter(x => x.id != id);
+            // eslint-disable-next-line eqeqeq
+            if (state.tabs.length > 0 && state.currentTab.id == id) {
+                const lastTab = state.tabs[state.tabs.length - 1];
+                state.currentTab = lastTab;
+            }
+            if (state.tabs.length == 0) {
+                state.currentTab = null;
+            }
+            if (isNotUndefinedOrNull(alias)) {
+                saveCacheSettingsClone(alias as string, state);
+            }
+        },
+        selectionTab: (state, action: { payload: { id: any } }) => {
+            const { id } = action.payload;
+            // eslint-disable-next-line eqeqeq
+            const tab = state.tabs.find(x => x.id == id);
+            if (tab) {
+                state.currentTab = tab;
+            }
+        },
+    },
+});
+
+function makeState(overrides: Partial<typeof initialState> = {}) {
+    return { ...initialState, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// formatTab
+// ---------------------------------------------------------------------------
+
+test('formatTab: whitelist-copies only id, refreshedDate, record, recordType', () => {
+    const result = formatTabClone({
+        id: '1',
+        refreshedDate: '2026-08-08',
+        record: { Name: 'Acme' },
+        recordType: '012',
+        extraneous: 'should be dropped',
+        anotherOne: 42,
+    });
+
+    assert.deepEqual(result, {
+        id: '1',
+        refreshedDate: '2026-08-08',
+        record: { Name: 'Acme' },
+        recordType: '012',
+    });
+});
+
+test('formatTab: drops whitelisted keys whose value is undefined', () => {
+    const result = formatTabClone({
+        id: '1',
+        refreshedDate: undefined,
+        record: { Name: 'Acme' },
+    });
+
+    assert.deepEqual(result, { id: '1', record: { Name: 'Acme' } });
+    assert.ok(!('refreshedDate' in result), 'undefined-valued whitelisted key must be excluded');
+});
+
+test('formatTab: returns empty object when payload has no whitelisted keys', () => {
+    const result = formatTabClone({ foo: 'bar' });
+    assert.deepEqual(result, {});
+});
+
+// ---------------------------------------------------------------------------
+// updateRecentPanel
+// ---------------------------------------------------------------------------
+
+test('updateRecentPanel: sets recentPanelToggled true only for strict boolean true', () => {
+    const before = makeState({ recentPanelToggled: false });
+    const next = testSlice.reducer(before, testSlice.actions.updateRecentPanel({ value: true }));
+    assert.equal(next.recentPanelToggled, true);
+});
+
+test('updateRecentPanel: coerces truthy-but-not-strictly-true values to false', () => {
+    for (const truthy of ['true', 1, {}, [], 'yes']) {
+        const before = makeState({ recentPanelToggled: true });
+        const next = testSlice.reducer(
+            before,
+            testSlice.actions.updateRecentPanel({ value: truthy })
+        );
+        assert.equal(
+            next.recentPanelToggled,
+            false,
+            `value ${JSON.stringify(truthy)} must coerce to false (strict === true check)`
+        );
+    }
+});
+
+test('updateRecentPanel: sets recentPanelToggled false for false', () => {
+    const before = makeState({ recentPanelToggled: true });
+    const next = testSlice.reducer(before, testSlice.actions.updateRecentPanel({ value: false }));
+    assert.equal(next.recentPanelToggled, false);
+});
+
+// ---------------------------------------------------------------------------
+// upsertTab
+// ---------------------------------------------------------------------------
+
+test('upsertTab: inserts a new tab and sets it as currentTab', () => {
+    const before = makeState();
+    const tab = { id: 't1', record: { Name: 'Acme' } };
+    const next = testSlice.reducer(before, testSlice.actions.upsertTab({ tab }));
+
+    assert.deepEqual(next.tabs, [tab]);
+    assert.deepEqual(next.currentTab, tab);
+});
+
+test('upsertTab: merges into an existing tab by id, preserving unspecified fields', () => {
+    const existing = { id: 't1', record: { Name: 'Acme' }, recordType: '012' };
+    const before = makeState({ tabs: [existing], currentTab: existing });
+
+    const update = { id: 't1', refreshedDate: '2026-08-08' };
+    const next = testSlice.reducer(before, testSlice.actions.upsertTab({ tab: update }));
+
+    assert.equal(next.tabs.length, 1);
+    assert.deepEqual(next.tabs[0], {
+        id: 't1',
+        record: { Name: 'Acme' },
+        recordType: '012',
+        refreshedDate: '2026-08-08',
+    });
+    assert.deepEqual(next.currentTab, next.tabs[0]);
+});
+
+// ---------------------------------------------------------------------------
+// removeTab
+// ---------------------------------------------------------------------------
+
+test('removeTab: removing the current tab reassigns currentTab to the new last tab', () => {
+    const tabA = { id: 'a' };
+    const tabB = { id: 'b' };
+    const before = makeState({ tabs: [tabA, tabB], currentTab: tabB });
+
+    const next = testSlice.reducer(before, testSlice.actions.removeTab({ id: 'b' }));
+
+    assert.deepEqual(next.tabs, [tabA]);
+    assert.deepEqual(next.currentTab, tabA);
+});
+
+test('removeTab: removing a non-current tab leaves currentTab untouched', () => {
+    const tabA = { id: 'a' };
+    const tabB = { id: 'b' };
+    const before = makeState({ tabs: [tabA, tabB], currentTab: tabB });
+
+    const next = testSlice.reducer(before, testSlice.actions.removeTab({ id: 'a' }));
+
+    assert.deepEqual(next.tabs, [tabB]);
+    assert.deepEqual(
+        next.currentTab,
+        tabB,
+        'currentTab must be untouched when a non-current tab is removed'
+    );
+});
+
+test('removeTab: sets currentTab to null when tabs becomes empty', () => {
+    const tabA = { id: 'a' };
+    const before = makeState({ tabs: [tabA], currentTab: tabA });
+
+    const next = testSlice.reducer(before, testSlice.actions.removeTab({ id: 'a' }));
+
+    assert.deepEqual(next.tabs, []);
+    assert.equal(next.currentTab, null);
+});
+
+// ---------------------------------------------------------------------------
+// selectionTab
+// ---------------------------------------------------------------------------
+
+test('selectionTab: sets currentTab when a matching tab is found', () => {
+    const tabA = { id: 'a' };
+    const tabB = { id: 'b' };
+    const before = makeState({ tabs: [tabA, tabB], currentTab: tabA });
+
+    const next = testSlice.reducer(before, testSlice.actions.selectionTab({ id: 'b' }));
+
+    assert.deepEqual(next.currentTab, tabB);
+});
+
+test('selectionTab: leaves currentTab unchanged when no tab matches', () => {
+    const tabA = { id: 'a' };
+    const before = makeState({ tabs: [tabA], currentTab: tabA });
+
+    const next = testSlice.reducer(
+        before,
+        testSlice.actions.selectionTab({ id: 'does-not-exist' })
+    );
+
+    assert.deepEqual(next.currentTab, tabA);
+});
+
+// ---------------------------------------------------------------------------
+// loadCacheSettings / saveCacheSettings — exercised via a stubbed localStorage
+// ---------------------------------------------------------------------------
+
+test('saveCacheSettings then loadCacheSettings: persists tabs + recentPanelToggled, NOT currentTab', () => {
+    const originalLocalStorage = (globalThis as any).localStorage;
+    (globalThis as any).localStorage = makeLocalStorageStub();
+    try {
+        const tabs = [{ id: 't1', record: { Name: 'Acme' } }];
+        const before = makeState({ tabs, currentTab: tabs[0], recentPanelToggled: true });
+
+        const afterSave = testSlice.reducer(
+            before,
+            testSlice.actions.saveCacheSettings({ alias: 'myOrg' })
+        );
+
+        // saveCacheSettings does not itself mutate state; confirm it round-trips.
+        assert.deepEqual(afterSave, before);
+
+        const raw = (globalThis as any).localStorage.getItem(`myOrg-${RECORDVIEWER_SETTINGS_KEY}`);
+        assert.ok(raw, 'expected settings to be persisted to localStorage');
+        const parsed = JSON.parse(raw);
+        assert.deepEqual(parsed, { tabs, recentPanelToggled: true });
+        assert.ok(!('currentTab' in parsed), 'currentTab must NOT be persisted');
+
+        // Now reload into a fresh (empty) state and confirm it restores tabs +
+        // recentPanelToggled, but currentTab is untouched by the load.
+        const fresh = makeState({ currentTab: { id: 'sentinel' } });
+        const afterLoad = testSlice.reducer(
+            fresh,
+            testSlice.actions.loadCacheSettings({ alias: 'myOrg' })
+        );
+
+        assert.deepEqual(afterLoad.tabs, tabs);
+        assert.equal(afterLoad.recentPanelToggled, true);
+        assert.deepEqual(
+            afterLoad.currentTab,
+            { id: 'sentinel' },
+            'loadCacheSettings must not touch currentTab (not part of the cached shape)'
+        );
+    } finally {
+        (globalThis as any).localStorage = originalLocalStorage;
+    }
+});
+
+test('loadCacheSettings: no-op when nothing cached for the alias', () => {
+    const originalLocalStorage = (globalThis as any).localStorage;
+    (globalThis as any).localStorage = makeLocalStorageStub();
+    try {
+        const before = makeState({ tabs: [{ id: 'keep-me' }] });
+        const next = testSlice.reducer(
+            before,
+            testSlice.actions.loadCacheSettings({ alias: 'unseen-alias' })
+        );
+        assert.deepEqual(
+            next.tabs,
+            [{ id: 'keep-me' }],
+            'state must be untouched when cache is empty'
+        );
+    } finally {
+        (globalThis as any).localStorage = originalLocalStorage;
+    }
+});
+
+test('updateRecentPanel: persists via saveCacheSettings when alias is provided', () => {
+    const originalLocalStorage = (globalThis as any).localStorage;
+    (globalThis as any).localStorage = makeLocalStorageStub();
+    try {
+        const before = makeState({ tabs: [], recentPanelToggled: false });
+        testSlice.reducer(
+            before,
+            testSlice.actions.updateRecentPanel({ value: true, alias: 'myOrg' })
+        );
+
+        const raw = (globalThis as any).localStorage.getItem(`myOrg-${RECORDVIEWER_SETTINGS_KEY}`);
+        assert.ok(raw, 'updateRecentPanel with an alias must persist settings');
+        assert.deepEqual(JSON.parse(raw), { tabs: [], recentPanelToggled: true });
+    } finally {
+        (globalThis as any).localStorage = originalLocalStorage;
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Source contract — pin key lines of the real slice so drift is caught.
+// ---------------------------------------------------------------------------
+
+test('source contract: recordViewer.ts wires the documented reducer names and checks', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const src = fs.readFileSync(path.resolve(here, '../recordViewer.ts'), 'utf8');
+
+    // formatTab whitelist.
+    assert.match(
+        src,
+        /const validParams = \['id', 'refreshedDate', 'record', 'recordType'\];/,
+        'formatTab whitelist must be id, refreshedDate, record, recordType'
+    );
+    assert.match(src, /if \(key in payload && payload\[key\] !== undefined\)/);
+
+    // initialState shape.
+    assert.match(src, /tabs: \[\],/);
+    assert.match(src, /currentTab: null,/);
+    assert.match(src, /recentPanelToggled: false,/);
+
+    // updateRecentPanel: strict === true check.
+    assert.match(
+        src,
+        /updateRecentPanel:[\s\S]+?state\.recentPanelToggled = value === true;/,
+        'updateRecentPanel must use a strict === true check'
+    );
+
+    // upsertTab: insert-or-merge by id.
+    assert.match(src, /upsertTab:[\s\S]+?state\.tabs\.findIndex\(x => x\.id === tab\.id\)/);
+    assert.match(src, /upsertTab:[\s\S]+?Object\.assign\(originalTab, tab\)/);
+
+    // removeTab: reducer name is `removeTab`, reassigns currentTab only if it
+    // WAS the removed tab (non-strict `==`), and nulls out when tabs is empty.
+    assert.match(
+        src,
+        /removeTab:[\s\S]+?state\.tabs\.length > 0 && state\.currentTab\.id == id/,
+        'removeTab must only reassign currentTab if the removed tab was the current one'
+    );
+    assert.match(
+        src,
+        /removeTab:[\s\S]+?state\.tabs\.length == 0\) \{\s*state\.currentTab = null;/
+    );
+
+    // selectionTab (NOT selectTab): find-by-id with `==`, no-op if not found.
+    assert.match(
+        src,
+        /selectionTab: \(state, action\) => \{/,
+        'reducer must be named selectionTab'
+    );
+    assert.match(src, /selectionTab:[\s\S]+?state\.tabs\.find\(x => x\.id == id\)/);
+
+    // recentPanelToggled + updateRecentPanel exist (extra field vs. sobjectExplorer sibling).
+    assert.match(src, /updateRecentPanel: \(state, action\) => \{/);
+
+    // saveCacheSettings persists tabs + recentPanelToggled, NOT currentTab.
+    assert.match(
+        src,
+        /const \{ tabs, recentPanelToggled \} = state;[\s\S]+?JSON\.stringify\(\{\s*tabs,\s*recentPanelToggled,?\s*\}\)/,
+        'saveCacheSettings must persist only tabs + recentPanelToggled'
+    );
+});

--- a/packages/lwc/applications/soql/__tests__/describeResolver.test.ts
+++ b/packages/lwc/applications/soql/__tests__/describeResolver.test.ts
@@ -1,0 +1,199 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+    getDescribeEntriesByName,
+    getDescribeByName,
+    getDescribeByPrefix,
+    getAllDescribeEntries,
+} from '../describeResolver.ts';
+
+test('soql/getDescribeEntriesByName: returns [] when describeState is null/undefined', () => {
+    assert.deepEqual(getDescribeEntriesByName(null, 'Account'), []);
+    assert.deepEqual(getDescribeEntriesByName(undefined, 'Account'), []);
+});
+
+test('soql/getDescribeEntriesByName: returns [] when sobjectName is missing', () => {
+    const describeState = { nameEntriesMap: { account: [{ name: 'Account' }] } };
+    assert.deepEqual(getDescribeEntriesByName(describeState, null), []);
+    assert.deepEqual(getDescribeEntriesByName(describeState, undefined), []);
+    assert.deepEqual(getDescribeEntriesByName(describeState, ''), []);
+});
+
+test('soql/getDescribeEntriesByName: looks up nameEntriesMap case-insensitively', () => {
+    const entry = { name: 'Account', useToolingApi: false };
+    const describeState = { nameEntriesMap: { account: [entry] } };
+    assert.deepEqual(getDescribeEntriesByName(describeState, 'ACCOUNT'), [entry]);
+    assert.deepEqual(getDescribeEntriesByName(describeState, 'Account'), [entry]);
+});
+
+test('soql/getDescribeEntriesByName: returns [] when the entries array is empty and there is no legacy entry', () => {
+    const describeState = { nameEntriesMap: { account: [] }, nameMap: {} };
+    assert.deepEqual(getDescribeEntriesByName(describeState, 'Account'), []);
+});
+
+test('soql/getDescribeEntriesByName: falls back to the legacy nameMap entry when nameEntriesMap has none', () => {
+    const legacyEntry = { name: 'Account', useToolingApi: false };
+    const describeState = { nameEntriesMap: { account: [] }, nameMap: { account: legacyEntry } };
+    assert.deepEqual(getDescribeEntriesByName(describeState, 'Account'), [legacyEntry]);
+});
+
+test('soql/getDescribeEntriesByName: falls back to the legacy entry when nameEntriesMap is missing entirely', () => {
+    const legacyEntry = { name: 'Account', useToolingApi: false };
+    const describeState = { nameMap: { account: legacyEntry } };
+    assert.deepEqual(getDescribeEntriesByName(describeState, 'Account'), [legacyEntry]);
+});
+
+test('soql/getDescribeEntriesByName: does not duplicate the legacy entry when a matching name+useToolingApi entry already exists', () => {
+    const entry = { name: 'Account', useToolingApi: false, source: 'entries' };
+    const legacyEntry = { name: 'Account', useToolingApi: false, source: 'legacy' };
+    const describeState = {
+        nameEntriesMap: { account: [entry] },
+        nameMap: { account: legacyEntry },
+    };
+    assert.deepEqual(getDescribeEntriesByName(describeState, 'Account'), [entry]);
+});
+
+test('soql/getDescribeEntriesByName: appends the legacy entry when its useToolingApi differs from any existing entry', () => {
+    const entry = { name: 'Account', useToolingApi: false };
+    const legacyEntry = { name: 'Account', useToolingApi: true };
+    const describeState = {
+        nameEntriesMap: { account: [entry] },
+        nameMap: { account: legacyEntry },
+    };
+    assert.deepEqual(getDescribeEntriesByName(describeState, 'Account'), [entry, legacyEntry]);
+});
+
+test('soql/getDescribeEntriesByName: filters out falsy entries from nameEntriesMap groups', () => {
+    const entry = { name: 'Account', useToolingApi: false };
+    const describeState = { nameEntriesMap: { account: [entry, null, undefined] } };
+    assert.deepEqual(getDescribeEntriesByName(describeState, 'Account'), [entry]);
+});
+
+test('soql/getDescribeByName: returns null when there are no entries', () => {
+    assert.equal(getDescribeByName({ describeState: null, sobjectName: 'Account' }), null);
+    const describeState = { nameEntriesMap: { account: [] } };
+    assert.equal(getDescribeByName({ describeState, sobjectName: 'Account' }), null);
+});
+
+test('soql/getDescribeByName: useToolingApi true prefers the tooling entry', () => {
+    const standardEntry = { name: 'Account', useToolingApi: false };
+    const toolingEntry = { name: 'Account', useToolingApi: true };
+    const describeState = { nameEntriesMap: { account: [standardEntry, toolingEntry] } };
+    assert.equal(
+        getDescribeByName({ describeState, sobjectName: 'Account', useToolingApi: true }),
+        toolingEntry
+    );
+});
+
+test('soql/getDescribeByName: useToolingApi true falls back to the first entry when no tooling entry exists', () => {
+    const standardEntry = { name: 'Account', useToolingApi: false };
+    const otherEntry = { name: 'Account', useToolingApi: false, tag: 'second' };
+    const describeState = { nameEntriesMap: { account: [standardEntry, otherEntry] } };
+    assert.equal(
+        getDescribeByName({ describeState, sobjectName: 'Account', useToolingApi: true }),
+        standardEntry
+    );
+});
+
+test('soql/getDescribeByName: useToolingApi false/undefined prefers the non-tooling entry', () => {
+    const toolingEntry = { name: 'Account', useToolingApi: true };
+    const standardEntry = { name: 'Account', useToolingApi: false };
+    const describeState = { nameEntriesMap: { account: [toolingEntry, standardEntry] } };
+    assert.equal(
+        getDescribeByName({ describeState, sobjectName: 'Account', useToolingApi: false }),
+        standardEntry
+    );
+    assert.equal(getDescribeByName({ describeState, sobjectName: 'Account' }), standardEntry);
+});
+
+test('soql/getDescribeByName: useToolingApi false falls back to the first entry when every entry is a tooling entry', () => {
+    const toolingEntry = { name: 'Account', useToolingApi: true };
+    const otherToolingEntry = { name: 'Account', useToolingApi: true, tag: 'second' };
+    const describeState = { nameEntriesMap: { account: [toolingEntry, otherToolingEntry] } };
+    assert.equal(
+        getDescribeByName({ describeState, sobjectName: 'Account', useToolingApi: false }),
+        toolingEntry
+    );
+});
+
+test('soql/getDescribeByPrefix: returns null when describeState or idPrefix is missing', () => {
+    assert.equal(getDescribeByPrefix({ describeState: null, idPrefix: '001' }), null);
+    assert.equal(getDescribeByPrefix({ describeState: {}, idPrefix: null }), null);
+    assert.equal(getDescribeByPrefix({ describeState: {}, idPrefix: '' }), null);
+});
+
+test('soql/getDescribeByPrefix: looks up prefixEntriesMap case-insensitively', () => {
+    const entry = { name: 'Account', useToolingApi: false };
+    const describeState = { prefixEntriesMap: { '001': [entry] } };
+    assert.equal(getDescribeByPrefix({ describeState, idPrefix: '001' }), entry);
+});
+
+test('soql/getDescribeByPrefix: falls back to the legacy prefixMap entry and dedups on name+useToolingApi', () => {
+    const entry = { name: 'Account', useToolingApi: false, source: 'entries' };
+    const legacyEntry = { name: 'Account', useToolingApi: false, source: 'legacy' };
+    const describeState = {
+        prefixEntriesMap: { '001': [entry] },
+        prefixMap: { '001': legacyEntry },
+    };
+    assert.equal(getDescribeByPrefix({ describeState, idPrefix: '001' }), entry);
+});
+
+test('soql/getDescribeByPrefix: honors useToolingApi preference over the merged legacy entry', () => {
+    const standardEntry = { name: 'Account', useToolingApi: false };
+    const legacyToolingEntry = { name: 'Account', useToolingApi: true };
+    const describeState = {
+        prefixEntriesMap: { '001': [standardEntry] },
+        prefixMap: { '001': legacyToolingEntry },
+    };
+    assert.equal(
+        getDescribeByPrefix({ describeState, idPrefix: '001', useToolingApi: true }),
+        legacyToolingEntry
+    );
+    assert.equal(
+        getDescribeByPrefix({ describeState, idPrefix: '001', useToolingApi: false }),
+        standardEntry
+    );
+});
+
+test('soql/getAllDescribeEntries: returns [] when describeState is null/undefined', () => {
+    assert.deepEqual(getAllDescribeEntries(null), []);
+    assert.deepEqual(getAllDescribeEntries(undefined), []);
+});
+
+test('soql/getAllDescribeEntries: flattens every group in nameEntriesMap', () => {
+    const accountEntry = { name: 'Account' };
+    const contactEntry1 = { name: 'Contact', useToolingApi: false };
+    const contactEntry2 = { name: 'Contact', useToolingApi: true };
+    const describeState = {
+        nameEntriesMap: {
+            account: [accountEntry],
+            contact: [contactEntry1, contactEntry2],
+        },
+    };
+    assert.deepEqual(getAllDescribeEntries(describeState), [
+        accountEntry,
+        contactEntry1,
+        contactEntry2,
+    ]);
+});
+
+test('soql/getAllDescribeEntries: falls back to nameMap values when nameEntriesMap is empty', () => {
+    const legacyAccount = { name: 'Account' };
+    const legacyContact = { name: 'Contact' };
+    const describeState = {
+        nameEntriesMap: { account: [], contact: [] },
+        nameMap: { account: legacyAccount, contact: legacyContact },
+    };
+    assert.deepEqual(getAllDescribeEntries(describeState), [legacyAccount, legacyContact]);
+});
+
+test('soql/getAllDescribeEntries: falls back to nameMap values when nameEntriesMap is missing entirely', () => {
+    const legacyAccount = { name: 'Account' };
+    const describeState = { nameMap: { account: legacyAccount } };
+    assert.deepEqual(getAllDescribeEntries(describeState), [legacyAccount]);
+});
+
+test('soql/getAllDescribeEntries: returns [] when both maps are missing', () => {
+    assert.deepEqual(getAllDescribeEntries({}), []);
+});

--- a/packages/lwc/applications/soql/app/__tests__/util.test.ts
+++ b/packages/lwc/applications/soql/app/__tests__/util.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Unit tests for the pure helpers in `../util.ts`.
+ *
+ * Why we don't import `../util.ts` directly
+ * ------------------------------------------
+ * The file imports `store` from `host-api/store` and `LightningConfirm` from
+ * `lightning/confirm`. `host-api/store` transitively loads the full core
+ * store graph including LWC components decorated with `@api`/`@wire` —
+ * invalid syntax under plain Node, since this test runner only strips
+ * TypeScript types and cannot parse LWC decorator syntax. `lightning/confirm`
+ * is an LWC-registered module id that doesn't resolve outside the LWC
+ * compiler/runtime at all. Importing the real module throws
+ * `SyntaxError: Invalid or unexpected token` (verified empirically — see
+ * `agentforce/slices/__tests__/agents.test.ts` and
+ * `platformevent/slices/__tests__/platformEvent.test.ts`, which document the
+ * same constraint for `host-api/store`).
+ *
+ * Pragmatic alternative: `escapeCsvValue` and `formatQueryWithComment` are
+ * both fully pure (no store/LWC dependency), so we re-construct ("clone")
+ * them locally, faithful line-for-line to `../util.ts`, and pin the clone's
+ * fidelity with "source contract" tests that `readFileSync` the real file and
+ * `assert.match` key lines. Any drift between the clone and the real
+ * implementation is caught by those contract tests.
+ *
+ * `confirmDiscardPendingEdits` is intentionally NOT tested here — it's driven
+ * end-to-end by `LightningConfirm.open(...)` and `store.dispatch(...)`, both
+ * blocked imports. Cloning just its early-return guards would mostly test a
+ * hand-rolled mock of LightningConfirm rather than real logic, so it's
+ * skipped (see report).
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+import { isSoqlCommentLine } from '../../slices/stripSoqlComments.ts';
+
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(path.resolve(here, '../util.ts'), 'utf8');
+
+// ---------------------------------------------------------------------------
+// Test rig: faithful clone of the pure exports of `../util.ts`. MUST stay in
+// sync with the real file; the "source contract" tests below pin the real
+// source against regexes so drift is caught.
+// ---------------------------------------------------------------------------
+
+function escapeCsvValue(separator: string, value: unknown) {
+    if (value == null) return ''; // Handle null or undefined values
+    const stringValue = String(value); // Convert to string
+    if (
+        stringValue.includes(separator) ||
+        stringValue.includes('"') ||
+        stringValue.includes('\n')
+    ) {
+        // Escape double quotes by doubling them
+        return `"${stringValue.replace(/"/g, '""')}"`;
+    }
+    return stringValue;
+}
+
+function formatQueryWithComment(query: string) {
+    return query
+        .split('\n')
+        .map(line => {
+            if (isSoqlCommentLine(line)) {
+                return '';
+            }
+            const commentIndex = line.indexOf('//');
+            if (commentIndex !== -1) {
+                // Include everything before `//`, excluding the comment
+                return line.slice(0, commentIndex).trim();
+            }
+            // Include the entire line if no `//` is found
+            return line.trim();
+        })
+        .filter(line => line.length > 0) // Exclude empty lines
+        .join(' '); // Join back into a single query string
+}
+
+// ---------------------------------------------------------------------------
+// escapeCsvValue
+// ---------------------------------------------------------------------------
+
+test('escapeCsvValue: null/undefined become an empty string', () => {
+    assert.equal(escapeCsvValue(',', null), '');
+    assert.equal(escapeCsvValue(',', undefined), '');
+});
+
+test('escapeCsvValue: plain values pass through unchanged', () => {
+    assert.equal(escapeCsvValue(',', 'hello'), 'hello');
+    assert.equal(escapeCsvValue(',', 42), '42');
+    assert.equal(escapeCsvValue(',', true), 'true');
+});
+
+test('escapeCsvValue: quotes and wraps a value containing the separator', () => {
+    assert.equal(escapeCsvValue(',', 'a,b'), '"a,b"');
+    assert.equal(escapeCsvValue(';', 'a;b'), '"a;b"');
+});
+
+test('escapeCsvValue: does not quote a value containing a DIFFERENT separator', () => {
+    assert.equal(escapeCsvValue(';', 'a,b'), 'a,b');
+});
+
+test('escapeCsvValue: quotes a value containing a double quote and doubles the inner quotes', () => {
+    assert.equal(escapeCsvValue(',', 'say "hi"'), '"say ""hi"""');
+});
+
+test('escapeCsvValue: quotes a value containing a newline', () => {
+    assert.equal(escapeCsvValue(',', 'line1\nline2'), '"line1\nline2"');
+});
+
+test('escapeCsvValue: coerces non-string values via String() before checking', () => {
+    // 0 and false are valid CSV cell values, not "empty" — only null/undefined
+    // short-circuit to ''.
+    assert.equal(escapeCsvValue(',', 0), '0');
+    assert.equal(escapeCsvValue(',', false), 'false');
+});
+
+// ---------------------------------------------------------------------------
+// formatQueryWithComment
+// ---------------------------------------------------------------------------
+
+test('formatQueryWithComment: a single-line query with no comments is returned trimmed', () => {
+    assert.equal(formatQueryWithComment('SELECT Id FROM Account'), 'SELECT Id FROM Account');
+});
+
+test('formatQueryWithComment: strips a full-line -- comment (delegates to isSoqlCommentLine)', () => {
+    const query = '-- full line comment\nSELECT Id FROM Account';
+    assert.equal(formatQueryWithComment(query), 'SELECT Id FROM Account');
+});
+
+test('formatQueryWithComment: strips a full-line # comment', () => {
+    const query = '# full line comment\nSELECT Id FROM Account';
+    assert.equal(formatQueryWithComment(query), 'SELECT Id FROM Account');
+});
+
+test('formatQueryWithComment: strips a trailing // comment from a line', () => {
+    const query = 'SELECT Id FROM Account // trailing comment';
+    assert.equal(formatQueryWithComment(query), 'SELECT Id FROM Account');
+});
+
+test('formatQueryWithComment: joins multiple lines into a single space-joined query', () => {
+    const query = 'SELECT Id, Name\nFROM Account\nWHERE Name != null';
+    assert.equal(formatQueryWithComment(query), 'SELECT Id, Name FROM Account WHERE Name != null');
+});
+
+test('formatQueryWithComment: filters out blank lines', () => {
+    const query = 'SELECT Id\n\n\nFROM Account';
+    assert.equal(formatQueryWithComment(query), 'SELECT Id FROM Account');
+});
+
+test('formatQueryWithComment: mixes full-line and trailing comments plus blank lines', () => {
+    const query = [
+        '-- header comment',
+        'SELECT Id, Name // only need these two',
+        '',
+        '# another full-line comment',
+        'FROM Account',
+    ].join('\n');
+    assert.equal(formatQueryWithComment(query), 'SELECT Id, Name FROM Account');
+});
+
+test('formatQueryWithComment: a // marker inside a quoted literal is NOT a documented guard here — pins current behavior', () => {
+    // Unlike stripSoqlComments (which guards against markers inside string
+    // literals for # and --), formatQueryWithComment's `//` handling is a
+    // naive indexOf and does NOT special-case quoted literals. This test
+    // pins the current (documented-as-is) behavior rather than an intended
+    // guarantee.
+    const query = "SELECT Id FROM Account WHERE Name = 'http://example.com'";
+    assert.equal(formatQueryWithComment(query), "SELECT Id FROM Account WHERE Name = 'http:");
+});
+
+test('formatQueryWithComment: empty string input returns empty string', () => {
+    assert.equal(formatQueryWithComment(''), '');
+});
+
+// ---------------------------------------------------------------------------
+// Source contract tests — pin the real `../util.ts` against regexes so drift
+// between this clone and the real implementation is caught.
+// ---------------------------------------------------------------------------
+
+test('source contract: escapeCsvValue short-circuits null/undefined to empty string', () => {
+    assert.match(SRC, /export const escapeCsvValue = \(separator: string, value: unknown\) => \{/);
+    assert.match(SRC, /if \(value == null\) return '';/);
+});
+
+test('source contract: escapeCsvValue quotes on separator, double-quote, or newline and doubles inner quotes', () => {
+    assert.match(
+        SRC,
+        /stringValue\.includes\(separator\) \|\|\s*\n\s*stringValue\.includes\('"'\) \|\|\s*\n\s*stringValue\.includes\('\\n'\)/
+    );
+    assert.match(SRC, /return `"\$\{stringValue\.replace\(\/"\/g, '""'\)\}"`;/);
+});
+
+test('source contract: formatQueryWithComment delegates full-line detection to isSoqlCommentLine', () => {
+    assert.match(SRC, /export const formatQueryWithComment = \(query: string\) => \{/);
+    assert.match(SRC, /if \(isSoqlCommentLine\(line\)\) \{\s*\n\s*return '';/);
+});
+
+test('source contract: formatQueryWithComment strips trailing // comments via indexOf and joins with a space', () => {
+    assert.match(SRC, /const commentIndex = line\.indexOf\('\/\/'\);/);
+    assert.match(SRC, /\.filter\(line => line\.length > 0\)/);
+    assert.match(SRC, /\.join\(' '\);/);
+});
+
+test('source contract: confirmDiscardPendingEdits is intentionally left untested here (documents why)', () => {
+    // Pins that the function still exists and is still built on the blocked
+    // LightningConfirm/store imports — if that coupling is ever removed,
+    // this test (and the file header) should be revisited so the function
+    // gets real coverage.
+    assert.match(SRC, /export const confirmDiscardPendingEdits = async \(/);
+    assert.match(SRC, /LightningConfirm\.open\(/);
+    assert.match(SRC, /store\.dispatch\(/);
+});

--- a/packages/lwc/applications/soql/slices/__tests__/query.test.ts
+++ b/packages/lwc/applications/soql/slices/__tests__/query.test.ts
@@ -1,0 +1,443 @@
+/**
+ * Slice-behavior tests for the soql `queriesSlice` — focused on the
+ * synchronous entity-adapter reducers (`deleteRecords`, `mergeRecordUpdates`,
+ * `loadMorePage`, `clearQueryError`). The async thunks (`executeQuery`,
+ * `executeQueryIncognito`, `loadMoreRecords`, `explainQuery`) are NOT cloned
+ * here — they need a real connector/network call and aren't worth faking.
+ *
+ * Why we don't import `../query.ts` directly
+ * -------------------------------------------
+ * The slice file imports `ERROR, DOCUMENT` from `host-api/store`, which
+ * transitively loads the full core store graph including LWC components
+ * decorated with `@api`/`@wire` — invalid syntax under plain Node, since this
+ * test runner only strips TypeScript types and cannot parse LWC decorator
+ * syntax. Importing the real module throws
+ * `SyntaxError: Invalid or unexpected token`. This has been verified
+ * empirically in this repo (see `agentforce/slices/__tests__/agents.test.ts`
+ * and `platformevent/slices/__tests__/platformEvent.test.ts`, which document
+ * the same constraint). `core/store/storeRef` (for `getStore`) and
+ * `host-api/utils` (for `lowerCaseKey`) DO import cleanly on their own, but
+ * the blocked `host-api/store` import at the top of the file poisons the
+ * whole module graph for `../query.ts`.
+ *
+ * Pragmatic alternative: re-construct the same reducers the slice uses as a
+ * "faithful clone" built with `createSlice`/`createEntityAdapter` from
+ * `@reduxjs/toolkit` (the same library the real slice uses) plus the real,
+ * already-tested `mergeQueryPage` helper from `./queryPagination.ts` (pure,
+ * no blocked imports — see `../__tests__/queryPagination.test.ts`), and pin
+ * the clone's fidelity with "source contract" tests that `readFileSync` the
+ * real `../query.ts` and `assert.match` key lines/policies. Any drift between
+ * the clone and the real file gets caught by those contract tests.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import { createSlice, createEntityAdapter } from '@reduxjs/toolkit';
+
+import { mergeQueryPage } from '../queryPagination.ts';
+
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+const SRC = fs.readFileSync(path.resolve(here, '../query.ts'), 'utf8');
+
+// ---------------------------------------------------------------------------
+// Test rig: faithful clone of the queriesSlice's synchronous reducers. MUST
+// stay in sync with `../query.ts`. Each reducer below mirrors the real
+// implementation line-for-line; the "source contract" tests at the bottom
+// pin the real source against regexes so drift is caught.
+// ---------------------------------------------------------------------------
+
+// Minimal stand-in for `lowerCaseKey` from `host-api/utils` (pure, no store dep).
+function lowerCaseKey(key: string | null | undefined): string | null {
+    return key != null ? key.toLowerCase() : null;
+}
+
+const testAdapter = createEntityAdapter<any>();
+
+const testSlice = createSlice({
+    name: 'queriesTest',
+    initialState: testAdapter.getInitialState(),
+    reducers: {
+        deleteRecords: (state, action: { payload: { tabId: string; deletedRecordIds: any[] } }) => {
+            const { tabId, deletedRecordIds } = action.payload;
+
+            const existingRecord = testAdapter
+                .getSelectors()
+                .selectById(state, lowerCaseKey(tabId));
+            if (existingRecord && existingRecord.data) {
+                const updatedRecords = existingRecord.data.records.filter(
+                    (x: any) => !deletedRecordIds.includes(x.Id)
+                );
+
+                testAdapter.upsertOne(state, {
+                    ...existingRecord,
+                    data: {
+                        ...existingRecord.data,
+                        totalSize: existingRecord.data.totalSize - deletedRecordIds.length || 0,
+                        records: updatedRecords,
+                    },
+                });
+            }
+        },
+        mergeRecordUpdates: (state, action: { payload: { tabId: string; updates: any[] } }) => {
+            // Merges successful inline-edit values into the query result records
+            // so the table reflects the persisted value without a re-query.
+            const { tabId, updates } = action.payload || ({} as any);
+            if (!tabId || !Array.isArray(updates) || updates.length === 0) return;
+
+            const existingRecord = testAdapter
+                .getSelectors()
+                .selectById(state, lowerCaseKey(tabId));
+            if (!existingRecord?.data?.records) return;
+
+            const byId = new Map(
+                updates
+                    .filter((u: any) => u && u.recordId)
+                    .map((u: any) => [String(u.recordId), u.changes || {}])
+            );
+            const updatedRecords = existingRecord.data.records.map((record: any) => {
+                const changes = byId.get(String(record?.Id));
+                return changes ? { ...record, ...changes } : record;
+            });
+            testAdapter.upsertOne(state, {
+                ...existingRecord,
+                data: {
+                    ...existingRecord.data,
+                    records: updatedRecords,
+                },
+            });
+        },
+        loadMorePage: (state, action: { payload: { tabId: string; page: any } }) => {
+            // Append a fetched `queryMore` page to the tab's current result set.
+            const { tabId, page } = action.payload;
+            const existingRecord = testAdapter
+                .getSelectors()
+                .selectById(state, lowerCaseKey(tabId));
+            if (!existingRecord?.data) return;
+            testAdapter.upsertOne(state, {
+                ...existingRecord,
+                data: mergeQueryPage(existingRecord.data, page),
+            });
+        },
+        clearQueryError: (state, action: { payload: { tabId: string } }) => {
+            const { tabId } = action.payload;
+            testAdapter.upsertOne(state, {
+                id: lowerCaseKey(tabId),
+                error: null,
+            });
+        },
+    },
+});
+
+function makeStateWithRecord(tabId: string, data: any, extra: Record<string, any> = {}) {
+    const initial = testAdapter.getInitialState();
+    return testAdapter.upsertOne(initial, { id: lowerCaseKey(tabId), data, ...extra });
+}
+
+// ---------------------------------------------------------------------------
+// deleteRecords
+// ---------------------------------------------------------------------------
+
+test('deleteRecords: removes matching records by Id and decrements totalSize', () => {
+    const state = makeStateWithRecord('Tab1', {
+        totalSize: 3,
+        records: [{ Id: 'a' }, { Id: 'b' }, { Id: 'c' }],
+    });
+
+    const next = testSlice.reducer(
+        state,
+        testSlice.actions.deleteRecords({ tabId: 'Tab1', deletedRecordIds: ['b'] })
+    );
+
+    const entity = (next.entities as any)['tab1'];
+    assert.deepEqual(
+        entity.data.records.map((r: any) => r.Id),
+        ['a', 'c']
+    );
+    assert.equal(entity.data.totalSize, 2);
+});
+
+test('deleteRecords: keyed by lowercased tabId (case-insensitive lookup)', () => {
+    const state = makeStateWithRecord('TabMixedCase', {
+        totalSize: 1,
+        records: [{ Id: 'a' }],
+    });
+
+    const next = testSlice.reducer(
+        state,
+        testSlice.actions.deleteRecords({ tabId: 'TABMIXEDCASE', deletedRecordIds: ['a'] })
+    );
+
+    const entity = (next.entities as any)['tabmixedcase'];
+    assert.deepEqual(entity.data.records, []);
+});
+
+test('deleteRecords: is a no-op when the tab has no existing record', () => {
+    const state = testAdapter.getInitialState();
+    const next = testSlice.reducer(
+        state,
+        testSlice.actions.deleteRecords({ tabId: 'MissingTab', deletedRecordIds: ['a'] })
+    );
+    assert.equal(next.ids.length, 0);
+});
+
+test('deleteRecords: is a no-op when the existing entity has no `data`', () => {
+    const initial = testAdapter.getInitialState();
+    const state = testAdapter.upsertOne(initial, { id: 'tab1', data: null, isFetching: true });
+
+    const next = testSlice.reducer(
+        state,
+        testSlice.actions.deleteRecords({ tabId: 'Tab1', deletedRecordIds: ['a'] })
+    );
+
+    assert.equal((next.entities as any)['tab1'].data, null, 'entity is untouched');
+});
+
+test('deleteRecords: totalSize falls back to 0 when the result would be NaN', () => {
+    // existingRecord.data.totalSize - deletedRecordIds.length || 0:
+    // undefined - 1 === NaN, and NaN || 0 === 0.
+    const state = makeStateWithRecord('TabNoTotal', {
+        records: [{ Id: 'a' }],
+    });
+
+    const next = testSlice.reducer(
+        state,
+        testSlice.actions.deleteRecords({ tabId: 'TabNoTotal', deletedRecordIds: ['a'] })
+    );
+
+    assert.equal((next.entities as any)['tabnototal'].data.totalSize, 0);
+});
+
+// ---------------------------------------------------------------------------
+// mergeRecordUpdates
+// ---------------------------------------------------------------------------
+
+test('mergeRecordUpdates: merges changes into matching records by recordId/Id', () => {
+    const state = makeStateWithRecord('Tab2', {
+        totalSize: 2,
+        records: [
+            { Id: 'a', Name: 'Old A' },
+            { Id: 'b', Name: 'Old B' },
+        ],
+    });
+
+    const next = testSlice.reducer(
+        state,
+        testSlice.actions.mergeRecordUpdates({
+            tabId: 'Tab2',
+            updates: [{ recordId: 'a', changes: { Name: 'New A' } }],
+        })
+    );
+
+    const records = (next.entities as any)['tab2'].data.records;
+    assert.equal(records.find((r: any) => r.Id === 'a').Name, 'New A');
+    assert.equal(
+        records.find((r: any) => r.Id === 'b').Name,
+        'Old B',
+        'unmatched record is untouched'
+    );
+});
+
+test('mergeRecordUpdates: recordId is compared as a String() (numeric vs string Id)', () => {
+    const state = makeStateWithRecord('Tab3', {
+        records: [{ Id: 1, Name: 'Old' }],
+    });
+
+    const next = testSlice.reducer(
+        state,
+        testSlice.actions.mergeRecordUpdates({
+            tabId: 'Tab3',
+            updates: [{ recordId: '1', changes: { Name: 'New' } }],
+        })
+    );
+
+    assert.equal((next.entities as any)['tab3'].data.records[0].Name, 'New');
+});
+
+for (const badPayload of [
+    { tabId: '', updates: [{ recordId: 'a', changes: {} }] },
+    { tabId: 'Tab4', updates: null },
+    { tabId: 'Tab4', updates: 'not-an-array' },
+    { tabId: 'Tab4', updates: [] },
+]) {
+    test(`mergeRecordUpdates: no-op for malformed payload ${JSON.stringify(badPayload)}`, () => {
+        const state = makeStateWithRecord('Tab4', { records: [{ Id: 'a', Name: 'Untouched' }] });
+        const next = testSlice.reducer(
+            state,
+            testSlice.actions.mergeRecordUpdates(badPayload as any)
+        );
+        assert.equal((next.entities as any)['tab4'].data.records[0].Name, 'Untouched');
+    });
+}
+
+test('mergeRecordUpdates: no-op when the tab has no existing record with data.records', () => {
+    const state = testAdapter.getInitialState();
+    const next = testSlice.reducer(
+        state,
+        testSlice.actions.mergeRecordUpdates({
+            tabId: 'MissingTab',
+            updates: [{ recordId: 'a', changes: { Name: 'New' } }],
+        })
+    );
+    assert.equal(next.ids.length, 0);
+});
+
+test('mergeRecordUpdates: updates missing a recordId are filtered out of the merge map', () => {
+    const state = makeStateWithRecord('Tab5', {
+        records: [{ Id: 'a', Name: 'Old A' }],
+    });
+
+    const next = testSlice.reducer(
+        state,
+        testSlice.actions.mergeRecordUpdates({
+            tabId: 'Tab5',
+            updates: [{ changes: { Name: 'Should Not Apply' } }, null, undefined],
+        })
+    );
+
+    assert.equal((next.entities as any)['tab5'].data.records[0].Name, 'Old A');
+});
+
+// ---------------------------------------------------------------------------
+// loadMorePage
+// ---------------------------------------------------------------------------
+
+test('loadMorePage: merges a fetched page via mergeQueryPage and advances the cursor', () => {
+    const state = makeStateWithRecord('Tab6', {
+        totalSize: 4,
+        done: false,
+        nextRecordsUrl: '/services/data/v60.0/query/01g0',
+        records: [{ Id: 'a' }, { Id: 'b' }],
+    });
+
+    const next = testSlice.reducer(
+        state,
+        testSlice.actions.loadMorePage({
+            tabId: 'Tab6',
+            page: {
+                totalSize: 4,
+                done: true,
+                records: [{ Id: 'c' }, { Id: 'd' }],
+            },
+        })
+    );
+
+    const data = (next.entities as any)['tab6'].data;
+    assert.deepEqual(
+        data.records.map((r: any) => r.Id),
+        ['a', 'b', 'c', 'd']
+    );
+    assert.equal(data.nextRecordsUrl, null, 'cursor cleared once jsforce omits nextRecordsUrl');
+    assert.equal(data.done, true);
+});
+
+test('loadMorePage: is a no-op when the tab has no existing data', () => {
+    const initial = testAdapter.getInitialState();
+    const state = testAdapter.upsertOne(initial, { id: 'tab7', data: null });
+
+    const next = testSlice.reducer(
+        state,
+        testSlice.actions.loadMorePage({ tabId: 'Tab7', page: { records: [{ Id: 'x' }] } })
+    );
+
+    assert.equal((next.entities as any)['tab7'].data, null);
+});
+
+test('loadMorePage: is a no-op when the tab does not exist at all', () => {
+    const state = testAdapter.getInitialState();
+    const next = testSlice.reducer(
+        state,
+        testSlice.actions.loadMorePage({ tabId: 'MissingTab', page: { records: [] } })
+    );
+    assert.equal(next.ids.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// clearQueryError
+// ---------------------------------------------------------------------------
+
+test('clearQueryError: clears error on an existing entity without touching other fields', () => {
+    const state = makeStateWithRecord(
+        'Tab8',
+        { records: [{ Id: 'a' }] },
+        { error: { message: 'boom' }, isFetching: false }
+    );
+
+    const next = testSlice.reducer(state, testSlice.actions.clearQueryError({ tabId: 'Tab8' }));
+
+    const entity = (next.entities as any)['tab8'];
+    assert.equal(entity.error, null);
+    assert.deepEqual(
+        entity.data.records,
+        [{ Id: 'a' }],
+        'unrelated fields are preserved by upsert'
+    );
+});
+
+test('clearQueryError: creates a bare entity (id + error:null) when the tab did not previously exist', () => {
+    const state = testAdapter.getInitialState();
+    const next = testSlice.reducer(state, testSlice.actions.clearQueryError({ tabId: 'NewTab' }));
+
+    const entity = (next.entities as any)['newtab'];
+    assert.ok(entity, 'upsertOne inserts a new entity when none exists');
+    assert.equal(entity.error, null);
+});
+
+test('clearQueryError: keyed by lowercased tabId', () => {
+    const state = makeStateWithRecord('MixedCaseTab', { records: [] }, { error: 'x' });
+    const next = testSlice.reducer(
+        state,
+        testSlice.actions.clearQueryError({ tabId: 'MIXEDCASETAB' })
+    );
+    assert.equal((next.entities as any)['mixedcasetab'].error, null);
+});
+
+// ---------------------------------------------------------------------------
+// Source contract tests — pin the real `../query.ts` against regexes so
+// drift between this clone and the real implementation is caught.
+// ---------------------------------------------------------------------------
+
+test('source contract: queriesSlice declares the four synchronous reducers under test', () => {
+    assert.match(SRC, /reducers: \{\s*\n\s*deleteRecords: \(state, action\) => \{/);
+    assert.match(SRC, /mergeRecordUpdates: \(state, action\) => \{/);
+    assert.match(SRC, /loadMorePage: \(state, action\) => \{/);
+    assert.match(SRC, /clearQueryError: \(state, action\) => \{/);
+});
+
+test('source contract: each reducer keys entities via lowerCaseKey(tabId)', () => {
+    assert.match(
+        SRC,
+        /deleteRecords: \(state, action\) => \{[\s\S]+?selectById\(state, lowerCaseKey\(tabId\)\)/
+    );
+    assert.match(
+        SRC,
+        /mergeRecordUpdates: \(state, action\) => \{[\s\S]+?selectById\(state, lowerCaseKey\(tabId\)\)/
+    );
+    assert.match(
+        SRC,
+        /loadMorePage: \(state, action\) => \{[\s\S]+?selectById\(state, lowerCaseKey\(tabId\)\)/
+    );
+    assert.match(SRC, /clearQueryError: \(state, action\) => \{[\s\S]+?id: lowerCaseKey\(tabId\),/);
+});
+
+test('source contract: mergeRecordUpdates guards on tabId/updates shape before touching state', () => {
+    assert.match(
+        SRC,
+        /if \(!tabId \|\| !Array\.isArray\(updates\) \|\| updates\.length === 0\) return;/
+    );
+    assert.match(SRC, /if \(!existingRecord\?\.data\?\.records\) return;/);
+});
+
+test('source contract: loadMorePage calls mergeQueryPage(existingRecord.data, page)', () => {
+    assert.match(SRC, /if \(!existingRecord\?\.data\) return;/);
+    assert.match(SRC, /data: mergeQueryPage\(existingRecord\.data, page\),/);
+});
+
+test('source contract: deleteRecords decrements totalSize with an `|| 0` NaN guard', () => {
+    assert.match(
+        SRC,
+        /totalSize: existingRecord\.data\.totalSize - deletedRecordIds\.length \|\| 0,/
+    );
+});

--- a/packages/lwc/extension/extension/utils/__tests__/utils.test.ts
+++ b/packages/lwc/extension/extension/utils/__tests__/utils.test.ts
@@ -1,7 +1,90 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { isEmpty, getSfPathFromUrl, loadConfiguration, PANELS } from '../utils.ts';
+import {
+    isEmpty,
+    getSfPathFromUrl,
+    loadConfiguration,
+    PANELS,
+    getCurrentTab,
+    getCurrentObjectType,
+    chromeOpenInWindow,
+} from '../utils.ts';
+
+// Small helper to let fire-and-forget chrome-callback chains (used inside
+// chromeOpenInWindow's "new window" branch) flush before we assert on them.
+function flushMicrotasks() {
+    return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+function makeChrome({
+    windows = [],
+    newWindow = { id: 'new-window-id' },
+    tabGroupsForWindow = {},
+    newTabId = 'tab-id',
+    groupIdForNew = 'new-group-id',
+} = {}) {
+    const calls = {
+        windowsGetAll: [],
+        windowsCreate: [],
+        tabsCreate: [],
+        tabsQuery: [],
+        tabsGroup: [],
+        tabGroupsQuery: [],
+        tabGroupsUpdate: [],
+    };
+    globalThis.chrome = {
+        windows: {
+            getAll: opts => {
+                calls.windowsGetAll.push(opts);
+                return Promise.resolve(windows);
+            },
+            create: opts => {
+                calls.windowsCreate.push(opts);
+                return Promise.resolve(newWindow);
+            },
+        },
+        tabs: {
+            create: opts => {
+                calls.tabsCreate.push(opts);
+                return Promise.resolve({ id: newTabId });
+            },
+            query: (opts, cb) => {
+                calls.tabsQuery.push(opts);
+                const tabs = [{ id: newTabId }];
+                if (cb) cb(tabs);
+                return Promise.resolve(tabs);
+            },
+            group: (opts, cb) => {
+                calls.tabsGroup.push(opts);
+                const newGroupId = groupIdForNew;
+                if (cb) {
+                    cb(newGroupId);
+                    return undefined;
+                }
+                return Promise.resolve(newGroupId);
+            },
+        },
+        tabGroups: {
+            query: opts => {
+                calls.tabGroupsQuery.push(opts);
+                return Promise.resolve(tabGroupsForWindow[opts.windowId] || []);
+            },
+            update: (groupId, opts, cb) => {
+                calls.tabGroupsUpdate.push({ groupId, opts });
+                if (cb) cb();
+                return Promise.resolve();
+            },
+        },
+    };
+    return calls;
+}
+
+const origWarn = console.warn;
+console.warn = () => {};
+test.after(() => {
+    console.warn = origWarn;
+});
 
 test('isEmpty: empty string returns true', () => {
     assert.equal(isEmpty(''), true);
@@ -48,4 +131,177 @@ test('loadConfiguration: returns {} on malformed JSON without throwing', () => {
 test('PANELS: exposes salesforce + default keys', () => {
     assert.equal(PANELS.SALESFORCE, 'salesforce');
     assert.equal(PANELS.DEFAULT, 'default');
+});
+
+test('getCurrentTab: resolves to the tab returned by chrome.tabs.query', async () => {
+    const expectedTab = { id: 42, active: true };
+    globalThis.chrome = {
+        tabs: {
+            query: async () => [expectedTab],
+        },
+    };
+    const tab = await getCurrentTab();
+    assert.deepEqual(tab, expectedTab);
+});
+
+test('getCurrentTab: resolves to undefined when no tab matches', async () => {
+    globalThis.chrome = {
+        tabs: {
+            query: async () => [],
+        },
+    };
+    const tab = await getCurrentTab();
+    assert.equal(tab, undefined);
+});
+
+test('getCurrentObjectType: resolves the parsed sobject type on success', async () => {
+    const conn = {
+        tooling: {
+            executeAnonymous: async () => ({
+                exceptionMessage: 'Line 1, column 1: Account',
+            }),
+        },
+    };
+    const result = await getCurrentObjectType(conn, '001xx000003DGb1AAG');
+    assert.equal(result, 'Account');
+});
+
+test('getCurrentObjectType: resolves null when the parsed value is the literal string "null"', async () => {
+    const conn = {
+        tooling: {
+            executeAnonymous: async () => ({
+                exceptionMessage: 'Line 1, column 1: null',
+            }),
+        },
+    };
+    const result = await getCurrentObjectType(conn, 'invalid-id');
+    assert.equal(result, null);
+});
+
+test('getCurrentObjectType: rejects when executeAnonymous rejects', async () => {
+    const boom = new Error('anonymous apex failed');
+    const conn = {
+        tooling: {
+            executeAnonymous: async () => {
+                throw boom;
+            },
+        },
+    };
+    await assert.rejects(getCurrentObjectType(conn, '001xx000003DGb1AAG'), boom);
+});
+
+test('chromeOpenInWindow: no existing window creates a new window, tab, and group', async () => {
+    const calls = makeChrome({ windows: [] });
+    await chromeOpenInWindow('https://example.com', 'MyGroup');
+    await flushMicrotasks();
+
+    assert.equal(calls.windowsGetAll.length, 1);
+    assert.equal(calls.windowsCreate.length, 1);
+    assert.deepEqual(calls.windowsCreate[0], {
+        url: 'https://example.com',
+        incognito: false,
+    });
+    assert.equal(calls.tabsCreate.length, 0);
+    assert.equal(calls.tabsQuery.length, 1);
+    assert.deepEqual(calls.tabsQuery[0], { windowId: 'new-window-id' });
+    assert.equal(calls.tabsGroup.length, 1);
+    assert.deepEqual(calls.tabsGroup[0], {
+        createProperties: { windowId: 'new-window-id' },
+        tabIds: 'tab-id',
+    });
+    assert.equal(calls.tabGroupsUpdate.length, 1);
+    assert.deepEqual(calls.tabGroupsUpdate[0], {
+        groupId: 'new-group-id',
+        opts: { title: 'MyGroup' },
+    });
+});
+
+test('chromeOpenInWindow: reuses an existing window and existing matching group', async () => {
+    const calls = makeChrome({
+        windows: [{ id: 'w1', incognito: false }],
+        tabGroupsForWindow: { w1: [{ id: 'existing-group-id', title: 'MyGroup' }] },
+    });
+    await chromeOpenInWindow('https://example.com', 'MyGroup');
+
+    assert.equal(calls.windowsCreate.length, 0);
+    assert.equal(calls.tabsCreate.length, 1);
+    assert.deepEqual(calls.tabsCreate[0], { url: 'https://example.com', windowId: 'w1' });
+    assert.equal(calls.tabGroupsQuery.length, 1);
+    assert.deepEqual(calls.tabGroupsQuery[0], { windowId: 'w1' });
+    assert.equal(calls.tabsGroup.length, 1);
+    assert.deepEqual(calls.tabsGroup[0], { groupId: 'existing-group-id', tabIds: 'tab-id' });
+    // Reusing an existing group does not create/rename a group.
+    assert.equal(calls.tabGroupsUpdate.length, 0);
+});
+
+test('chromeOpenInWindow: reuses an existing window but creates a new group when none matches', async () => {
+    const calls = makeChrome({
+        windows: [{ id: 'w1', incognito: false }],
+        tabGroupsForWindow: { w1: [{ id: 'other-group-id', title: 'OtherGroup' }] },
+    });
+    await chromeOpenInWindow('https://example.com', 'MyGroup');
+
+    assert.equal(calls.windowsCreate.length, 0);
+    assert.equal(calls.tabsGroup.length, 1);
+    assert.deepEqual(calls.tabsGroup[0], { createProperties: {}, tabIds: 'tab-id' });
+    assert.equal(calls.tabGroupsUpdate.length, 1);
+    assert.deepEqual(calls.tabGroupsUpdate[0], {
+        groupId: 'new-group-id',
+        opts: { title: 'MyGroup' },
+    });
+});
+
+test('chromeOpenInWindow: newWindow=true forces a new window even though a matching window exists', async () => {
+    const calls = makeChrome({ windows: [{ id: 'w1', incognito: false }] });
+    await chromeOpenInWindow('https://example.com', 'MyGroup', false, true);
+    await flushMicrotasks();
+
+    assert.equal(calls.tabsCreate.length, 0);
+    assert.equal(calls.windowsCreate.length, 1);
+    assert.deepEqual(calls.windowsCreate[0], {
+        url: 'https://example.com',
+        incognito: false,
+    });
+});
+
+test('chromeOpenInWindow: incognito=true with no incognito window available creates a new incognito window', async () => {
+    const calls = makeChrome({ windows: [{ id: 'w1', incognito: false }] });
+    await chromeOpenInWindow('https://example.com', 'MyGroup', true, false);
+    await flushMicrotasks();
+
+    assert.equal(calls.tabsCreate.length, 0);
+    assert.equal(calls.windowsCreate.length, 1);
+    assert.deepEqual(calls.windowsCreate[0], {
+        url: 'https://example.com',
+        incognito: true,
+    });
+});
+
+test('chromeOpenInWindow: incognito=true reuses an existing incognito window', async () => {
+    const calls = makeChrome({ windows: [{ id: 'w-incog', incognito: true }] });
+    await chromeOpenInWindow('https://example.com', 'MyGroup', true, false);
+
+    assert.equal(calls.windowsCreate.length, 0);
+    assert.equal(calls.tabsCreate.length, 1);
+    assert.deepEqual(calls.tabsCreate[0], { url: 'https://example.com', windowId: 'w-incog' });
+});
+
+test('chromeOpenInWindow: warns when the browser denies incognito window creation', async () => {
+    // Pass `null` (not `undefined`) — destructuring defaults kick in for
+    // `undefined`, which would silently restore the default truthy window.
+    const calls = makeChrome({ windows: [], newWindow: null });
+    let warned = null;
+    const origWarn = console.warn;
+    console.warn = msg => {
+        warned = msg;
+    };
+    try {
+        await chromeOpenInWindow('https://example.com', 'MyGroup', true, false);
+    } finally {
+        console.warn = origWarn;
+    }
+
+    assert.equal(calls.tabsQuery.length, 0);
+    assert.equal(calls.tabsGroup.length, 0);
+    assert.match(warned, /Authorize the extension/);
 });

--- a/packages/lwc/extension/panels/default/__tests__/applicationState.test.js
+++ b/packages/lwc/extension/panels/default/__tests__/applicationState.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { APPLICATIONS, normalizeApplicationName } from '../applicationState.js';
+
+test('APPLICATIONS: exposes exactly the expected keys/values', () => {
+    assert.deepEqual(APPLICATIONS, {
+        CONNECTION: 'connection',
+        DOCUMENTATION: 'documentation',
+        ASSISTANT: 'assistant',
+        AGENT: 'agent',
+        SMARTINPUT: 'smartinput',
+    });
+});
+
+test('normalizeApplicationName: valid app name is returned unchanged', () => {
+    assert.equal(normalizeApplicationName(APPLICATIONS.AGENT), APPLICATIONS.AGENT);
+    assert.equal(normalizeApplicationName(APPLICATIONS.DOCUMENTATION), APPLICATIONS.DOCUMENTATION);
+    assert.equal(normalizeApplicationName(APPLICATIONS.ASSISTANT), APPLICATIONS.ASSISTANT);
+});
+
+test('normalizeApplicationName: "home" maps to CONNECTION', () => {
+    assert.equal(normalizeApplicationName('home'), APPLICATIONS.CONNECTION);
+});
+
+test('normalizeApplicationName: unknown/invalid name falls back to CONNECTION', () => {
+    assert.equal(normalizeApplicationName('unknown-app'), APPLICATIONS.CONNECTION);
+});
+
+test('normalizeApplicationName: non-string, empty, or whitespace-only input falls back to CONNECTION', () => {
+    assert.equal(normalizeApplicationName(null), APPLICATIONS.CONNECTION);
+    assert.equal(normalizeApplicationName(undefined), APPLICATIONS.CONNECTION);
+    assert.equal(normalizeApplicationName(42), APPLICATIONS.CONNECTION);
+    assert.equal(normalizeApplicationName(''), APPLICATIONS.CONNECTION);
+    assert.equal(normalizeApplicationName('   '), APPLICATIONS.CONNECTION);
+});
+
+test('normalizeApplicationName: SMARTINPUT without beta flag falls back to CONNECTION', () => {
+    assert.equal(normalizeApplicationName(APPLICATIONS.SMARTINPUT, false), APPLICATIONS.CONNECTION);
+    assert.equal(normalizeApplicationName(APPLICATIONS.SMARTINPUT), APPLICATIONS.CONNECTION);
+});
+
+test('normalizeApplicationName: SMARTINPUT with beta flag enabled stays SMARTINPUT', () => {
+    assert.equal(normalizeApplicationName(APPLICATIONS.SMARTINPUT, true), APPLICATIONS.SMARTINPUT);
+});


### PR DESCRIPTION
## Summary
- Adds direct-import unit tests for pure helper modules with no prior coverage: `soql/describeResolver.ts`, `jobs/tableUtils.ts` (fills the gap on `statusTone`/`statusBadgeClass`/`matchesFilter`), `accessAnalyzer/utils.ts` (`fileFormatter`), `object/sessionCallOptions.ts`; also extends `graphql/shortcutsModal` with the missing no-arg `detectIsMac()` case.
- Adds "faithful clone" tests for Redux slices that can't be imported directly under the `node:test` harness — they transitively import `host-api/store`, which loads LWC `@api`/`@wire`-decorated components the strip-types-only test runner can't parse: `object/slices/sobjectExplorer.ts`, `platformevent/slices/platformEvent.ts`, `recordviewer/slices/recordViewer.ts`, and the pure helpers in `anonymousApex/slices/apex.ts`. These follow the precedent pattern already established in `agentforce/slices/__tests__/agents.test.ts`, including source-contract regex checks that read the real source and catch drift between it and the cloned reducer logic.
- No production/source files were changed — this is purely additive test coverage.

## Test plan
- [x] `npm test` — 2058 tests passing (up from before this PR), 0 failures
- [x] `npm run lint` — clean (eslint + prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)