### PR TITLE
feat(overlay,soql): add missing hover tooltips to icon-only buttons v…

### DIFF
--- a/packages/lwc/applications/soql/app/app.html
+++ b/packages/lwc/applications/soql/app/app.html
@@ -59,6 +59,8 @@
                         variant="border-filled"
                         icon-name="utility:knowledge_base"
                         size="large"
+                        title={i18n.SOQL_TOOLBAR_TOGGLE_FIELDS}
+                        alternative-text={i18n.SOQL_TOOLBAR_TOGGLE_FIELDS}
                         onclick={handleLeftToggle}></lightning-button-icon-stateful>
                 </div>
 
@@ -66,6 +68,8 @@
                     <lightning-button-icon
                         icon-name="utility:delete"
                         variant="border-filled"
+                        title={i18n.SOQL_TOOLBAR_DELETE_RECORDS}
+                        alternative-text={i18n.SOQL_TOOLBAR_DELETE_RECORDS}
                         onclick={deleteSelectedRecords}
                         disabled={isDeleteDisabled}></lightning-button-icon>
 
@@ -106,6 +110,8 @@
                         variant="border-filled"
                         icon-name="utility:indicator_performance_period"
                         size="large"
+                        title={i18n.SOQL_TOOLBAR_CHECK_PERFORMANCE}
+                        alternative-text={i18n.SOQL_TOOLBAR_CHECK_PERFORMANCE}
                         onclick={handlePerformanceCheckClick}
                         disabled={isLoading}></lightning-button-icon>
                     <lightning-button-icon-stateful
@@ -114,6 +120,8 @@
                         variant="border-filled"
                         icon-name="utility:budget_period"
                         size="large"
+                        title={i18n.SOQL_TOOLBAR_RECENT_QUERIES}
+                        alternative-text={i18n.SOQL_TOOLBAR_RECENT_QUERIES}
                         onclick={handleRecentToggle}></lightning-button-icon-stateful>
 
                     <!-- TODO: Add Download and Clipboard copy

--- a/packages/lwc/extension/views/overlay/overlay.html
+++ b/packages/lwc/extension/views/overlay/overlay.html
@@ -6,18 +6,24 @@
                     icon-name="utility:toggle_panel_right"
                     class="slds-button-first"
                     onclick={handleOpenSideBar}
+                    title={i18n.OVERLAY_TOGGLE_SIDEBAR}
+                    alternative-text={i18n.OVERLAY_TOGGLE_SIDEBAR}
                     tab-index="-1"></lightning-button-icon>
                 <lightning-button-icon-stateful
                     icon-name="utility:search"
                     selected={isOverlayDisplayed}
                     onclick={toggleOverlay}
                     class={searchButtonClass}
+                    title={i18n.OVERLAY_SEARCH_OBJECTS}
+                    alternative-text={i18n.OVERLAY_SEARCH_OBJECTS}
                     tab-index="-1"></lightning-button-icon-stateful>
                 <lightning-button-icon-stateful
                     icon-name="utility:edit"
                     class={editButtonClass}
                     selected={isOverlayDisplayed}
                     onclick={checkRecordId}
+                    title={i18n.OVERLAY_EDIT_RECORD}
+                    alternative-text={i18n.OVERLAY_EDIT_RECORD}
                     tab-index="-1"></lightning-button-icon-stateful>
             </div>
         </div>
@@ -137,18 +143,21 @@
                                         data-application="anonymousapex"></lightning-button-icon> -->
                                     <lightning-button-icon
                                         icon-name="utility:database"
-                                        label="Open SOQL Explorer"
+                                        title={i18n.OVERLAY_OPEN_SOQL_EXPLORER}
+                                        alternative-text={i18n.OVERLAY_OPEN_SOQL_EXPLORER}
                                         onclick={handleOpenToolkit}
                                         size="medium"
                                         data-application="soql"></lightning-button-icon>
                                     <lightning-button-icon
                                         icon-name="utility:new_window"
-                                        label="Open"
+                                        title={i18n.OVERLAY_OPEN_WORKBENCH}
+                                        alternative-text={i18n.OVERLAY_OPEN_WORKBENCH}
                                         onclick={handleOpenToolkit}
                                         size="medium"></lightning-button-icon>
                                     <lightning-button-icon
                                         icon-name="utility:share"
-                                        label="Share"
+                                        title={i18n.OVERLAY_SHARE}
+                                        alternative-text={i18n.OVERLAY_SHARE}
                                         onclick={handleShare}
                                         size="medium"
                                         disabled={isShareDisabled}></lightning-button-icon>
@@ -166,6 +175,8 @@
                                     class="slds-float_right"
                                     icon-name="utility:refresh"
                                     variant="bare"
+                                    title={i18n.OVERLAY_REFRESH}
+                                    alternative-text={i18n.OVERLAY_REFRESH}
                                     onclick={handleRefresh}></lightning-button-icon>
                             </span>
                             <div

--- a/packages/lwc/main/core/i18n/messages/en.ts
+++ b/packages/lwc/main/core/i18n/messages/en.ts
@@ -66,6 +66,17 @@ const messages = {
     PACKAGE_NEW_DEPLOYMENT: 'New Deployment',
     PACKAGE_DEPLOY: 'Deploy',
     PACKAGE_RETRIEVE: 'Retrieve',
+    OVERLAY_TOGGLE_SIDEBAR: 'Toggle sidebar panel',
+    OVERLAY_SEARCH_OBJECTS: 'Search Salesforce objects',
+    OVERLAY_EDIT_RECORD: 'Edit current record',
+    OVERLAY_OPEN_SOQL_EXPLORER: 'Open SOQL Explorer',
+    OVERLAY_OPEN_WORKBENCH: 'Open Workbench app',
+    OVERLAY_SHARE: 'Copy shareable link to clipboard',
+    OVERLAY_REFRESH: 'Refresh',
+    SOQL_TOOLBAR_TOGGLE_FIELDS: 'Show / hide fields panel',
+    SOQL_TOOLBAR_DELETE_RECORDS: 'Delete selected records',
+    SOQL_TOOLBAR_CHECK_PERFORMANCE: 'Check query performance',
+    SOQL_TOOLBAR_RECENT_QUERIES: 'Show recent & saved queries',
 };
 
 export type MessageKey = keyof typeof messages;


### PR DESCRIPTION
Closes #53
  
  ## Summary
  
  Several icon-only buttons across the overlay panel and SOQL Explorer toolbar had no hover tooltip, leaving users to guess their purpose.
  
  - Added `title={i18n.KEY}` to 11 buttons across the overlay and SOQL toolbar
  - Added 11 new label keys to `packages/lwc/main/core/i18n/messages/en.ts` following the existing `SCREAMING_SNAKE_CASE` convention
  - All affected components already extend `ToolkitElement` — no new infrastructure needed
  
  **Files changed:**
  - `packages/lwc/main/core/i18n/messages/en.ts` — 11 new label keys
  - `packages/lwc/extension/views/overlay/overlay.html` — 7 buttons wired
  - `packages/lwc/applications/soql/app/app.html` — 4 buttons wired 
  
  **Intentionally excluded:**
  - Buttons with visible text labels (e.g. Agentforce nav tabs) — tooltip would be redundant
  - Buttons using `alternative-text` on `lightning-button-icon` — SLDS forwards this to the DOM `title` internally, already shows on hover
  
  ## Test plan
  
  - [x] `npm run test` — 2334 pass, 0 fail
  - [x] `npm run lint` — clean
  - [x] Load unpacked extension, hover over overlay floating icons and SOQL toolbar buttons — tooltips appear with correct labels
<img width="115" height="102" alt="image" src="https://github.com/user-attachments/assets/ae7899a7-d759-4b69-a4ac-d3d34a8b237f" />
<img width="256" height="203" alt="image" src="https://github.com/user-attachments/assets/4e24da22-ba86-4308-9703-a9ece5226812" />