### PR TITLE
chore(release): 2.1.1 - agent current-tab inspection and live model catalogs

### DIFF
--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -7,7 +7,7 @@ slug: /
 
 Workbench is a Salesforce productivity toolkit that ships as a **Chrome extension** and a **desktop app**. All surfaces share the same LWC frontend, an embedded VS Code workbench, and an AI agent for Salesforce-oriented tasks.
 
-Latest release: **v2.1.0**
+Latest release: **v2.1.1**
 
 It is the modern replacement for **Salesforce Workbench** and **Benchpress**.
 

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -1,16 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import screenshotWelcome from '../../../assets/images/screenshots/screenshot-welcome.png';
-import screenshotOverlay from '../../../assets/images/screenshots/screenshot-overlay.png';
-import screenshotEditor from '../../../assets/images/screenshots/screenshot-editor.png';
-import screenshotSoql from '../../../assets/images/screenshots/screenshot-soql.gif';
-import screenshotMetadata from '../../../assets/images/screenshots/screenshot-metadata.gif';
-import screenshotAgent from '../../../assets/images/screenshots/screenshot-agent.gif';
-import {
-    CHROME_STORE_URL,
-    FakeBrowser,
-    SiteShell,
-} from './SiteChrome';
+import { CHROME_STORE_URL, SiteShell } from './SiteChrome';
+import { FeatureSlide, ProductDemo } from './product-tour/ProductDemo';
+import { SLIDES, type TourSlideId } from './product-tour/slides';
+import { TourNavContext } from './product-tour/tour-nav';
 
 function useInView<T extends Element>(threshold = 0.1) {
     const ref = useRef<T>(null);
@@ -25,7 +18,9 @@ function useInView<T extends Element>(threshold = 0.1) {
             return;
         }
         const obs = new IntersectionObserver(
-            ([entry]) => { if (entry.isIntersecting) setInView(true); },
+            ([entry]) => {
+                if (entry.isIntersecting) setInView(true);
+            },
             { threshold }
         );
         obs.observe(el);
@@ -34,13 +29,10 @@ function useInView<T extends Element>(threshold = 0.1) {
     return [ref, inView] as const;
 }
 
-const FEATURE_SECTIONS = [
-    { id: 'overlay', align: 'right' as const, screenshot: screenshotOverlay, url: 'chrome - Workbench App' },
-    { id: 'editor', align: 'left' as const, screenshot: screenshotEditor, url: 'chrome - Workbench Editor' },
-    { id: 'workbench', align: 'right' as const, screenshot: screenshotMetadata, url: 'chrome - Metadata Explorer' },
-    { id: 'soql', align: 'left' as const, screenshot: screenshotSoql, url: 'chrome - SOQL Explorer' },
-    { id: 'agent', align: 'right' as const, screenshot: screenshotAgent, url: 'chrome - AI Agent' },
-] as const;
+const FEATURE_SECTIONS = SLIDES.map((slide, index) => ({
+    ...slide,
+    align: (index % 2 === 0 ? 'right' : 'left') as 'left' | 'right',
+}));
 
 const PLATFORM_META = [
     {
@@ -48,7 +40,17 @@ const PLATFORM_META = [
         href: CHROME_STORE_URL,
         badgeVariant: 'recommended' as const,
         icon: (
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.75"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+            >
                 <circle cx="12" cy="12" r="10" />
                 <circle cx="12" cy="12" r="4" />
                 <line x1="21.17" y1="8" x2="12" y2="8" />
@@ -62,7 +64,17 @@ const PLATFORM_META = [
         href: null as string | null,
         badgeVariant: 'wip' as const,
         icon: (
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.75"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+            >
                 <rect x="2" y="3" width="20" height="14" rx="2" />
                 <path d="M8 21h8" />
                 <path d="M12 17v4" />
@@ -105,9 +117,15 @@ function FAQSection() {
                             </span>
                             <svg
                                 className="faq-chevron"
-                                width="16" height="16" viewBox="0 0 24 24"
-                                fill="none" stroke="currentColor" strokeWidth="2"
-                                strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"
+                                width="16"
+                                height="16"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                aria-hidden="true"
                             >
                                 <polyline points="6 9 12 15 18 9" />
                             </svg>
@@ -126,7 +144,23 @@ function FAQSection() {
     );
 }
 
-function FeatureSection({ section, index }: { section: typeof FEATURE_SECTIONS[number]; index: number }) {
+function FeatureGallery({ children }: { children: ReactNode }) {
+    const goToSlide = useCallback((slideId: TourSlideId) => {
+        const target = document.getElementById(slideId);
+        if (!target) return;
+        const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        target.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' });
+    }, []);
+    return <TourNavContext.Provider value={goToSlide}>{children}</TourNavContext.Provider>;
+}
+
+function FeatureSection({
+    section,
+    index,
+}: {
+    section: (typeof FEATURE_SECTIONS)[number];
+    index: number;
+}) {
     const { t } = useTranslation();
     const [ref, inView] = useInView<HTMLElement>(0.12);
     const isAlt = index % 2 !== 0;
@@ -141,10 +175,12 @@ function FeatureSection({ section, index }: { section: typeof FEATURE_SECTIONS[n
                 <div className="feature-text">
                     <p className="section-kicker">{t(`home.features.${section.id}.kicker`)}</p>
                     <h2 id={`ft-${section.id}`}>{t(`home.features.${section.id}.title`)}</h2>
-                    <p className="feature-description">{t(`home.features.${section.id}.description`)}</p>
+                    <p className="feature-description">
+                        {t(`home.features.${section.id}.description`)}
+                    </p>
                 </div>
                 <div className="feature-browser">
-                    <FakeBrowser url={section.url} screenshot={section.screenshot} />
+                    <FeatureSlide slideId={section.id} url={section.url} />
                 </div>
             </div>
         </section>
@@ -157,73 +193,93 @@ export default function App() {
 
     return (
         <SiteShell>
-                <section
-                    ref={heroRef}
-                    className={`hero-full${heroInView ? ' is-visible' : ''}`}
-                    aria-labelledby="welcome-title"
-                >
-                    <div className="hero-full-content">
-                        <p className="eyebrow">{t('home.hero.eyebrow')}</p>
-                        <h1 id="welcome-title">{t('home.hero.title')}</h1>
-                        <p className="hero-text">{t('home.hero.body')}</p>
-                        <div className="hero-actions">
-                            <a className="button" href={CHROME_STORE_URL} target="_blank" rel="noopener noreferrer">
-                                {t('home.hero.cta')}
-                            </a>
-                        </div>
+            <section
+                ref={heroRef}
+                className={`hero-full${heroInView ? ' is-visible' : ''}`}
+                aria-labelledby="welcome-title"
+            >
+                <div className="hero-full-content">
+                    <p className="eyebrow">{t('home.hero.eyebrow')}</p>
+                    <h1 id="welcome-title">{t('home.hero.title')}</h1>
+                    <p className="hero-text">{t('home.hero.body')}</p>
+                    <div className="hero-actions">
+                        <a
+                            className="button"
+                            href={CHROME_STORE_URL}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            {t('home.hero.cta')}
+                        </a>
                     </div>
-                    <div className="hero-browser">
-                        <FakeBrowser url="chrome - Workbench App" screenshot={screenshotWelcome} />
-                    </div>
-                </section>
+                </div>
+                <div className="home-tour">
+                    <ProductDemo />
+                </div>
+            </section>
 
+            <FeatureGallery>
                 {FEATURE_SECTIONS.map((section, i) => (
                     <FeatureSection key={section.id} section={section} index={i} />
                 ))}
+            </FeatureGallery>
 
-                <section className="platforms-section" aria-labelledby="platforms-title">
-                    <div className="section-heading">
-                        <p className="section-kicker">{t('home.platforms.kicker')}</p>
-                        <h2 id="platforms-title">{t('home.platforms.title')}</h2>
-                    </div>
-                    <div className="platforms" aria-label={t('home.platforms.title')}>
-                        {PLATFORM_META.map(p => (
-                            <article key={p.id} className="platform-card">
-                                <div className="platform-header">
-                                    <span className="platform-icon">{p.icon}</span>
-                                    <span className={`platform-badge platform-badge--${p.badgeVariant}`}>
-                                        {t(`home.platforms.${p.id}.badge`)}
-                                    </span>
-                                </div>
-                                <div className="platform-body">
-                                    <h3>{t(`home.platforms.${p.id}.name`)}</h3>
-                                    <p>{t(`home.platforms.${p.id}.description`)}</p>
-                                </div>
-                                {p.href ? (
-                                    <a className="button button-ghost button-small platform-cta" href={p.href}>
-                                        {t(`home.platforms.${p.id}.cta`)}
-                                    </a>
-                                ) : (
-                                    <span className="button button-ghost button-small platform-cta platform-cta--disabled" aria-disabled="true">
-                                        {t(`home.platforms.${p.id}.cta`)}
-                                    </span>
-                                )}
-                            </article>
-                        ))}
-                    </div>
-                </section>
+            <section className="platforms-section" aria-labelledby="platforms-title">
+                <div className="section-heading">
+                    <p className="section-kicker">{t('home.platforms.kicker')}</p>
+                    <h2 id="platforms-title">{t('home.platforms.title')}</h2>
+                </div>
+                <div className="platforms" aria-label={t('home.platforms.title')}>
+                    {PLATFORM_META.map(p => (
+                        <article key={p.id} className="platform-card">
+                            <div className="platform-header">
+                                <span className="platform-icon">{p.icon}</span>
+                                <span
+                                    className={`platform-badge platform-badge--${p.badgeVariant}`}
+                                >
+                                    {t(`home.platforms.${p.id}.badge`)}
+                                </span>
+                            </div>
+                            <div className="platform-body">
+                                <h3>{t(`home.platforms.${p.id}.name`)}</h3>
+                                <p>{t(`home.platforms.${p.id}.description`)}</p>
+                            </div>
+                            {p.href ? (
+                                <a
+                                    className="button button-ghost button-small platform-cta"
+                                    href={p.href}
+                                >
+                                    {t(`home.platforms.${p.id}.cta`)}
+                                </a>
+                            ) : (
+                                <span
+                                    className="button button-ghost button-small platform-cta platform-cta--disabled"
+                                    aria-disabled="true"
+                                >
+                                    {t(`home.platforms.${p.id}.cta`)}
+                                </span>
+                            )}
+                        </article>
+                    ))}
+                </div>
+            </section>
 
-                <FAQSection />
+            <FAQSection />
 
-                <section className="download" aria-labelledby="download-title">
-                    <h2 id="download-title">{t('home.download.title')}</h2>
-                    <p>{t('home.download.body')}</p>
-                    <div className="hero-actions">
-                        <a className="button" href={CHROME_STORE_URL} target="_blank" rel="noopener noreferrer">
-                            {t('home.download.cta')}
-                        </a>
-                    </div>
-                </section>
+            <section className="download" aria-labelledby="download-title">
+                <h2 id="download-title">{t('home.download.title')}</h2>
+                <p>{t('home.download.body')}</p>
+                <div className="hero-actions">
+                    <a
+                        className="button"
+                        href={CHROME_STORE_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        {t('home.download.cta')}
+                    </a>
+                </div>
+            </section>
         </SiteShell>
     );
 }

--- a/apps/ui/src/SiteChrome.tsx
+++ b/apps/ui/src/SiteChrome.tsx
@@ -184,13 +184,16 @@ export function SiteFooter() {
 export function FakeBrowser({
     url = 'app.workbench.io',
     screenshot,
+    children,
 }: {
     url?: string;
     screenshot?: string;
+    children?: ReactNode;
 }) {
     const { t } = useTranslation();
+    const isWireframe = Boolean(children);
     return (
-        <div className="fake-browser">
+        <div className={`fake-browser${isWireframe ? ' fake-browser--tour' : ''}`}>
             <div className="fake-browser-bar">
                 <div className="fake-browser-dots">
                     <span className="dot dot-red" />
@@ -244,9 +247,11 @@ export function FakeBrowser({
                 </div>
             </div>
             <div
-                className={`fake-browser-content${screenshot ? ' fake-browser-content--screenshot' : ''}`}
+                className={`fake-browser-content${screenshot ? ' fake-browser-content--screenshot' : ''}${isWireframe ? ' fake-browser-content--wireframe' : ''}`}
             >
-                {screenshot ? (
+                {children ? (
+                    children
+                ) : screenshot ? (
                     <img src={screenshot} alt="" className="fake-browser-screenshot" />
                 ) : (
                     <div className="fake-browser-placeholder">

--- a/apps/ui/src/locales/de.json
+++ b/apps/ui/src/locales/de.json
@@ -17,9 +17,35 @@
     "home": {
         "hero": {
             "eyebrow": "Salesforce-Administrations-Toolkit",
-            "title": "Das Toolkit für Salesforce-Admins",
+            "title": "Das Toolkit von Salesforce-Ingenieuren",
             "body": "Workbench bettet sich direkt in Salesforce ein – mit einem seitlichen Panel, einem VS Code-Editor im Browser, einem vollständigen Metadaten-Explorer und einem KI-Agenten, der Ihren Browser steuern kann – alles in einer Erweiterung.",
             "cta": "Erweiterung hinzufügen"
+        },
+        "demo": {
+            "ariaLabel": "Produktdemo",
+            "seeAllFeatures": "Alle Funktionen ansehen",
+            "headings": {
+                "overlay": "Overlay",
+                "editor": "VS Code",
+                "soql": "SOQL",
+                "agent": "Agent"
+            },
+            "captions": {
+                "edge": "Eine Salesforce-Seite — Workbench sitzt am Rand.",
+                "overlay": "Das Overlay gleitet ein, ohne den Datensatz zu verlassen.",
+                "search": "Objekte suchen, ohne die Seite zu verlassen.",
+                "vscode": "VS Code öffnen, ohne Salesforce zu verlassen.",
+                "loadingEditor": "VS Code wird geöffnet…",
+                "typeCode": "Eine LWC im selben Browser anlegen.",
+                "editorReady": "Die Vorlage ist fertig — jetzt die Daten abfragen.",
+                "loading": "SOQL Explorer wird geöffnet…",
+                "toolkit": "Das volle Toolkit, weiter im Browser.",
+                "query": "SOQL schreiben, mit der Org im Blick.",
+                "results": "Accounts aus Acme, sofort.",
+                "ask": "Das Seitenpanel auf jeder Website öffnen.",
+                "stream": "Der Agent füllt das Support-Formular.",
+                "action": "Abgeschickt — ohne die Seite zu verlassen."
+            }
         },
         "features": {
             "overlay": {

--- a/apps/ui/src/locales/de.json
+++ b/apps/ui/src/locales/de.json
@@ -1,6 +1,6 @@
 {
     "chrome": {
-        "announce": "Der moderne Ersatz für <bold>Salesforce Workbench</bold> und <bold>Benchpress</bold>",
+        "announce": "Workbench <bold>2.1.1</bold> ist da — der Agent prüft den Tab neben dem Seitenpanel, und die Modellauswahl lädt Live-Kataloge aus Ihren API-Schlüsseln",
         "nav": {
             "github": "GitHub",
             "docs": "Docs",

--- a/apps/ui/src/locales/en.json
+++ b/apps/ui/src/locales/en.json
@@ -1,6 +1,6 @@
 {
     "chrome": {
-        "announce": "The modern replacement for <bold>Salesforce Workbench</bold> and <bold>Benchpress</bold>",
+        "announce": "Workbench <bold>2.1.1</bold> is here — the Agent inspects the tab beside the side panel, and the model picker loads live catalogs from your API keys",
         "nav": {
             "github": "GitHub",
             "docs": "Docs",

--- a/apps/ui/src/locales/en.json
+++ b/apps/ui/src/locales/en.json
@@ -17,9 +17,35 @@
     "home": {
         "hero": {
             "eyebrow": "Salesforce Administration Toolkit",
-            "title": "The toolkit built for Salesforce admins",
+            "title": "The toolkit built by Salesforce Engineers",
             "body": "Workbench embeds directly into Salesforce with a page overlay, brings a VS Code editor to your browser, a full metadata explorer, and an AI agent that can control your browser — all in one extension.",
             "cta": "Add Web Extension"
+        },
+        "demo": {
+            "ariaLabel": "Product demo",
+            "seeAllFeatures": "See all features",
+            "headings": {
+                "overlay": "Overlay",
+                "editor": "VS Code",
+                "soql": "SOQL",
+                "agent": "Agent"
+            },
+            "captions": {
+                "edge": "A Salesforce page — Workbench sits on the edge.",
+                "overlay": "The overlay slides in without leaving the record.",
+                "search": "Search objects without leaving the page.",
+                "vscode": "Open VS Code without leaving Salesforce.",
+                "loadingEditor": "Opening VS Code…",
+                "typeCode": "Create an LWC in the same browser.",
+                "editorReady": "The template is ready — now query the data.",
+                "loading": "Opening SOQL Explorer…",
+                "toolkit": "The full toolkit, still in the browser.",
+                "query": "Write SOQL with the org in view.",
+                "results": "Accounts from Acme, instantly.",
+                "ask": "Open the side panel on any website.",
+                "stream": "The agent fills the support form.",
+                "action": "Submitted — without leaving the page."
+            }
         },
         "features": {
             "overlay": {

--- a/apps/ui/src/locales/es.json
+++ b/apps/ui/src/locales/es.json
@@ -17,9 +17,35 @@
     "home": {
         "hero": {
             "eyebrow": "Kit de herramientas para administradores de Salesforce",
-            "title": "El toolkit creado para admins de Salesforce",
+            "title": "El toolkit creado por ingenieros de Salesforce",
             "body": "Workbench se integra directamente en Salesforce con un panel superpuesto, trae un editor VS Code a tu navegador, un explorador completo de metadatos y un agente de IA que puede controlar tu navegador — todo en una sola extensión.",
             "cta": "Añadir extensión web"
+        },
+        "demo": {
+            "ariaLabel": "Demo del producto",
+            "seeAllFeatures": "Ver todas las funciones",
+            "headings": {
+                "overlay": "Overlay",
+                "editor": "VS Code",
+                "soql": "SOQL",
+                "agent": "Agente"
+            },
+            "captions": {
+                "edge": "Una página de Salesforce — Workbench queda al borde.",
+                "overlay": "El panel se desliza sin salir del registro.",
+                "search": "Busca objetos sin salir de la página.",
+                "vscode": "Abre VS Code sin salir de Salesforce.",
+                "loadingEditor": "Abriendo VS Code…",
+                "typeCode": "Crea un LWC en el mismo navegador.",
+                "editorReady": "La plantilla está lista — ahora consulta los datos.",
+                "loading": "Abriendo el explorador SOQL…",
+                "toolkit": "El toolkit completo, todavía en el navegador.",
+                "query": "Escribe SOQL con la org a la vista.",
+                "results": "Cuentas de Acme, al instante.",
+                "ask": "Abre el panel lateral en cualquier sitio.",
+                "stream": "El agente rellena el formulario de soporte.",
+                "action": "Enviado — sin salir de la página."
+            }
         },
         "features": {
             "overlay": {

--- a/apps/ui/src/locales/es.json
+++ b/apps/ui/src/locales/es.json
@@ -1,6 +1,6 @@
 {
     "chrome": {
-        "announce": "El reemplazo moderno de <bold>Salesforce Workbench</bold> y <bold>Benchpress</bold>",
+        "announce": "Workbench <bold>2.1.1</bold> ya está aquí — el Agente inspecciona la pestaña junto al panel lateral, y el selector de modelos carga catálogos en vivo desde tus claves API",
         "nav": {
             "github": "GitHub",
             "docs": "Docs",

--- a/apps/ui/src/locales/fr.json
+++ b/apps/ui/src/locales/fr.json
@@ -17,9 +17,35 @@
     "home": {
         "hero": {
             "eyebrow": "Boîte à outils pour administrateurs Salesforce",
-            "title": "La boîte à outils pour les admins Salesforce",
+            "title": "La boîte à outils conçue par des ingénieurs Salesforce",
             "body": "Workbench s'intègre directement dans Salesforce avec un panneau superposé, apporte un éditeur VS Code dans votre navigateur, un explorateur de métadonnées complet et un agent IA capable de contrôler votre navigateur — tout en une seule extension.",
             "cta": "Ajouter l'extension"
+        },
+        "demo": {
+            "ariaLabel": "Démo produit",
+            "seeAllFeatures": "Voir toutes les fonctionnalités",
+            "headings": {
+                "overlay": "Overlay",
+                "editor": "VS Code",
+                "soql": "SOQL",
+                "agent": "Agent"
+            },
+            "captions": {
+                "edge": "Une page Salesforce — Workbench reste sur le bord.",
+                "overlay": "Le panneau glisse sans quitter l'enregistrement.",
+                "search": "Recherchez des objets sans quitter la page.",
+                "vscode": "Ouvrez VS Code sans quitter Salesforce.",
+                "loadingEditor": "Ouverture de VS Code…",
+                "typeCode": "Créez un LWC dans le même navigateur.",
+                "editorReady": "Le modèle est prêt — interrogez les données.",
+                "loading": "Ouverture de l'explorateur SOQL…",
+                "toolkit": "Toute la boîte à outils, toujours dans le navigateur.",
+                "query": "Écrivez du SOQL avec l'org sous les yeux.",
+                "results": "Les comptes d'Acme, instantanément.",
+                "ask": "Ouvrez le panneau latéral sur n'importe quel site.",
+                "stream": "L'agent remplit le formulaire d'assistance.",
+                "action": "Envoyé — sans quitter la page."
+            }
         },
         "features": {
             "overlay": {

--- a/apps/ui/src/locales/fr.json
+++ b/apps/ui/src/locales/fr.json
@@ -1,6 +1,6 @@
 {
     "chrome": {
-        "announce": "Le remplaçant moderne de <bold>Salesforce Workbench</bold> et <bold>Benchpress</bold>",
+        "announce": "Workbench <bold>2.1.1</bold> est disponible — l'Agent inspecte l'onglet à côté du panneau latéral, et le sélecteur de modèles charge les catalogues en direct depuis vos clés API",
         "nav": {
             "github": "GitHub",
             "docs": "Docs",

--- a/apps/ui/src/locales/ja.json
+++ b/apps/ui/src/locales/ja.json
@@ -1,6 +1,6 @@
 {
     "chrome": {
-        "announce": "<bold>Salesforce Workbench</bold> と <bold>Benchpress</bold> の現代的な代替ツール",
+        "announce": "Workbench <bold>2.1.1</bold> リリース — エージェントはサイドパネル横のタブを直接確認でき、モデル選択は API キーから最新カタログを読み込みます",
         "nav": {
             "github": "GitHub",
             "docs": "ドキュメント",

--- a/apps/ui/src/locales/ja.json
+++ b/apps/ui/src/locales/ja.json
@@ -17,9 +17,35 @@
     "home": {
         "hero": {
             "eyebrow": "Salesforce 管理者向けツールキット",
-            "title": "Salesforce 管理者のための統合ツールキット",
+            "title": "Salesforce エンジニアが構築したツールキット",
             "body": "Workbench は Salesforce に直接組み込まれ、ページオーバーレイ、ブラウザ内 VS Code エディタ、フルメタデータエクスプローラー、ブラウザを操作できる AI エージェントをひとつの拡張機能として提供します。",
             "cta": "拡張機能を追加"
+        },
+        "demo": {
+            "ariaLabel": "製品デモ",
+            "seeAllFeatures": "すべての機能を見る",
+            "headings": {
+                "overlay": "Overlay",
+                "editor": "VS Code",
+                "soql": "SOQL",
+                "agent": "Agent"
+            },
+            "captions": {
+                "edge": "Salesforce のページ — Workbench は端に控えています。",
+                "overlay": "レコードを離れることなくオーバーレイが滑り込む。",
+                "search": "ページを離れずにオブジェクトを検索。",
+                "vscode": "Salesforce を離れずに VS Code を開く。",
+                "loadingEditor": "VS Code を開いています…",
+                "typeCode": "同じブラウザで LWC を作る。",
+                "editorReady": "テンプレートの準備完了 — 次はデータを照会。",
+                "loading": "SOQL Explorer を開いています…",
+                "toolkit": "フルツールキットは、まだブラウザの中。",
+                "query": "Org を見ながら SOQL を書く。",
+                "results": "Acme の Account がすぐに表示。",
+                "ask": "どのサイトでもサイドパネルを開く。",
+                "stream": "エージェントがサポートフォームを入力する。",
+                "action": "ページを離れずに送信。"
+            }
         },
         "features": {
             "overlay": {

--- a/apps/ui/src/main.tsx
+++ b/apps/ui/src/main.tsx
@@ -5,6 +5,7 @@ import './i18n';
 import App from './App';
 import Welcome from './Welcome';
 import './styles.css';
+import './product-tour/product-tour.css';
 
 const gaId = import.meta.env.VITE_GA_MEASUREMENT_ID as string | undefined;
 if (gaId) {
@@ -15,7 +16,9 @@ if (gaId) {
     // @ts-expect-error — gtag global injected at runtime
     window.dataLayer = window.dataLayer || [];
     // @ts-expect-error — gtag global injected at runtime
-    window.gtag = function gtag() { window.dataLayer.push(arguments); };
+    window.gtag = function gtag() {
+        window.dataLayer.push(arguments);
+    };
     // @ts-expect-error — gtag global injected at runtime
     window.gtag('js', new Date());
     // @ts-expect-error — gtag global injected at runtime

--- a/apps/ui/src/product-tour/ProductDemo.tsx
+++ b/apps/ui/src/product-tour/ProductDemo.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FakeBrowser } from '../SiteChrome';
+import {
+    completedScene,
+    demoUrlForView,
+    FLOW_LOOP_MS,
+    headingForView,
+    sceneForElapsed,
+} from './flow-scene';
+import { SpatialFixture } from './SpatialFixture';
+import { HomeFlowWireframe, SlideWireframe } from './wireframes';
+import type { TourSlideId } from './slides';
+import { completedSlidePlay, slideLoopMs, slidePlayForElapsed } from './slide-scene';
+
+function usePrefersReducedMotion(): boolean {
+    const [reduce, setReduce] = useState(false);
+    useEffect(() => {
+        const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+        setReduce(media.matches);
+        const onChange = () => setReduce(media.matches);
+        media.addEventListener('change', onChange);
+        return () => media.removeEventListener('change', onChange);
+    }, []);
+    return reduce;
+}
+
+function useTourElapsed(loopMs: number, enabled: boolean): number {
+    const [elapsed, setElapsed] = useState(0);
+    useEffect(() => {
+        if (!enabled || loopMs <= 0) return;
+        let frame = 0;
+        const origin = performance.now();
+        const tick = (now: number) => {
+            setElapsed((now - origin) % loopMs);
+            frame = requestAnimationFrame(tick);
+        };
+        frame = requestAnimationFrame(tick);
+        return () => cancelAnimationFrame(frame);
+    }, [enabled, loopMs]);
+    return elapsed;
+}
+
+export function ProductDemo(): ReactNode {
+    const { t } = useTranslation();
+    const reduceMotion = usePrefersReducedMotion();
+    const elapsed = useTourElapsed(FLOW_LOOP_MS, !reduceMotion);
+    const scene = reduceMotion ? completedScene() : sceneForElapsed(elapsed);
+    const heading = headingForView(scene.view);
+
+    return (
+        <div className="product-tour" data-tour-demo>
+            <section aria-label={t('home.demo.ariaLabel')}>
+                <header className="product-tour-heading">
+                    <h2>{t(`home.demo.headings.${heading}`)}</h2>
+                    <p>{t(`home.demo.captions.${scene.captionKey}`)}</p>
+                </header>
+                <SpatialFixture>
+                    <FakeBrowser url={demoUrlForView(scene.view)}>
+                        <HomeFlowWireframe scene={scene} />
+                    </FakeBrowser>
+                </SpatialFixture>
+                <p className="product-tour-more">
+                    <a className="button button-ghost button-small" href="#overlay">
+                        {t('home.demo.seeAllFeatures')}
+                    </a>
+                </p>
+            </section>
+        </div>
+    );
+}
+
+export function FeatureSlide({ slideId, url }: { slideId: TourSlideId; url: string }): ReactNode {
+    const reduceMotion = usePrefersReducedMotion();
+    const rootRef = useRef<HTMLDivElement>(null);
+    const [inView, setInView] = useState(false);
+
+    useEffect(() => {
+        const el = rootRef.current;
+        if (!el) return;
+        const obs = new IntersectionObserver(([entry]) => setInView(entry.isIntersecting), {
+            threshold: 0.35,
+        });
+        obs.observe(el);
+        return () => obs.disconnect();
+    }, []);
+
+    const loopMs = slideLoopMs(slideId);
+    const elapsed = useTourElapsed(loopMs, inView && !reduceMotion);
+    const play =
+        inView && !reduceMotion
+            ? slidePlayForElapsed(slideId, elapsed)
+            : completedSlidePlay(slideId);
+
+    return (
+        <div ref={rootRef}>
+            <SpatialFixture>
+                <FakeBrowser url={url}>
+                    <SlideWireframe slideId={slideId} play={play} />
+                </FakeBrowser>
+            </SpatialFixture>
+        </div>
+    );
+}

--- a/apps/ui/src/product-tour/SpatialFixture.tsx
+++ b/apps/ui/src/product-tour/SpatialFixture.tsx
@@ -1,0 +1,67 @@
+import { useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
+import { spatialFixtureScale } from './slides';
+
+export function SpatialFixture({ children }: { children: ReactNode }): ReactNode {
+    const frameRef = useRef<HTMLDivElement>(null);
+    const fixtureRef = useRef<HTMLDivElement>(null);
+    const [geometry, setGeometry] = useState({
+        scale: 1,
+        height: null as number | null,
+        width: null as number | null,
+        offsetX: 0,
+    });
+
+    useLayoutEffect(() => {
+        const frame = frameRef.current;
+        const fixture = fixtureRef.current;
+        if (!frame || !fixture) return;
+        const measure = () => {
+            const authoredWidth = fixture.scrollWidth;
+            const authoredHeight = fixture.scrollHeight;
+            const scale = spatialFixtureScale(frame.clientWidth, authoredWidth);
+            const scaled = Math.abs(scale - 1) >= 0.0001;
+            const height = scaled ? authoredHeight * scale : null;
+            const width = scaled ? authoredWidth : null;
+            const offsetX = scaled ? (frame.clientWidth - authoredWidth) / 2 : 0;
+            setGeometry(current =>
+                Math.abs(current.scale - scale) < 0.0001 &&
+                current.height === height &&
+                current.width === width &&
+                Math.abs(current.offsetX - offsetX) < 0.5
+                    ? current
+                    : { scale, height, width, offsetX }
+            );
+        };
+        measure();
+        const observer = new ResizeObserver(measure);
+        observer.observe(frame);
+        observer.observe(fixture);
+        return () => observer.disconnect();
+    }, []);
+
+    const scaled = geometry.height !== null;
+    return (
+        <div
+            ref={frameRef}
+            data-tour-scale={geometry.scale.toFixed(4)}
+            className="product-tour-spatial"
+            style={scaled ? { height: geometry.height ?? undefined } : undefined}
+        >
+            <div
+                ref={fixtureRef}
+                className="product-tour-spatial-inner"
+                style={
+                    scaled
+                        ? ({
+                              transform: `scale(${geometry.scale})`,
+                              width: geometry.width ?? undefined,
+                              marginLeft: geometry.offsetX,
+                          } as CSSProperties)
+                        : undefined
+                }
+            >
+                {children}
+            </div>
+        </div>
+    );
+}

--- a/apps/ui/src/product-tour/__test__/flow-scene.test.ts
+++ b/apps/ui/src/product-tour/__test__/flow-scene.test.ts
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+    ASSISTANT_REPLY,
+    CHAR_MS,
+    FORM_EMAIL,
+    FORM_MESSAGE,
+    FORM_NAME,
+    FORM_ORDER,
+    LWC_HTML,
+    PALETTE_QUERY,
+    SEARCH_QUERY,
+    SOQL_QUERY,
+    FLOW_LOOP_MS,
+    T,
+    T_ACTION,
+    T_BUNDLE,
+    T_EDITOR,
+    T_FORM_NAME,
+    T_HTML_DONE,
+    T_LOADING_EDITOR,
+    T_LOADING_SOQL,
+    T_PALETTE,
+    T_RESULTS,
+    T_SIDEPANEL,
+    T_SOQL,
+    T_STREAM,
+    T_TYPE_HTML,
+    T_TYPE_PALETTE,
+    T_VSCODE_PULSE,
+    completedScene,
+    headingForView,
+    sceneForElapsed,
+} from '../flow-scene.ts';
+import { MAX_FIXTURE_SCALE, spatialFixtureScale } from '../slides.ts';
+import { completedSlidePlay, slidePlayForElapsed } from '../slide-scene.ts';
+
+test('spatialFixtureScale: scales together and caps at the legibility ceiling', () => {
+    assert.equal(spatialFixtureScale(360, 720), 0.5);
+    assert.equal(spatialFixtureScale(720, 720), 1);
+    assert.equal(spatialFixtureScale(1280, 720), MAX_FIXTURE_SCALE);
+    assert.equal(spatialFixtureScale(1280, 720, 700, 700), 1);
+    assert.equal(spatialFixtureScale(1280, 720, 350, 700), 0.5);
+});
+
+test('sceneForElapsed: starts on a Salesforce page with the overlay closed', () => {
+    const scene = sceneForElapsed(0);
+    assert.equal(scene.view, 'salesforce');
+    assert.equal(scene.overlayOpen, false);
+    assert.equal(scene.loading, false);
+    assert.equal(scene.captionKey, 'edge');
+    assert.equal(headingForView(scene.view), 'overlay');
+});
+
+test('sceneForElapsed: opens the overlay then types Account', () => {
+    const opened = sceneForElapsed(T.overlayOpen + 10);
+    assert.equal(opened.overlayOpen, true);
+    assert.equal(opened.captionKey, 'overlay');
+    const typing = sceneForElapsed(T.typeSearch + SEARCH_QUERY.length * CHAR_MS);
+    assert.equal(typing.overlaySearch, SEARCH_QUERY);
+    assert.equal(typing.captionKey, 'search');
+});
+
+test('sceneForElapsed: pulses VS Code then opens the editor', () => {
+    const pulse = sceneForElapsed(T_VSCODE_PULSE + 10);
+    assert.equal(pulse.vscodeHot, true);
+    assert.equal(pulse.view, 'salesforce');
+    const loading = sceneForElapsed(T_LOADING_EDITOR + 50);
+    assert.equal(loading.loading, true);
+    assert.equal(loading.loadingTarget, 'editor');
+    assert.equal(loading.captionKey, 'loadingEditor');
+    const editor = sceneForElapsed(T_EDITOR + 10);
+    assert.equal(editor.view, 'editor');
+    assert.equal(editor.loading, false);
+    assert.equal(headingForView(editor.view), 'editor');
+});
+
+test('sceneForElapsed: opens the palette then types an LWC template', () => {
+    const palette = sceneForElapsed(T_PALETTE + 10);
+    assert.equal(palette.view, 'editor');
+    assert.equal(palette.paletteOpen, true);
+    assert.equal(palette.palettePhase, 'command');
+    const typingCmd = sceneForElapsed(T_TYPE_PALETTE + PALETTE_QUERY.length * CHAR_MS);
+    assert.equal(typingCmd.paletteQuery, PALETTE_QUERY);
+    const bundled = sceneForElapsed(T_BUNDLE + 10);
+    assert.equal(bundled.bundleReady, true);
+    assert.equal(bundled.paletteOpen, false);
+    const typing = sceneForElapsed(T_TYPE_HTML + 10);
+    assert.equal(typing.caret, 'editor');
+    assert.equal(typing.editorDirty, true);
+    const done = sceneForElapsed(T_HTML_DONE + 10);
+    assert.equal(done.editorTyped, LWC_HTML);
+    assert.match(done.editorTyped, /<lightning-card title=\{name\}>/);
+    assert.equal(done.captionKey, 'editorReady');
+});
+
+test('sceneForElapsed: lands in SOQL Explorer with a typed query and results', () => {
+    const loading = sceneForElapsed(T_LOADING_SOQL + 20);
+    assert.equal(loading.loadingTarget, 'soql');
+    const soql = sceneForElapsed(T_SOQL + 10);
+    assert.equal(soql.view, 'soql');
+    assert.equal(soql.loading, false);
+    assert.equal(headingForView(soql.view), 'soql');
+    const withQuery = sceneForElapsed(T_RESULTS + 10);
+    assert.equal(withQuery.soqlDraft, SOQL_QUERY);
+    assert.equal(withQuery.resultsVisible, true);
+    assert.equal(withQuery.captionKey, 'results');
+});
+
+test('sceneForElapsed: opens a side panel and fills the Acme support form', () => {
+    const panel = sceneForElapsed(T_SIDEPANEL + 10);
+    assert.equal(panel.view, 'sidepanel');
+    assert.equal(headingForView(panel.view), 'agent');
+    assert.equal(panel.captionKey, 'ask');
+    const streaming = sceneForElapsed(T_STREAM + 50);
+    assert.ok(streaming.assistant.length > 0);
+    const filling = sceneForElapsed(T_FORM_NAME + 10);
+    assert.equal(filling.formFocus, 'name');
+    assert.equal(filling.formName, FORM_NAME);
+    assert.equal(filling.captionKey, 'stream');
+    const submitted = sceneForElapsed(T_ACTION + 10);
+    assert.equal(submitted.assistant, ASSISTANT_REPLY);
+    assert.equal(submitted.formFocus, 'submit');
+    assert.equal(submitted.formEmail, FORM_EMAIL);
+    assert.equal(submitted.formOrder, FORM_ORDER);
+    assert.equal(submitted.formMessage, FORM_MESSAGE);
+    assert.equal(submitted.formSubmitPulse, true);
+    assert.equal(submitted.captionKey, 'action');
+});
+
+test('completedScene: freezes on the filled support form', () => {
+    const scene = completedScene();
+    assert.equal(scene.view, 'sidepanel');
+    assert.equal(scene.formName, FORM_NAME);
+    assert.equal(scene.formFocus, 'submit');
+    assert.equal(scene.assistant, ASSISTANT_REPLY);
+    assert.equal(scene.loading, false);
+    assert.equal(sceneForElapsed(FLOW_LOOP_MS - 1).view, 'sidepanel');
+});
+
+test('slidePlayForElapsed: editor creates an LWC then types the template', () => {
+    const start = slidePlayForElapsed('editor', 0);
+    assert.equal(start.editorTyped, '');
+    assert.equal(start.bundleReady, false);
+    assert.equal(start.paletteOpen, false);
+    const done = completedSlidePlay('editor');
+    assert.equal(done.bundleReady, true);
+    assert.equal(done.editorTyped, LWC_HTML);
+    assert.match(done.editorTyped, /<template>/);
+    assert.equal(done.editorDirty, false);
+    assert.equal(done.paletteOpen, false);
+});
+
+test('slidePlayForElapsed: metadata filters then selects Account', () => {
+    const start = slidePlayForElapsed('workbench', 0);
+    assert.equal(start.metaSelected, false);
+    const done = completedSlidePlay('workbench');
+    assert.equal(done.metaFilter, SEARCH_QUERY);
+    assert.equal(done.metaSelected, true);
+});
+
+test('slidePlayForElapsed: SOQL types a query then shows results', () => {
+    const start = slidePlayForElapsed('soql', 0);
+    assert.equal(start.resultsVisible, false);
+    const done = completedSlidePlay('soql');
+    assert.equal(done.soqlDraft, SOQL_QUERY);
+    assert.equal(done.resultsVisible, true);
+});
+
+test('slidePlayForElapsed: agent fills the Acme support form', () => {
+    const start = slidePlayForElapsed('agent', 0);
+    assert.equal(start.formName, '');
+    assert.equal(start.formFocus, null);
+    const done = completedSlidePlay('agent');
+    assert.equal(done.formName, FORM_NAME);
+    assert.equal(done.formEmail, FORM_EMAIL);
+    assert.equal(done.formOrder, FORM_ORDER);
+    assert.equal(done.formMessage, FORM_MESSAGE);
+    assert.equal(done.formFocus, 'submit');
+    assert.equal(done.assistant, ASSISTANT_REPLY);
+});

--- a/apps/ui/src/product-tour/flow-scene.ts
+++ b/apps/ui/src/product-tour/flow-scene.ts
@@ -1,0 +1,230 @@
+export type FlowView = 'salesforce' | 'editor' | 'soql' | 'sidepanel';
+
+export type CaptionKey =
+    | 'edge'
+    | 'overlay'
+    | 'search'
+    | 'vscode'
+    | 'loadingEditor'
+    | 'typeCode'
+    | 'editorReady'
+    | 'loading'
+    | 'toolkit'
+    | 'query'
+    | 'results'
+    | 'ask'
+    | 'stream'
+    | 'action';
+
+export type CaretTarget = 'search' | 'editor' | 'soql' | 'palette' | null;
+
+export type LoadingTarget = 'editor' | 'soql' | null;
+
+export type PalettePhase = 'command' | 'name' | null;
+
+export type FormFocus = 'name' | 'email' | 'order' | 'message' | 'submit' | null;
+
+export interface FlowScene {
+    view: FlowView;
+    overlayOpen: boolean;
+    overlaySearch: string;
+    soqlDraft: string;
+    resultsVisible: boolean;
+    loading: boolean;
+    loadingTarget: LoadingTarget;
+    assistant: string;
+    caret: CaretTarget;
+    vscodeHot: boolean;
+    soqlHot: boolean;
+    sendPulse: boolean;
+    paletteOpen: boolean;
+    palettePhase: PalettePhase;
+    paletteQuery: string;
+    paletteName: string;
+    bundleReady: boolean;
+    editorTyped: string;
+    editorDirty: boolean;
+    formFocus: FormFocus;
+    formName: string;
+    formEmail: string;
+    formOrder: string;
+    formMessage: string;
+    formSubmitPulse: boolean;
+    captionKey: CaptionKey;
+}
+
+export const SEARCH_QUERY = 'Account';
+export const SOQL_QUERY = 'SELECT Id, Name, Industry FROM Account LIMIT 10';
+export const PALETTE_QUERY = 'Create LWC';
+export const LWC_BUNDLE = 'accountHighlight';
+export const LWC_HTML = `<template>
+  <lightning-card title={name}>
+    <p class="slds-p-horizontal_small">{industry}</p>
+  </lightning-card>
+</template>`;
+export const FORM_NAME = 'Alex Rivera';
+export const FORM_EMAIL = 'alex@acme.com';
+export const FORM_ORDER = '1842';
+export const FORM_MESSAGE = 'Need help with the Acme Corp shipment.';
+export const ASSISTANT_REPLY = 'Filled name, email, and order 1842. Ready to send.';
+
+export const CHAR_MS = 42;
+export const STREAM_MS = 22;
+
+const searchDur = SEARCH_QUERY.length * CHAR_MS;
+const paletteDur = PALETTE_QUERY.length * CHAR_MS;
+const bundleDur = LWC_BUNDLE.length * CHAR_MS;
+const htmlDur = LWC_HTML.length * STREAM_MS;
+const queryDur = SOQL_QUERY.length * CHAR_MS;
+
+export const T = {
+    overlayOpen: 900,
+    typeSearch: 1800,
+} as const;
+
+export const T_SEARCH_DONE = T.typeSearch + searchDur + 380;
+export const T_VSCODE_PULSE = T_SEARCH_DONE + 180;
+export const T_LOADING_EDITOR = T_VSCODE_PULSE + 900;
+export const T_EDITOR = T_LOADING_EDITOR + 1200;
+export const T_PALETTE = T_EDITOR + 280;
+export const T_TYPE_PALETTE = T_PALETTE + 180;
+export const T_PALETTE_PICK = T_TYPE_PALETTE + paletteDur + 420;
+export const T_TYPE_BUNDLE = T_PALETTE_PICK + 220;
+export const T_BUNDLE = T_TYPE_BUNDLE + bundleDur + 380;
+export const T_TYPE_HTML = T_BUNDLE + 320;
+export const T_HTML_DONE = T_TYPE_HTML + htmlDur + 420;
+export const T_LOADING_SOQL = T_HTML_DONE + 700;
+export const T_SOQL = T_LOADING_SOQL + 1200;
+export const T_TYPE_QUERY = T_SOQL + 420;
+export const T_RUN = T_TYPE_QUERY + queryDur + 280;
+export const T_RESULTS = T_RUN + 520;
+export const T_SIDEPANEL = T_RESULTS + 1600;
+export const T_STREAM = T_SIDEPANEL + 480;
+export const T_FORM_NAME = T_SIDEPANEL + 700;
+export const T_FORM_EMAIL = T_FORM_NAME + 650;
+export const T_FORM_ORDER = T_FORM_EMAIL + 650;
+export const T_FORM_MESSAGE = T_FORM_ORDER + 650;
+export const T_FORM_SUBMIT = T_FORM_MESSAGE + 800;
+export const T_ACTION = T_FORM_SUBMIT;
+export const FLOW_LOOP_MS = T_FORM_SUBMIT + 3200;
+
+export function typed(text: string, start: number, now: number, msPerChar: number): string {
+    if (now < start) return '';
+    const chars = Math.floor((now - start) / msPerChar);
+    return text.slice(0, Math.max(0, Math.min(text.length, chars)));
+}
+
+export function inRange(now: number, start: number, end: number): boolean {
+    return now >= start && now < end;
+}
+
+function captionFor(now: number): CaptionKey {
+    if (now >= T_FORM_SUBMIT) return 'action';
+    if (now >= T_FORM_NAME) return 'stream';
+    if (now >= T_SIDEPANEL) return 'ask';
+    if (now >= T_RESULTS) return 'results';
+    if (now >= T_TYPE_QUERY) return 'query';
+    if (now >= T_SOQL) return 'toolkit';
+    if (now >= T_LOADING_SOQL) return 'loading';
+    if (now >= T_HTML_DONE) return 'editorReady';
+    if (now >= T_TYPE_HTML) return 'typeCode';
+    if (now >= T_BUNDLE) return 'typeCode';
+    if (now >= T_PALETTE) return 'typeCode';
+    if (now >= T_EDITOR) return 'typeCode';
+    if (now >= T_LOADING_EDITOR) return 'loadingEditor';
+    if (now >= T_VSCODE_PULSE) return 'vscode';
+    if (now >= T.typeSearch) return 'search';
+    if (now >= T.overlayOpen) return 'overlay';
+    return 'edge';
+}
+
+export function headingForView(view: FlowView): 'overlay' | 'editor' | 'soql' | 'agent' {
+    if (view === 'editor') return 'editor';
+    if (view === 'soql') return 'soql';
+    if (view === 'sidepanel') return 'agent';
+    return 'overlay';
+}
+
+function formFocusFor(now: number): FormFocus {
+    if (now >= T_FORM_SUBMIT) return 'submit';
+    if (now >= T_FORM_MESSAGE) return 'message';
+    if (now >= T_FORM_ORDER) return 'order';
+    if (now >= T_FORM_EMAIL) return 'email';
+    if (now >= T_FORM_NAME) return 'name';
+    return null;
+}
+
+export function sceneForElapsed(ms: number): FlowScene {
+    const now = Number.isFinite(ms) ? Math.max(0, ms) : 0;
+    const loadingTarget: LoadingTarget = inRange(now, T_LOADING_EDITOR, T_EDITOR)
+        ? 'editor'
+        : inRange(now, T_LOADING_SOQL, T_SOQL)
+          ? 'soql'
+          : null;
+    const view: FlowView =
+        now >= T_SIDEPANEL
+            ? 'sidepanel'
+            : now >= T_SOQL
+              ? 'soql'
+              : now >= T_EDITOR
+                ? 'editor'
+                : 'salesforce';
+
+    let palettePhase: PalettePhase = null;
+    if (inRange(now, T_PALETTE, T_PALETTE_PICK)) palettePhase = 'command';
+    else if (inRange(now, T_PALETTE_PICK, T_BUNDLE)) palettePhase = 'name';
+
+    let caret: CaretTarget = null;
+    if (inRange(now, T.typeSearch, T_SEARCH_DONE)) caret = 'search';
+    else if (inRange(now, T_TYPE_PALETTE, T_BUNDLE)) caret = 'palette';
+    else if (inRange(now, T_TYPE_HTML, T_HTML_DONE)) caret = 'editor';
+    else if (inRange(now, T_TYPE_QUERY, T_RUN)) caret = 'soql';
+
+    const focus = formFocusFor(now);
+
+    return {
+        view,
+        overlayOpen: now >= T.overlayOpen,
+        overlaySearch: typed(SEARCH_QUERY, T.typeSearch, now, CHAR_MS),
+        soqlDraft: typed(SOQL_QUERY, T_TYPE_QUERY, now, CHAR_MS),
+        resultsVisible: now >= T_RESULTS,
+        loading: loadingTarget !== null,
+        loadingTarget,
+        assistant: typed(ASSISTANT_REPLY, T_STREAM, now, STREAM_MS),
+        caret,
+        vscodeHot: inRange(now, T_VSCODE_PULSE, T_LOADING_EDITOR),
+        soqlHot: false,
+        sendPulse: inRange(now, T_RUN, T_RESULTS),
+        paletteOpen: palettePhase !== null,
+        palettePhase,
+        paletteQuery: typed(PALETTE_QUERY, T_TYPE_PALETTE, now, CHAR_MS),
+        paletteName: typed(LWC_BUNDLE, T_TYPE_BUNDLE, now, CHAR_MS),
+        bundleReady: now >= T_BUNDLE,
+        editorTyped: typed(LWC_HTML, T_TYPE_HTML, now, STREAM_MS),
+        editorDirty: now >= T_TYPE_HTML && now < T_HTML_DONE + 350,
+        formFocus: focus,
+        formName: now >= T_FORM_NAME ? FORM_NAME : '',
+        formEmail: now >= T_FORM_EMAIL ? FORM_EMAIL : '',
+        formOrder: now >= T_FORM_ORDER ? FORM_ORDER : '',
+        formMessage: now >= T_FORM_MESSAGE ? FORM_MESSAGE : '',
+        formSubmitPulse: inRange(now, T_FORM_SUBMIT, T_FORM_SUBMIT + 900),
+        captionKey: captionFor(now),
+    };
+}
+
+export function completedScene(): FlowScene {
+    return sceneForElapsed(T_FORM_SUBMIT + 100);
+}
+
+export function demoUrlForView(view: FlowView): string {
+    if (view === 'salesforce') {
+        return 'acme.lightning.force.com/lightning/r/Account/001xx000003DHP0/view';
+    }
+    if (view === 'editor') {
+        return 'chrome - Workbench Editor';
+    }
+    if (view === 'sidepanel') {
+        return 'help.acme.com/support';
+    }
+    return 'chrome-extension://workbench/views/app.html';
+}

--- a/apps/ui/src/product-tour/product-tour.css
+++ b/apps/ui/src/product-tour/product-tour.css
@@ -1,0 +1,1244 @@
+/* Product tour — HTML fake Workbench / Lightning UI for the marketing homepage. */
+
+.product-tour {
+    --pt-navy: #032d60;
+    --pt-header: #16325c;
+    --pt-blue: #0176d3;
+    --pt-blue-dark: #014486;
+    --pt-text: #181818;
+    --pt-muted: #3e3e3c;
+    --pt-border: #c9c7c5;
+    --pt-bg: #f3f2f2;
+    --pt-white: #ffffff;
+    --pt-cloud: #1b96ff;
+    --pt-success: #2e844a;
+    --pt-font: 'Salesforce Sans', 'Segoe UI', system-ui, sans-serif;
+    --pt-mono: 'SF Mono', ui-monospace, Menlo, Consolas, monospace;
+    width: 100%;
+    max-width: 1120px;
+    margin: 0 auto;
+    color: var(--color-text);
+    text-align: left;
+}
+
+.product-tour-heading {
+    margin-bottom: 12px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.product-tour-heading h2 {
+    margin: 0;
+    font-size: 1.05rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+}
+
+.product-tour-heading p {
+    margin: 6px 0 0;
+    max-width: 42rem;
+    color: var(--color-text-muted);
+    font-size: 0.88rem;
+    line-height: 1.45;
+    font-weight: 400;
+}
+
+.product-tour-more {
+    display: flex;
+    justify-content: center;
+    margin: 18px 0 0;
+}
+
+.product-tour-spatial {
+    width: 100%;
+    overflow-x: clip;
+}
+
+.product-tour-spatial-inner {
+    transform-origin: top center;
+}
+
+.product-tour section {
+    overflow-x: clip;
+}
+
+.pt-stage {
+    position: relative;
+    overflow: hidden;
+    background: var(--pt-bg);
+    color: var(--pt-text);
+    font-family: var(--pt-font);
+    font-size: 12px;
+    line-height: 1.35;
+    user-select: none;
+}
+
+.pt-caret {
+    display: inline-block;
+    width: 1px;
+    height: 0.95em;
+    margin-left: 1px;
+    background: var(--pt-blue);
+    vertical-align: text-bottom;
+    animation: pt-pulse 1s steps(1) infinite;
+}
+
+.pt-pulse {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--pt-blue);
+    animation: pt-pulse 1.1s ease-in-out infinite;
+}
+
+@keyframes pt-pulse {
+    0%,
+    49% {
+        opacity: 1;
+    }
+    50%,
+    100% {
+        opacity: 0.15;
+    }
+}
+
+@keyframes pt-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@keyframes pt-sweep {
+    0% {
+        transform: translateX(-120%);
+    }
+    100% {
+        transform: translateX(220%);
+    }
+}
+
+/* ── Lightning page ──────────────────────────────────────── */
+
+.pt-lex {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    background: var(--pt-bg);
+}
+
+.pt-lex-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    height: 40px;
+    padding: 0 12px;
+    background: var(--pt-header);
+    color: #fff;
+    flex: 0 0 auto;
+}
+
+.pt-lex-launcher,
+.pt-lex-cloud {
+    display: grid;
+    place-items: center;
+    opacity: 0.92;
+}
+
+.pt-lex-app {
+    font-weight: 700;
+    font-size: 13px;
+    letter-spacing: 0.02em;
+}
+
+.pt-lex-search {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: 1;
+    max-width: 280px;
+    margin-left: 12px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 0.72);
+    font-size: 11px;
+}
+
+.pt-lex-header-end {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-left: auto;
+}
+
+.pt-avatar {
+    display: grid;
+    place-items: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: #1b96ff;
+    font-size: 10px;
+    font-weight: 700;
+}
+
+.pt-lex-nav {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    height: 32px;
+    padding: 0 12px;
+    background: #0b2e5b;
+    color: rgba(255, 255, 255, 0.78);
+    flex: 0 0 auto;
+}
+
+.pt-lex-nav span,
+.pt-lex-nav button {
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    padding: 4px 10px;
+    border-radius: 4px;
+}
+
+.pt-lex-nav .is-active {
+    background: rgba(255, 255, 255, 0.14);
+    color: #fff;
+    font-weight: 600;
+}
+
+.pt-lex-body {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    padding: 16px 20px;
+}
+
+.pt-record h3 {
+    margin: 0;
+    font-size: 22px;
+    letter-spacing: -0.02em;
+}
+
+.pt-record-kicker {
+    margin: 0 0 2px;
+    color: var(--pt-muted);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.pt-record-tabs {
+    display: flex;
+    gap: 16px;
+    margin: 12px 0 14px;
+    border-bottom: 1px solid var(--pt-border);
+    color: var(--pt-muted);
+}
+
+.pt-record-tabs span {
+    padding: 6px 0 8px;
+}
+
+.pt-record-tabs .is-active {
+    color: var(--pt-blue);
+    font-weight: 600;
+    box-shadow: inset 0 -2px 0 var(--pt-blue);
+}
+
+.pt-highlights {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 10px;
+    margin: 0 0 16px;
+}
+
+.pt-highlights dt {
+    color: var(--pt-muted);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.pt-highlights dd {
+    margin: 2px 0 0;
+    font-weight: 600;
+}
+
+.pt-skel-block {
+    display: grid;
+    gap: 8px;
+}
+
+.pt-skel-block i {
+    display: block;
+    height: 8px;
+    border-radius: 4px;
+    background: #e5e5e5;
+}
+
+.pt-skel-block i:nth-child(2) {
+    width: 78%;
+}
+
+.pt-skel-block i:nth-child(3) {
+    width: 64%;
+}
+
+.pt-skel-block i:nth-child(4) {
+    width: 52%;
+}
+
+/* ── Overlay ─────────────────────────────────────────────── */
+
+.pt-overlay-dock {
+    position: absolute;
+    top: 88px;
+    right: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 4px 6px 4px 4px;
+    background: var(--pt-white);
+    border: 1px solid var(--pt-navy);
+    border-radius: 6px 0 0 6px;
+    z-index: 3;
+}
+
+.pt-overlay-dock span,
+.pt-overlay-dock button,
+.pt-overlay-soql {
+    display: grid;
+    place-items: center;
+    width: 22px;
+    height: 22px;
+    border: 0;
+    background: transparent;
+    color: var(--pt-navy);
+    border-radius: 4px;
+    padding: 0;
+}
+
+.pt-overlay-dock .is-active,
+.pt-overlay-soql.is-hot {
+    background: #eef4ff;
+    color: var(--pt-blue);
+    box-shadow: 0 0 0 1px var(--pt-blue);
+}
+
+.pt-overlay {
+    position: absolute;
+    top: 78px;
+    right: 28px;
+    width: 320px;
+    height: calc(100% - 96px);
+    display: flex;
+    flex-direction: column;
+    background: rgba(255, 255, 255, 0.82);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(3, 45, 96, 0.35);
+    border-radius: 12px;
+    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.22);
+    overflow: hidden;
+    z-index: 2;
+    animation: pt-fade-in 280ms ease;
+}
+
+@keyframes pt-fade-in {
+    from {
+        opacity: 0;
+        transform: translateX(12px);
+    }
+    to {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+.pt-overlay-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--pt-border);
+}
+
+.pt-overlay-search {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: 1;
+    min-width: 0;
+    padding: 4px 8px;
+    border: 1px solid var(--pt-border);
+    border-radius: 4px;
+    background: var(--pt-white);
+    color: var(--pt-muted);
+}
+
+.pt-overlay-search-value {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--pt-text);
+}
+
+.pt-overlay-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--pt-navy);
+}
+
+.pt-overlay-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 10px;
+    color: var(--pt-muted);
+    font-size: 10px;
+    border-bottom: 1px solid var(--pt-border);
+}
+
+.pt-overlay-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 10px;
+    overflow: auto;
+}
+
+.pt-info-card {
+    margin: 0;
+    padding: 8px 10px 6px;
+    border: 1px solid var(--pt-border);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.7);
+}
+
+.pt-info-card legend {
+    padding: 0 4px;
+    font-size: 9px;
+    letter-spacing: 0.08em;
+    color: var(--pt-muted);
+}
+
+.pt-info-card div {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 3px 0;
+}
+
+.pt-info-card span {
+    color: var(--pt-muted);
+}
+
+.pt-info-card strong {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-weight: 600;
+}
+
+.pt-overlay-list {
+    margin: 0;
+    padding: 6px 0;
+    list-style: none;
+    overflow: auto;
+}
+
+.pt-overlay-list li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 7px 12px;
+}
+
+.pt-overlay-list li.is-hot {
+    background: #eef4ff;
+    color: var(--pt-blue-dark);
+    font-weight: 600;
+}
+
+/* ── Toolkit shell ───────────────────────────────────────── */
+
+.pt-toolkit {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    background: var(--pt-white);
+}
+
+.pt-nav {
+    display: flex;
+    flex-direction: column;
+    width: 168px;
+    flex: 0 0 168px;
+    padding: 8px 8px 10px;
+    background: #f7f7f7;
+    border-right: 1px solid var(--pt-border);
+}
+
+.pt-nav-brand {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px 10px;
+    font-weight: 700;
+    font-size: 13px;
+}
+
+.pt-beta {
+    padding: 1px 6px;
+    border-radius: 999px;
+    background: #f2f2f2;
+    border: 1px solid var(--pt-border);
+    color: var(--pt-muted);
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.pt-nav-group {
+    margin-bottom: 8px;
+}
+
+.pt-nav-group p {
+    margin: 0 8px 4px;
+    color: var(--pt-muted);
+    font-size: 9px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.pt-nav-item {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    width: 100%;
+    border: 0;
+    background: transparent;
+    color: var(--pt-text);
+    font: inherit;
+    padding: 5px 8px;
+    border-radius: 4px;
+    text-align: left;
+}
+
+.pt-nav-item,
+.pt-lex-nav button,
+.pt-overlay-soql,
+.pt-agent-toggle,
+.pt-tree-group button {
+    cursor: pointer;
+}
+
+.pt-nav-item.is-active {
+    background: #eef4ff;
+    color: var(--pt-blue-dark);
+    font-weight: 600;
+}
+
+.pt-nav-agent {
+    margin-top: auto;
+}
+
+.pt-toolkit-main {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    flex: 1;
+}
+
+.pt-context {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 40px;
+    padding: 0 12px;
+    border-bottom: 1px solid var(--pt-border);
+    background: var(--pt-white);
+}
+
+.pt-context-name {
+    font-weight: 700;
+}
+
+.pt-tab {
+    padding: 8px 10px 7px;
+    color: var(--pt-muted);
+}
+
+.pt-tab.is-active {
+    color: var(--pt-text);
+    font-weight: 600;
+    box-shadow: inset 0 -2px 0 var(--pt-blue);
+}
+
+.pt-context-end {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: auto;
+    color: var(--pt-muted);
+}
+
+.pt-agent-toggle {
+    display: grid;
+    place-items: center;
+    width: 24px;
+    height: 24px;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    border-radius: 4px;
+}
+
+.pt-agent-toggle.is-active {
+    color: var(--pt-blue);
+    background: #eef4ff;
+}
+
+.pt-canvas {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+}
+
+.pt-canvas > :first-child {
+    flex: 1;
+    min-width: 0;
+}
+
+/* ── SOQL ────────────────────────────────────────────────── */
+
+.pt-soql {
+    display: flex;
+    flex-direction: column;
+    background: var(--pt-white);
+}
+
+.pt-soql-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--pt-border);
+    color: var(--pt-muted);
+}
+
+.pt-run {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 10px;
+    border-radius: 4px;
+    background: var(--pt-blue);
+    color: #fff;
+    font-weight: 600;
+}
+
+.pt-run.is-pulse {
+    animation: pt-pulse 0.6s ease-in-out 2;
+}
+
+.pt-soql-editor {
+    margin: 0;
+    min-height: 88px;
+    padding: 10px 12px;
+    font-family: var(--pt-mono);
+    font-size: 12px;
+    color: #032d60;
+    background: #fafaf9;
+    border-bottom: 1px solid var(--pt-border);
+    white-space: pre-wrap;
+}
+
+.pt-placeholder {
+    color: #969492;
+}
+
+.pt-results {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 11px;
+}
+
+.pt-results th,
+.pt-results td {
+    padding: 6px 12px;
+    border-bottom: 1px solid var(--pt-border);
+    text-align: left;
+}
+
+.pt-results th {
+    background: #f3f3f3;
+    color: var(--pt-muted);
+    font-weight: 600;
+}
+
+.pt-soql-empty {
+    padding: 18px 12px;
+    color: var(--pt-muted);
+}
+
+/* ── Metadata ────────────────────────────────────────────── */
+
+.pt-meta {
+    display: flex;
+    height: 100%;
+}
+
+.pt-meta-tree {
+    width: 210px;
+    flex: 0 0 210px;
+    padding: 10px;
+    border-right: 1px solid var(--pt-border);
+    background: #fafaf9;
+}
+
+.pt-meta-filter {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 10px;
+    padding: 5px 8px;
+    border: 1px solid var(--pt-border);
+    border-radius: 4px;
+    background: var(--pt-white);
+    color: var(--pt-muted);
+}
+
+.pt-tree-group {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-bottom: 10px;
+}
+
+.pt-tree-group span,
+.pt-tree-group button {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    padding: 4px 6px;
+    border-radius: 4px;
+    text-align: left;
+}
+
+.pt-tree-group .is-active {
+    background: #eef4ff;
+    color: var(--pt-blue-dark);
+    font-weight: 600;
+}
+
+.pt-meta-detail {
+    flex: 1;
+    padding: 14px 16px;
+}
+
+.pt-meta-detail header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 14px;
+    font-size: 16px;
+    font-weight: 700;
+}
+
+.pt-pill {
+    padding: 1px 7px;
+    border-radius: 999px;
+    background: #eef4ff;
+    color: var(--pt-blue-dark);
+    font-size: 10px;
+    font-weight: 600;
+}
+
+.pt-meta-detail dl {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px 16px;
+    margin: 0 0 16px;
+}
+
+.pt-meta-detail dt {
+    color: var(--pt-muted);
+    font-size: 10px;
+    text-transform: uppercase;
+}
+
+.pt-meta-detail dd {
+    margin: 2px 0 0;
+    font-weight: 600;
+}
+
+/* ── VS Code ─────────────────────────────────────────────── */
+
+.pt-vscode {
+    display: flex;
+    height: 100%;
+    background: #1e1e1e;
+    color: #d4d4d4;
+}
+
+.pt-vscode-rail {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    width: 40px;
+    padding: 10px 0;
+    background: #333333;
+    color: #cccccc;
+}
+
+.pt-vscode-files {
+    width: 160px;
+    padding: 10px 8px;
+    background: #252526;
+    font-size: 11px;
+}
+
+.pt-vscode-files p {
+    margin: 0 0 8px;
+    color: #bbbbbb;
+    letter-spacing: 0.08em;
+    font-size: 9px;
+}
+
+.pt-tree-row {
+    display: block;
+    padding: 3px 6px;
+    border-radius: 3px;
+    color: #cccccc;
+}
+
+.pt-tree-row.is-folder {
+    padding-left: 14px;
+    color: #bbbbbb;
+}
+
+.pt-tree-row.is-file {
+    padding-left: 22px;
+}
+
+.pt-tree-row.is-muted {
+    padding-left: 14px;
+    color: #6f6f6f;
+}
+
+.pt-vscode-files .is-active {
+    background: #37373d;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.pt-dirty {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #c5c5c5;
+    flex: 0 0 auto;
+}
+
+.pt-vscode-main {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.pt-vscode-tabs {
+    display: flex;
+    flex: 0 0 auto;
+    background: #252526;
+    border-bottom: 1px solid #1e1e1e;
+}
+
+.pt-vscode-tab {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 12px;
+    background: #1e1e1e;
+    color: #fff;
+    font-size: 11px;
+    border-right: 1px solid #1e1e1e;
+}
+
+.pt-vscode-tab.is-empty {
+    color: #8b8b8b;
+    background: transparent;
+}
+
+.pt-vscode-editor {
+    flex: 1;
+    margin: 0;
+    padding: 8px 0;
+    overflow: hidden;
+    font-family: var(--pt-mono);
+    font-size: 11.5px;
+    line-height: 1.55;
+}
+
+.pt-code-line {
+    display: grid;
+    grid-template-columns: 28px 1fr;
+    min-width: 0;
+    padding: 0 8px 0 0;
+    white-space: pre;
+    overflow: hidden;
+}
+
+.pt-code-line em {
+    color: #858585;
+    font-style: normal;
+    text-align: right;
+    padding-right: 8px;
+}
+
+.pt-code-line span {
+    min-width: 0;
+    overflow: hidden;
+    color: #d4d4d4;
+}
+
+.pt-vscode-status {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 4px 10px;
+    background: #007acc;
+    color: #fff;
+    font-size: 10px;
+}
+
+.pt-palette {
+    position: absolute;
+    top: 36px;
+    left: 50%;
+    z-index: 3;
+    width: min(420px, calc(100% - 24px));
+    transform: translateX(-50%);
+    border: 1px solid #3c3c3c;
+    border-radius: 6px;
+    background: #252526;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+}
+
+.pt-palette-input {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    border-bottom: 1px solid #3c3c3c;
+    color: #fff;
+}
+
+.pt-palette ul {
+    margin: 0;
+    padding: 6px;
+    list-style: none;
+}
+
+.pt-palette li {
+    padding: 6px 8px;
+    border-radius: 4px;
+    color: #cccccc;
+}
+
+.pt-palette li.is-active {
+    background: #04395e;
+    color: #fff;
+}
+
+.pt-palette-hint {
+    margin: 0;
+    padding: 8px 10px;
+    color: #8b8b8b;
+    font-size: 11px;
+}
+
+/* ── Side panel on any site ──────────────────────────────── */
+
+.pt-sidepanel-scene {
+    display: flex;
+    height: 100%;
+    background: #f6f7f8;
+}
+
+.pt-acme-site {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+}
+
+.pt-acme-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 18px;
+    background: #fff;
+    border-bottom: 1px solid #e4e6e8;
+}
+
+.pt-acme-header strong {
+    font-size: 15px;
+    letter-spacing: -0.03em;
+}
+
+.pt-acme-header nav {
+    display: flex;
+    gap: 14px;
+    color: var(--pt-muted);
+}
+
+.pt-acme-header .is-active {
+    color: var(--pt-navy);
+    font-weight: 600;
+}
+
+.pt-acme-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-width: 420px;
+    padding: 18px 22px;
+}
+
+.pt-acme-kicker {
+    margin: 0;
+    color: var(--pt-blue);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.pt-acme-form h3 {
+    margin: 0 0 6px;
+    font-size: 20px;
+    letter-spacing: -0.03em;
+}
+
+.pt-form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: var(--pt-muted);
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.pt-form-field span {
+    min-height: 28px;
+    padding: 6px 8px;
+    border: 1px solid var(--pt-border);
+    border-radius: 6px;
+    background: #fff;
+    color: var(--pt-text);
+    font-weight: 500;
+}
+
+.pt-form-field.is-area span {
+    min-height: 56px;
+}
+
+.pt-form-field.is-focus span {
+    border-color: var(--pt-blue);
+    box-shadow: 0 0 0 3px rgba(1, 118, 211, 0.18);
+    animation: pt-pulse 0.7s ease-in-out 2;
+}
+
+.pt-form-submit {
+    align-self: flex-start;
+    margin-top: 6px;
+    padding: 7px 16px;
+    border-radius: 6px;
+    background: var(--pt-navy);
+    color: #fff;
+    font-weight: 700;
+}
+
+.pt-form-submit.is-pulse {
+    animation: pt-pulse 0.6s ease-in-out 3;
+}
+
+.pt-sidepanel {
+    display: flex;
+    flex-direction: column;
+    width: 280px;
+    flex: 0 0 280px;
+    border-left: 1px solid var(--pt-border);
+    background: #fbfbfb;
+}
+
+.pt-sidepanel header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--pt-border);
+    font-weight: 700;
+}
+
+.pt-sidepanel header svg:last-child {
+    margin-left: auto;
+    color: var(--pt-muted);
+}
+
+/* ── Agent ───────────────────────────────────────────────── */
+
+.pt-agent {
+    display: flex;
+    flex-direction: column;
+    width: 280px;
+    flex: 0 0 280px;
+    border-left: 1px solid var(--pt-border);
+    background: #fbfbfb;
+}
+
+.pt-agent header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--pt-border);
+    font-weight: 700;
+}
+
+.pt-agent-thread {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex: 1;
+    padding: 10px;
+    overflow: hidden;
+}
+
+.pt-bubble {
+    max-width: 95%;
+    padding: 8px 10px;
+    border-radius: 10px;
+    line-height: 1.4;
+}
+
+.pt-bubble.is-user {
+    align-self: flex-end;
+    background: var(--pt-blue);
+    color: #fff;
+}
+
+.pt-bubble.is-assistant {
+    background: var(--pt-white);
+    border: 1px solid var(--pt-border);
+}
+
+.pt-bubble.is-pending {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--pt-muted);
+}
+
+.pt-tool {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 8px;
+    border-radius: 6px;
+    background: #eef4ff;
+    color: var(--pt-blue-dark);
+    font-size: 11px;
+}
+
+.pt-tool.is-action {
+    background: #eef8f0;
+    color: var(--pt-success);
+}
+
+.pt-composer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: 8px;
+    padding: 7px 10px;
+    border: 1px solid var(--pt-border);
+    border-radius: 8px;
+    background: var(--pt-white);
+    color: var(--pt-muted);
+}
+
+/* ── Loading ─────────────────────────────────────────────── */
+
+.pt-loading {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    align-content: center;
+    gap: 10px;
+    background: rgba(243, 242, 242, 0.72);
+    color: var(--pt-navy);
+    font-weight: 600;
+    z-index: 5;
+}
+
+.pt-spinner {
+    width: 22px;
+    height: 22px;
+    border: 2px solid var(--pt-border);
+    border-top-color: var(--pt-blue);
+    border-radius: 50%;
+    animation: pt-spin 0.7s linear infinite;
+}
+
+@media (max-width: 720px) {
+    .pt-lex-nav,
+    .pt-nav,
+    .pt-vscode-files,
+    .pt-acme-header nav,
+    .pt-highlights div:nth-child(n + 3) {
+        display: none;
+    }
+
+    .pt-overlay {
+        width: 240px;
+        right: 12px;
+    }
+
+    .pt-sidepanel {
+        width: 220px;
+        flex-basis: 220px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .pt-caret,
+    .pt-pulse,
+    .pt-run.is-pulse,
+    .pt-form-field.is-focus span,
+    .pt-form-submit.is-pulse,
+    .pt-spinner,
+    .pt-overlay {
+        animation: none;
+    }
+}

--- a/apps/ui/src/product-tour/slide-scene.ts
+++ b/apps/ui/src/product-tour/slide-scene.ts
@@ -1,0 +1,218 @@
+import {
+    ASSISTANT_REPLY,
+    CHAR_MS,
+    FORM_EMAIL,
+    FORM_MESSAGE,
+    FORM_NAME,
+    FORM_ORDER,
+    LWC_BUNDLE,
+    LWC_HTML,
+    PALETTE_QUERY,
+    SEARCH_QUERY,
+    SOQL_QUERY,
+    STREAM_MS,
+    inRange,
+    typed,
+    type FormFocus,
+    type PalettePhase,
+} from './flow-scene.ts';
+import type { TourSlideId } from './slides';
+
+export interface SlidePlay {
+    overlayOpen: boolean;
+    overlaySearch: string;
+    overlayCaret: boolean;
+    vscodeHot: boolean;
+    soqlHot: boolean;
+    soqlDraft: string;
+    soqlCaret: boolean;
+    resultsVisible: boolean;
+    sendPulse: boolean;
+    assistant: string;
+    streaming: boolean;
+    paletteOpen: boolean;
+    palettePhase: PalettePhase;
+    paletteQuery: string;
+    paletteName: string;
+    paletteCaret: boolean;
+    bundleReady: boolean;
+    editorTyped: string;
+    editorCaret: boolean;
+    editorDirty: boolean;
+    metaFilter: string;
+    metaCaret: boolean;
+    metaSelected: boolean;
+    formFocus: FormFocus;
+    formName: string;
+    formEmail: string;
+    formOrder: string;
+    formMessage: string;
+    formSubmitPulse: boolean;
+}
+
+const HOLD_MS = 2800;
+
+function emptyPlay(): SlidePlay {
+    return {
+        overlayOpen: false,
+        overlaySearch: '',
+        overlayCaret: false,
+        vscodeHot: false,
+        soqlHot: false,
+        soqlDraft: '',
+        soqlCaret: false,
+        resultsVisible: false,
+        sendPulse: false,
+        assistant: '',
+        streaming: false,
+        paletteOpen: false,
+        palettePhase: null,
+        paletteQuery: '',
+        paletteName: '',
+        paletteCaret: false,
+        bundleReady: false,
+        editorTyped: '',
+        editorCaret: false,
+        editorDirty: false,
+        metaFilter: '',
+        metaCaret: false,
+        metaSelected: false,
+        formFocus: null,
+        formName: '',
+        formEmail: '',
+        formOrder: '',
+        formMessage: '',
+        formSubmitPulse: false,
+    };
+}
+
+function overlayLoop(now: number): { play: SlidePlay; loopMs: number } {
+    const openAt = 700;
+    const typeAt = 1500;
+    const typedDone = typeAt + SEARCH_QUERY.length * CHAR_MS;
+    const loopMs = typedDone + 400 + HOLD_MS;
+    return {
+        loopMs,
+        play: {
+            ...emptyPlay(),
+            overlayOpen: now >= openAt,
+            overlaySearch: typed(SEARCH_QUERY, typeAt, now, CHAR_MS),
+            overlayCaret: inRange(now, typeAt, typedDone + 200),
+        },
+    };
+}
+
+function editorLoop(now: number): { play: SlidePlay; loopMs: number } {
+    const paletteAt = 250;
+    const typeCmd = paletteAt + 160;
+    const cmdDone = typeCmd + PALETTE_QUERY.length * CHAR_MS + 380;
+    const typeName = cmdDone + 180;
+    const bundleAt = typeName + LWC_BUNDLE.length * CHAR_MS + 320;
+    const typeHtml = bundleAt + 280;
+    const htmlDone = typeHtml + LWC_HTML.length * STREAM_MS;
+    const loopMs = htmlDone + HOLD_MS;
+    let palettePhase: PalettePhase = null;
+    if (inRange(now, paletteAt, cmdDone)) palettePhase = 'command';
+    else if (inRange(now, cmdDone, bundleAt)) palettePhase = 'name';
+    return {
+        loopMs,
+        play: {
+            ...emptyPlay(),
+            paletteOpen: palettePhase !== null,
+            palettePhase,
+            paletteQuery: typed(PALETTE_QUERY, typeCmd, now, CHAR_MS),
+            paletteName: typed(LWC_BUNDLE, typeName, now, CHAR_MS),
+            paletteCaret: inRange(now, typeCmd, bundleAt),
+            bundleReady: now >= bundleAt,
+            editorTyped: typed(LWC_HTML, typeHtml, now, STREAM_MS),
+            editorCaret: inRange(now, typeHtml, htmlDone + 180),
+            editorDirty: now >= typeHtml && now < htmlDone,
+        },
+    };
+}
+
+function workbenchLoop(now: number): { play: SlidePlay; loopMs: number } {
+    const typeAt = 500;
+    const typedDone = typeAt + SEARCH_QUERY.length * CHAR_MS;
+    const selectAt = typedDone + 450;
+    const loopMs = selectAt + HOLD_MS;
+    return {
+        loopMs,
+        play: {
+            ...emptyPlay(),
+            metaFilter: typed(SEARCH_QUERY, typeAt, now, CHAR_MS),
+            metaCaret: inRange(now, typeAt, typedDone + 160),
+            metaSelected: now >= selectAt,
+        },
+    };
+}
+
+function soqlLoop(now: number): { play: SlidePlay; loopMs: number } {
+    const typeAt = 400;
+    const typedDone = typeAt + SOQL_QUERY.length * CHAR_MS;
+    const runAt = typedDone + 220;
+    const resultsAt = runAt + 480;
+    const loopMs = resultsAt + HOLD_MS;
+    return {
+        loopMs,
+        play: {
+            ...emptyPlay(),
+            soqlDraft: typed(SOQL_QUERY, typeAt, now, CHAR_MS),
+            soqlCaret: inRange(now, typeAt, runAt),
+            sendPulse: inRange(now, runAt, resultsAt),
+            resultsVisible: now >= resultsAt,
+        },
+    };
+}
+
+function agentLoop(now: number): { play: SlidePlay; loopMs: number } {
+    const streamAt = 400;
+    const nameAt = 650;
+    const emailAt = nameAt + 600;
+    const orderAt = emailAt + 600;
+    const messageAt = orderAt + 600;
+    const submitAt = messageAt + 700;
+    const loopMs = submitAt + HOLD_MS;
+    const assistant = typed(ASSISTANT_REPLY, streamAt, now, STREAM_MS);
+    let formFocus: FormFocus = null;
+    if (now >= submitAt) formFocus = 'submit';
+    else if (now >= messageAt) formFocus = 'message';
+    else if (now >= orderAt) formFocus = 'order';
+    else if (now >= emailAt) formFocus = 'email';
+    else if (now >= nameAt) formFocus = 'name';
+    return {
+        loopMs,
+        play: {
+            ...emptyPlay(),
+            assistant,
+            streaming: inRange(now, streamAt, submitAt),
+            formFocus,
+            formName: now >= nameAt ? FORM_NAME : '',
+            formEmail: now >= emailAt ? FORM_EMAIL : '',
+            formOrder: now >= orderAt ? FORM_ORDER : '',
+            formMessage: now >= messageAt ? FORM_MESSAGE : '',
+            formSubmitPulse: inRange(now, submitAt, submitAt + 900),
+        },
+    };
+}
+
+function loopFor(id: TourSlideId, now: number): { play: SlidePlay; loopMs: number } {
+    if (id === 'overlay') return overlayLoop(now);
+    if (id === 'editor') return editorLoop(now);
+    if (id === 'workbench') return workbenchLoop(now);
+    if (id === 'soql') return soqlLoop(now);
+    return agentLoop(now);
+}
+
+export function slideLoopMs(id: TourSlideId): number {
+    return loopFor(id, 0).loopMs;
+}
+
+export function slidePlayForElapsed(id: TourSlideId, ms: number): SlidePlay {
+    const now = Number.isFinite(ms) ? Math.max(0, ms) : 0;
+    return loopFor(id, now).play;
+}
+
+export function completedSlidePlay(id: TourSlideId): SlidePlay {
+    return slidePlayForElapsed(id, slideLoopMs(id) - HOLD_MS + 200);
+}

--- a/apps/ui/src/product-tour/slides.ts
+++ b/apps/ui/src/product-tour/slides.ts
@@ -1,0 +1,36 @@
+export const MAX_FIXTURE_SCALE = 1.2;
+
+export const AUTHORED_WIDTH = 1100;
+export const AUTHORED_HEIGHT = 540;
+
+export type TourSlideId = 'overlay' | 'editor' | 'workbench' | 'soql' | 'agent';
+
+export interface TourSlide {
+    id: TourSlideId;
+    url: string;
+}
+
+export const SLIDES: readonly TourSlide[] = [
+    { id: 'overlay', url: 'acme.lightning.force.com/lightning/r/Account/001xx000003DHP0/view' },
+    { id: 'editor', url: 'chrome - Workbench Editor' },
+    { id: 'workbench', url: 'chrome - Metadata Explorer' },
+    { id: 'soql', url: 'chrome - SOQL Explorer' },
+    { id: 'agent', url: 'help.acme.com/support' },
+];
+
+export function spatialFixtureScale(
+    availableWidth: number,
+    authoredWidth: number,
+    availableHeight?: number,
+    authoredHeight?: number
+): number {
+    if (availableWidth <= 0 || authoredWidth <= 0) return 1;
+    const heightScale =
+        availableHeight !== undefined &&
+        availableHeight > 0 &&
+        authoredHeight !== undefined &&
+        authoredHeight > 0
+            ? availableHeight / authoredHeight
+            : Number.POSITIVE_INFINITY;
+    return Math.min(MAX_FIXTURE_SCALE, availableWidth / authoredWidth, heightScale);
+}

--- a/apps/ui/src/product-tour/tour-nav.ts
+++ b/apps/ui/src/product-tour/tour-nav.ts
@@ -1,0 +1,8 @@
+import { createContext, useContext } from 'react';
+import type { TourSlideId } from './slides';
+
+export const TourNavContext = createContext<((slideId: TourSlideId) => void) | null>(null);
+
+export function useTourNav(): ((slideId: TourSlideId) => void) | null {
+    return useContext(TourNavContext);
+}

--- a/apps/ui/src/product-tour/wireframes.tsx
+++ b/apps/ui/src/product-tour/wireframes.tsx
@@ -1,0 +1,947 @@
+import type { ReactNode } from 'react';
+import {
+    Bell,
+    Bot,
+    Building2,
+    ChevronDown,
+    ChevronRight,
+    Cloud,
+    Code2,
+    Copy,
+    Database,
+    FileCode2,
+    Filter,
+    Folder,
+    Globe,
+    LayoutGrid,
+    MousePointerClick,
+    Package,
+    PanelRight,
+    Pencil,
+    Play,
+    RefreshCw,
+    Search,
+    Send,
+    Settings,
+    Share2,
+    SquareTerminal,
+    Table2,
+} from 'lucide-react';
+import type { FlowScene, FormFocus, PalettePhase } from './flow-scene';
+import { AUTHORED_HEIGHT, AUTHORED_WIDTH, type TourSlideId } from './slides';
+import { completedSlidePlay, type SlidePlay } from './slide-scene';
+import { useTourNav } from './tour-nav';
+
+function classNames(...parts: Array<string | false | null | undefined>): string {
+    return parts.filter(Boolean).join(' ');
+}
+
+function Caret(): ReactNode {
+    return <span className="pt-caret" aria-hidden />;
+}
+
+function SalesforceHeader(): ReactNode {
+    return (
+        <header className="pt-lex-header">
+            <span className="pt-lex-launcher" aria-hidden>
+                <LayoutGrid size={14} strokeWidth={1.75} />
+            </span>
+            <span className="pt-lex-cloud" aria-hidden>
+                <Cloud size={16} strokeWidth={1.75} />
+            </span>
+            <span className="pt-lex-app">Sales</span>
+            <span className="pt-lex-search">
+                <Search size={11} strokeWidth={2} aria-hidden />
+                Search Salesforce
+            </span>
+            <span className="pt-lex-header-end">
+                <Bell size={13} strokeWidth={1.75} aria-hidden />
+                <span className="pt-avatar" aria-hidden>
+                    A
+                </span>
+            </span>
+        </header>
+    );
+}
+
+function SalesforceNav({ onAccounts }: { onAccounts?: () => void }): ReactNode {
+    return (
+        <nav className="pt-lex-nav" aria-label="Salesforce apps">
+            <span>Home</span>
+            <button type="button" className="is-active" onClick={onAccounts}>
+                Accounts
+            </button>
+            <span>Contacts</span>
+            <span>Opportunities</span>
+            <span>Reports</span>
+        </nav>
+    );
+}
+
+function OverlayDock({
+    overlayOpen,
+    soqlHot,
+    vscodeHot,
+    onOpenSoql,
+    onOpenEditor,
+}: {
+    overlayOpen: boolean;
+    soqlHot?: boolean;
+    vscodeHot?: boolean;
+    onOpenSoql?: () => void;
+    onOpenEditor?: () => void;
+}): ReactNode {
+    return (
+        <div className={classNames('pt-overlay-dock', overlayOpen && 'is-open')} aria-hidden>
+            <span>
+                <PanelRight size={12} strokeWidth={2} />
+            </span>
+            <span className="is-active">
+                <Search size={12} strokeWidth={2} />
+            </span>
+            <span>
+                <Pencil size={12} strokeWidth={2} />
+            </span>
+            <button
+                type="button"
+                className={classNames('pt-overlay-soql', vscodeHot && 'is-hot')}
+                onClick={onOpenEditor}
+                aria-label="Open VS Code Editor"
+            >
+                <SquareTerminal size={12} strokeWidth={2} />
+            </button>
+            <button
+                type="button"
+                className={classNames('pt-overlay-soql', soqlHot && 'is-hot')}
+                onClick={onOpenSoql}
+                aria-label="Open SOQL Explorer"
+            >
+                <Database size={12} strokeWidth={2} />
+            </button>
+        </div>
+    );
+}
+
+function OverlayPanel({
+    search,
+    caret,
+    soqlHot,
+    vscodeHot,
+    onOpenSoql,
+    onOpenEditor,
+}: {
+    search: string;
+    caret: boolean;
+    soqlHot?: boolean;
+    vscodeHot?: boolean;
+    onOpenSoql?: () => void;
+    onOpenEditor?: () => void;
+}): ReactNode {
+    const q = search.toLowerCase();
+    const objects = ['Account', 'Contact', 'Opportunity', 'Lead', 'User'].filter(
+        name => !q || name.toLowerCase().includes(q)
+    );
+    return (
+        <aside className="pt-overlay" aria-label="Workbench overlay">
+            <div className="pt-overlay-bar">
+                <span className="pt-overlay-search">
+                    <Filter size={11} strokeWidth={2} aria-hidden />
+                    <span className="pt-overlay-search-value">
+                        {search || 'Search Object, Profiles and more'}
+                        {caret ? <Caret /> : null}
+                    </span>
+                </span>
+                <span className="pt-overlay-actions">
+                    <button
+                        type="button"
+                        className={classNames('pt-overlay-soql', vscodeHot && 'is-hot')}
+                        onClick={onOpenEditor}
+                        aria-label="Open VS Code Editor"
+                    >
+                        <SquareTerminal size={12} strokeWidth={2} />
+                    </button>
+                    <button
+                        type="button"
+                        className={classNames('pt-overlay-soql', soqlHot && 'is-hot')}
+                        onClick={onOpenSoql}
+                        aria-label="Open SOQL Explorer"
+                    >
+                        <Database size={12} strokeWidth={2} />
+                    </button>
+                    <Share2 size={12} strokeWidth={2} aria-hidden />
+                </span>
+            </div>
+            <div className="pt-overlay-meta">
+                48 objects • Refreshed just now
+                <RefreshCw size={11} strokeWidth={2} aria-hidden />
+            </div>
+            {search ? (
+                <ul className="pt-overlay-list">
+                    {objects.map(name => (
+                        <li key={name} className={name === 'Account' ? 'is-hot' : undefined}>
+                            <Building2 size={12} strokeWidth={2} aria-hidden />
+                            {name}
+                        </li>
+                    ))}
+                </ul>
+            ) : (
+                <div className="pt-overlay-cards">
+                    <fieldset className="pt-info-card">
+                        <legend>ORGANIZATION</legend>
+                        <div>
+                            <span>Name</span>
+                            <strong>
+                                Acme
+                                <Copy size={10} strokeWidth={2} aria-hidden />
+                            </strong>
+                        </div>
+                        <div>
+                            <span>Instance</span>
+                            <strong>NA123</strong>
+                        </div>
+                        <div>
+                            <span>Org Id</span>
+                            <strong>00Dxx0000001Acme</strong>
+                        </div>
+                    </fieldset>
+                    <fieldset className="pt-info-card">
+                        <legend>USER</legend>
+                        <div>
+                            <span>Name</span>
+                            <strong>Alex Rivera</strong>
+                        </div>
+                        <div>
+                            <span>Username</span>
+                            <strong>alex@acme.com</strong>
+                        </div>
+                    </fieldset>
+                </div>
+            )}
+        </aside>
+    );
+}
+
+function SalesforcePage({
+    overlayOpen,
+    overlaySearch,
+    caret,
+    soqlHot,
+    vscodeHot,
+    interactive,
+}: {
+    overlayOpen: boolean;
+    overlaySearch: string;
+    caret: boolean;
+    soqlHot?: boolean;
+    vscodeHot?: boolean;
+    interactive?: boolean;
+}): ReactNode {
+    const goToSlide = useTourNav();
+    return (
+        <div className="pt-lex">
+            <SalesforceHeader />
+            <SalesforceNav onAccounts={interactive ? () => goToSlide?.('overlay') : undefined} />
+            <div className="pt-lex-body">
+                <div className="pt-record">
+                    <p className="pt-record-kicker">Account</p>
+                    <h3>Acme Corp</h3>
+                    <div className="pt-record-tabs">
+                        <span className="is-active">Details</span>
+                        <span>Related</span>
+                        <span>News</span>
+                    </div>
+                    <dl className="pt-highlights">
+                        <div>
+                            <dt>Industry</dt>
+                            <dd>Technology</dd>
+                        </div>
+                        <div>
+                            <dt>Type</dt>
+                            <dd>Customer</dd>
+                        </div>
+                        <div>
+                            <dt>Phone</dt>
+                            <dd>(415) 555-0142</dd>
+                        </div>
+                        <div>
+                            <dt>Owner</dt>
+                            <dd>Alex Rivera</dd>
+                        </div>
+                    </dl>
+                    <div className="pt-skel-block">
+                        <i />
+                        <i />
+                        <i />
+                        <i />
+                    </div>
+                </div>
+            </div>
+            <OverlayDock
+                overlayOpen={overlayOpen}
+                soqlHot={soqlHot}
+                vscodeHot={vscodeHot}
+                onOpenSoql={interactive ? () => goToSlide?.('soql') : undefined}
+                onOpenEditor={interactive ? () => goToSlide?.('editor') : undefined}
+            />
+            {overlayOpen ? (
+                <OverlayPanel
+                    search={overlaySearch}
+                    caret={caret}
+                    soqlHot={soqlHot}
+                    vscodeHot={vscodeHot}
+                    onOpenSoql={interactive ? () => goToSlide?.('soql') : undefined}
+                    onOpenEditor={interactive ? () => goToSlide?.('editor') : undefined}
+                />
+            ) : null}
+        </div>
+    );
+}
+
+const NAV_ITEMS: Array<{
+    group: string;
+    items: Array<{ id: TourSlideId; label: string; icon: ReactNode }>;
+}> = [
+    {
+        group: 'Data',
+        items: [
+            { id: 'soql', label: 'SOQL Explorer', icon: <Database size={12} strokeWidth={2} /> },
+            { id: 'overlay', label: 'Record Viewer', icon: <Table2 size={12} strokeWidth={2} /> },
+        ],
+    },
+    {
+        group: 'Code',
+        items: [
+            { id: 'editor', label: 'VS Code', icon: <SquareTerminal size={12} strokeWidth={2} /> },
+            { id: 'soql', label: 'API Explorer', icon: <Globe size={12} strokeWidth={2} /> },
+        ],
+    },
+    {
+        group: 'Admin',
+        items: [
+            { id: 'workbench', label: 'Metadata', icon: <Package size={12} strokeWidth={2} /> },
+            { id: 'workbench', label: 'SObject', icon: <Building2 size={12} strokeWidth={2} /> },
+        ],
+    },
+];
+
+const ACTIVE_NAV_LABEL: Record<TourSlideId, string> = {
+    overlay: 'Record Viewer',
+    soql: 'SOQL Explorer',
+    editor: 'VS Code',
+    workbench: 'Metadata',
+    agent: 'Agent',
+};
+
+function ToolkitShell({
+    activeApp,
+    tabLabel,
+    agentOpen,
+    agent,
+    children,
+    interactive,
+}: {
+    activeApp: TourSlideId;
+    tabLabel: string;
+    agentOpen?: boolean;
+    agent?: ReactNode;
+    children: ReactNode;
+    interactive?: boolean;
+}): ReactNode {
+    const goToSlide = useTourNav();
+    return (
+        <div className={classNames('pt-toolkit', agentOpen && 'is-agent')}>
+            <aside className="pt-nav">
+                <div className="pt-nav-brand">
+                    <span>Workbench</span>
+                    <span className="pt-beta">Beta</span>
+                </div>
+                {NAV_ITEMS.map(section => (
+                    <div key={section.group} className="pt-nav-group">
+                        <p>{section.group}</p>
+                        {section.items.map(item => (
+                            <button
+                                key={`${section.group}-${item.label}`}
+                                type="button"
+                                className={classNames(
+                                    'pt-nav-item',
+                                    ACTIVE_NAV_LABEL[activeApp] === item.label && 'is-active'
+                                )}
+                                onClick={interactive ? () => goToSlide?.(item.id) : undefined}
+                            >
+                                {item.icon}
+                                {item.label}
+                            </button>
+                        ))}
+                    </div>
+                ))}
+                <button
+                    type="button"
+                    className={classNames(
+                        'pt-nav-item pt-nav-agent',
+                        activeApp === 'agent' && 'is-active'
+                    )}
+                    onClick={interactive ? () => goToSlide?.('agent') : undefined}
+                >
+                    <Bot size={12} strokeWidth={2} />
+                    Agent
+                </button>
+            </aside>
+            <div className="pt-toolkit-main">
+                <header className="pt-context">
+                    <span className="pt-context-name">Workbench</span>
+                    <span className="pt-beta">Beta</span>
+                    <span className="pt-tab is-active">{tabLabel}</span>
+                    <span className="pt-context-end">
+                        <Settings size={13} strokeWidth={1.75} aria-hidden />
+                        <button
+                            type="button"
+                            className={classNames('pt-agent-toggle', agentOpen && 'is-active')}
+                            onClick={interactive ? () => goToSlide?.('agent') : undefined}
+                            aria-label="Toggle agent"
+                        >
+                            <PanelRight size={13} strokeWidth={1.75} />
+                        </button>
+                    </span>
+                </header>
+                <div className="pt-canvas">
+                    {children}
+                    {agentOpen ? agent : null}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function SoqlBody({
+    draft,
+    caret,
+    resultsVisible,
+    sendPulse,
+}: {
+    draft: string;
+    caret: boolean;
+    resultsVisible: boolean;
+    sendPulse?: boolean;
+}): ReactNode {
+    return (
+        <div className="pt-soql">
+            <div className="pt-soql-toolbar">
+                <span>Acme · API 62.0</span>
+                <span className={classNames('pt-run', sendPulse && 'is-pulse')}>
+                    <Play size={11} strokeWidth={2.2} aria-hidden />
+                    Run
+                </span>
+            </div>
+            <pre className="pt-soql-editor">
+                {draft || <span className="pt-placeholder">SELECT Id, Name FROM Account</span>}
+                {caret ? <Caret /> : null}
+            </pre>
+            {resultsVisible ? (
+                <table className="pt-results">
+                    <thead>
+                        <tr>
+                            <th>Id</th>
+                            <th>Name</th>
+                            <th>Industry</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>001xx000003DHP0</td>
+                            <td>Acme Corp</td>
+                            <td>Technology</td>
+                        </tr>
+                        <tr>
+                            <td>001xx000003DHP1</td>
+                            <td>Globex</td>
+                            <td>Manufacturing</td>
+                        </tr>
+                        <tr>
+                            <td>001xx000003DHP2</td>
+                            <td>Initech</td>
+                            <td>Finance</td>
+                        </tr>
+                    </tbody>
+                </table>
+            ) : (
+                <div className="pt-soql-empty">Run a query to see records</div>
+            )}
+        </div>
+    );
+}
+
+function MetadataBody({
+    filter,
+    caret,
+    selected,
+}: {
+    filter: string;
+    caret: boolean;
+    selected: boolean;
+}): ReactNode {
+    const q = filter.toLowerCase();
+    const objects = ['Account', 'Contact', 'Opportunity'].filter(
+        name => !q || name.toLowerCase().includes(q)
+    );
+    return (
+        <div className="pt-meta">
+            <div className="pt-meta-tree">
+                <div className="pt-meta-filter">
+                    <Search size={11} strokeWidth={2} aria-hidden />
+                    <span>
+                        {filter || 'Filter metadata'}
+                        {caret ? <Caret /> : null}
+                    </span>
+                </div>
+                <div className="pt-tree-group">
+                    <span>
+                        <ChevronDown size={11} strokeWidth={2} /> CustomObject
+                    </span>
+                    {objects.map(name => (
+                        <button
+                            key={name}
+                            type="button"
+                            className={selected && name === 'Account' ? 'is-active' : undefined}
+                        >
+                            <Folder size={11} strokeWidth={2} /> {name}
+                        </button>
+                    ))}
+                </div>
+                <div className="pt-tree-group">
+                    <span>
+                        <ChevronRight size={11} strokeWidth={2} /> PermissionSet
+                    </span>
+                    <span>
+                        <ChevronRight size={11} strokeWidth={2} /> Profile
+                    </span>
+                    <span>
+                        <ChevronRight size={11} strokeWidth={2} /> Layout
+                    </span>
+                </div>
+            </div>
+            <div className="pt-meta-detail">
+                {selected ? (
+                    <>
+                        <header>
+                            <Package size={14} strokeWidth={1.75} />
+                            Account
+                            <span className="pt-pill">CustomObject</span>
+                        </header>
+                        <dl>
+                            <div>
+                                <dt>Label</dt>
+                                <dd>Account</dd>
+                            </div>
+                            <div>
+                                <dt>API Name</dt>
+                                <dd>Account</dd>
+                            </div>
+                            <div>
+                                <dt>Fields</dt>
+                                <dd>186</dd>
+                            </div>
+                            <div>
+                                <dt>Last modified</dt>
+                                <dd>Alex Rivera · 2h ago</dd>
+                            </div>
+                        </dl>
+                        <div className="pt-skel-block">
+                            <i />
+                            <i />
+                            <i />
+                        </div>
+                    </>
+                ) : (
+                    <p className="pt-soql-empty">Select a component to inspect it</p>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function EditorBody({
+    typedSource,
+    caret,
+    dirty,
+    paletteOpen,
+    palettePhase,
+    paletteQuery,
+    paletteName,
+    paletteCaret,
+    bundleReady,
+}: {
+    typedSource: string;
+    caret: boolean;
+    dirty: boolean;
+    paletteOpen: boolean;
+    palettePhase: PalettePhase;
+    paletteQuery: string;
+    paletteName: string;
+    paletteCaret: boolean;
+    bundleReady: boolean;
+}): ReactNode {
+    const lines = typedSource.length > 0 ? typedSource.split('\n') : [''];
+    const lastLine = lines[lines.length - 1] ?? '';
+    const paletteValue =
+        palettePhase === 'name'
+            ? paletteName || 'Component name'
+            : paletteQuery || 'Type a command';
+    return (
+        <div className="pt-vscode">
+            <aside className="pt-vscode-rail" aria-hidden>
+                <FileCode2 size={14} strokeWidth={1.75} />
+                <Search size={14} strokeWidth={1.75} />
+                <Code2 size={14} strokeWidth={1.75} />
+                <Settings size={14} strokeWidth={1.75} />
+            </aside>
+            <div className="pt-vscode-files">
+                <p>FORCE-APP</p>
+                <span className="pt-tree-row">force-app/main/default/lwc</span>
+                {bundleReady ? (
+                    <>
+                        <span className="pt-tree-row is-folder">accountHighlight</span>
+                        <span className="pt-tree-row is-file is-active">
+                            {dirty ? <i className="pt-dirty" aria-hidden /> : null}
+                            accountHighlight.html
+                        </span>
+                        <span className="pt-tree-row is-file">accountHighlight.js</span>
+                        <span className="pt-tree-row is-file">accountHighlight.js-meta.xml</span>
+                    </>
+                ) : (
+                    <span className="pt-tree-row is-muted">No components yet</span>
+                )}
+            </div>
+            <div className="pt-vscode-main">
+                <div className="pt-vscode-tabs">
+                    {bundleReady ? (
+                        <span className="pt-vscode-tab is-active">
+                            {dirty ? <i className="pt-dirty" aria-hidden /> : null}
+                            accountHighlight.html
+                        </span>
+                    ) : (
+                        <span className="pt-vscode-tab is-empty">Welcome</span>
+                    )}
+                </div>
+                <div className="pt-vscode-editor">
+                    {lines.map((line, i) => (
+                        <div key={`ln-${i}`} className="pt-code-line">
+                            <em>{i + 1}</em>
+                            <span>
+                                {line}
+                                {caret && i === lines.length - 1 ? <Caret /> : null}
+                            </span>
+                        </div>
+                    ))}
+                </div>
+                <footer className="pt-vscode-status">
+                    <span>{dirty ? '1 unsaved' : 'Saved'}</span>
+                    <span>HTML</span>
+                    <span>
+                        Ln {lines.length}, Col {lastLine.length + 1}
+                    </span>
+                </footer>
+                {paletteOpen ? (
+                    <div className="pt-palette" aria-label="Command palette">
+                        <div className="pt-palette-input">
+                            <Search size={12} strokeWidth={2} aria-hidden />
+                            <span>
+                                {paletteValue}
+                                {paletteCaret ? <Caret /> : null}
+                            </span>
+                        </div>
+                        {palettePhase === 'command' ? (
+                            <ul>
+                                <li className="is-active">SFDX: Create Lightning Web Component</li>
+                                <li>SFDX: Create Apex Class</li>
+                            </ul>
+                        ) : (
+                            <p className="pt-palette-hint">New Lightning web component</p>
+                        )}
+                    </div>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+const FORM_TOOL: Record<Exclude<FormFocus, null>, string> = {
+    name: 'browser_fill · Name',
+    email: 'browser_fill · Email',
+    order: 'browser_fill · Order #',
+    message: 'browser_fill · Message',
+    submit: 'Clicked Submit',
+};
+
+function SidePanelForm({
+    assistant,
+    streaming,
+    formFocus,
+    formName,
+    formEmail,
+    formOrder,
+    formMessage,
+    formSubmitPulse,
+}: {
+    assistant: string;
+    streaming?: boolean;
+    formFocus: FormFocus;
+    formName: string;
+    formEmail: string;
+    formOrder: string;
+    formMessage: string;
+    formSubmitPulse: boolean;
+}): ReactNode {
+    return (
+        <div className="pt-sidepanel-scene">
+            <div className="pt-acme-site">
+                <header className="pt-acme-header">
+                    <strong>Acme</strong>
+                    <nav>
+                        <span>Help Center</span>
+                        <span className="is-active">Contact</span>
+                        <span>Status</span>
+                    </nav>
+                </header>
+                <main className="pt-acme-form">
+                    <p className="pt-acme-kicker">Support</p>
+                    <h3>How can we help?</h3>
+                    <label
+                        className={classNames('pt-form-field', formFocus === 'name' && 'is-focus')}
+                    >
+                        Name
+                        <span>{formName || 'Full name'}</span>
+                    </label>
+                    <label
+                        className={classNames('pt-form-field', formFocus === 'email' && 'is-focus')}
+                    >
+                        Email
+                        <span>{formEmail || 'you@company.com'}</span>
+                    </label>
+                    <label
+                        className={classNames('pt-form-field', formFocus === 'order' && 'is-focus')}
+                    >
+                        Order #<span>{formOrder || 'e.g. 1842'}</span>
+                    </label>
+                    <label
+                        className={classNames(
+                            'pt-form-field is-area',
+                            formFocus === 'message' && 'is-focus'
+                        )}
+                    >
+                        Message
+                        <span>{formMessage || 'Describe the issue'}</span>
+                    </label>
+                    <span
+                        className={classNames(
+                            'pt-form-submit',
+                            (formFocus === 'submit' || formSubmitPulse) && 'is-pulse'
+                        )}
+                    >
+                        Submit
+                    </span>
+                </main>
+            </div>
+            <aside className="pt-sidepanel" aria-label="Workbench side panel">
+                <header>
+                    <Bot size={13} strokeWidth={1.75} />
+                    Workbench
+                    <Settings size={12} strokeWidth={1.75} aria-hidden />
+                </header>
+                <div className="pt-agent-thread">
+                    <div className="pt-bubble is-user">
+                        Fill this support form for Alex Rivera, order 1842.
+                    </div>
+                    {formFocus ? (
+                        <div
+                            className={classNames('pt-tool', formFocus === 'submit' && 'is-action')}
+                        >
+                            {formFocus === 'submit' ? (
+                                <MousePointerClick size={11} strokeWidth={2} />
+                            ) : (
+                                <Pencil size={11} strokeWidth={2} />
+                            )}
+                            {FORM_TOOL[formFocus]}
+                        </div>
+                    ) : null}
+                    {assistant ? (
+                        <div className="pt-bubble is-assistant">
+                            {assistant}
+                            {streaming ? <Caret /> : null}
+                        </div>
+                    ) : (
+                        <div className="pt-bubble is-assistant is-pending">
+                            <span className="pt-pulse" aria-hidden />
+                            Looking at the page…
+                        </div>
+                    )}
+                </div>
+                <div className="pt-composer">
+                    <span>Ask the agent to fill this form…</span>
+                    <Send size={12} strokeWidth={2} aria-hidden />
+                </div>
+            </aside>
+        </div>
+    );
+}
+
+function LoadingOverlay({ label }: { label: 'editor' | 'soql' }): ReactNode {
+    return (
+        <div className="pt-loading" aria-hidden>
+            <span className="pt-spinner" />
+            {label === 'editor' ? 'Opening VS Code…' : 'Opening SOQL Explorer…'}
+        </div>
+    );
+}
+
+export function HomeFlowWireframe({ scene }: { scene: FlowScene }): ReactNode {
+    const soqlBody = (
+        <SoqlBody
+            draft={scene.soqlDraft}
+            caret={scene.caret === 'soql'}
+            resultsVisible={scene.resultsVisible}
+            sendPulse={scene.sendPulse}
+        />
+    );
+    const editorBody = (
+        <EditorBody
+            typedSource={scene.editorTyped}
+            caret={scene.caret === 'editor'}
+            dirty={scene.editorDirty}
+            paletteOpen={scene.paletteOpen}
+            palettePhase={scene.palettePhase}
+            paletteQuery={scene.paletteQuery}
+            paletteName={scene.paletteName}
+            paletteCaret={scene.caret === 'palette'}
+            bundleReady={scene.bundleReady}
+        />
+    );
+    let body: ReactNode;
+    if (scene.view === 'salesforce') {
+        body = (
+            <SalesforcePage
+                overlayOpen={scene.overlayOpen}
+                overlaySearch={scene.overlaySearch}
+                caret={scene.caret === 'search'}
+                soqlHot={scene.soqlHot}
+                vscodeHot={scene.vscodeHot}
+            />
+        );
+    } else if (scene.view === 'editor') {
+        body = (
+            <ToolkitShell activeApp="editor" tabLabel="VS Code">
+                {editorBody}
+            </ToolkitShell>
+        );
+    } else if (scene.view === 'soql') {
+        body = (
+            <ToolkitShell activeApp="soql" tabLabel="SOQL Explorer">
+                {soqlBody}
+            </ToolkitShell>
+        );
+    } else {
+        body = (
+            <SidePanelForm
+                assistant={scene.assistant}
+                streaming={Boolean(scene.assistant) && scene.formFocus !== 'submit'}
+                formFocus={scene.formFocus}
+                formName={scene.formName}
+                formEmail={scene.formEmail}
+                formOrder={scene.formOrder}
+                formMessage={scene.formMessage}
+                formSubmitPulse={scene.formSubmitPulse}
+            />
+        );
+    }
+    return (
+        <div
+            className="pt-stage"
+            data-flow-view={scene.view}
+            style={{ width: AUTHORED_WIDTH, height: AUTHORED_HEIGHT }}
+        >
+            {body}
+            {scene.loadingTarget ? <LoadingOverlay label={scene.loadingTarget} /> : null}
+        </div>
+    );
+}
+
+export function SlideWireframe({
+    slideId,
+    play,
+}: {
+    slideId: TourSlideId;
+    play?: SlidePlay;
+}): ReactNode {
+    const scene = play ?? completedSlidePlay(slideId);
+    let body: ReactNode;
+    if (slideId === 'overlay') {
+        body = (
+            <SalesforcePage
+                overlayOpen={scene.overlayOpen}
+                overlaySearch={scene.overlaySearch}
+                caret={scene.overlayCaret}
+                vscodeHot={scene.vscodeHot}
+                soqlHot={scene.soqlHot}
+                interactive
+            />
+        );
+    } else if (slideId === 'editor') {
+        body = (
+            <ToolkitShell activeApp="editor" tabLabel="VS Code" interactive>
+                <EditorBody
+                    typedSource={scene.editorTyped}
+                    caret={scene.editorCaret}
+                    dirty={scene.editorDirty}
+                    paletteOpen={scene.paletteOpen}
+                    palettePhase={scene.palettePhase}
+                    paletteQuery={scene.paletteQuery}
+                    paletteName={scene.paletteName}
+                    paletteCaret={scene.paletteCaret}
+                    bundleReady={scene.bundleReady}
+                />
+            </ToolkitShell>
+        );
+    } else if (slideId === 'workbench') {
+        body = (
+            <ToolkitShell activeApp="workbench" tabLabel="Metadata Explorer" interactive>
+                <MetadataBody
+                    filter={scene.metaFilter}
+                    caret={scene.metaCaret}
+                    selected={scene.metaSelected}
+                />
+            </ToolkitShell>
+        );
+    } else if (slideId === 'soql') {
+        body = (
+            <ToolkitShell activeApp="soql" tabLabel="SOQL Explorer" interactive>
+                <SoqlBody
+                    draft={scene.soqlDraft}
+                    caret={scene.soqlCaret}
+                    resultsVisible={scene.resultsVisible}
+                    sendPulse={scene.sendPulse}
+                />
+            </ToolkitShell>
+        );
+    } else {
+        body = (
+            <SidePanelForm
+                assistant={scene.assistant}
+                streaming={scene.streaming}
+                formFocus={scene.formFocus}
+                formName={scene.formName}
+                formEmail={scene.formEmail}
+                formOrder={scene.formOrder}
+                formMessage={scene.formMessage}
+                formSubmitPulse={scene.formSubmitPulse}
+            />
+        );
+    }
+    return (
+        <div
+            className="pt-stage"
+            data-tour-slide={slideId}
+            style={{ width: AUTHORED_WIDTH, height: AUTHORED_HEIGHT }}
+        >
+            {body}
+        </div>
+    );
+}

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -55,7 +55,12 @@ a {
 .announce-bar {
     margin: 0 -1.75rem;
     padding: 0.5rem 1.75rem;
-    background: linear-gradient(90deg, rgba(61, 114, 244, 0.06), rgba(61, 114, 244, 0.11) 50%, rgba(61, 114, 244, 0.06));
+    background: linear-gradient(
+        90deg,
+        rgba(61, 114, 244, 0.06),
+        rgba(61, 114, 244, 0.11) 50%,
+        rgba(61, 114, 244, 0.06)
+    );
     border-bottom: 1px solid rgba(61, 114, 244, 0.18);
     display: flex;
     align-items: center;
@@ -153,7 +158,9 @@ a {
     padding: 4px 6px;
     border-radius: 6px;
     color: var(--color-text-muted);
-    transition: background 0.15s ease, color 0.15s ease;
+    transition:
+        background 0.15s ease,
+        color 0.15s ease;
     line-height: 1;
 }
 
@@ -187,7 +194,9 @@ a {
     background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: 10px;
-    box-shadow: 0 8px 24px -4px rgba(19, 48, 98, 0.14), 0 0 0 1px rgba(0,0,0,0.04);
+    box-shadow:
+        0 8px 24px -4px rgba(19, 48, 98, 0.14),
+        0 0 0 1px rgba(0, 0, 0, 0.04);
     min-width: 148px;
     z-index: 100;
 }
@@ -211,7 +220,9 @@ a {
     padding: 7px 10px;
     border-radius: 7px;
     text-align: left;
-    transition: background 0.12s ease, color 0.12s ease;
+    transition:
+        background 0.12s ease,
+        color 0.12s ease;
 }
 
 .lang-picker-option:hover {
@@ -253,7 +264,10 @@ a {
     color: #ffffff;
     font-weight: 600;
     font-size: 0.95rem;
-    transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    transition:
+        background-color 0.2s ease,
+        border-color 0.2s ease,
+        box-shadow 0.2s ease;
 }
 
 .button:hover,
@@ -347,7 +361,9 @@ h1 {
     max-width: 680px;
     opacity: 0;
     transform: translateY(28px);
-    transition: opacity 0.85s ease, transform 0.85s ease;
+    transition:
+        opacity 0.85s ease,
+        transform 0.85s ease;
     transition-delay: 0.05s;
 }
 
@@ -364,18 +380,21 @@ h1 {
     justify-content: center;
 }
 
-.hero-browser {
+.home-tour {
     width: 100%;
+    max-width: 1120px;
+    margin: 0 auto;
     opacity: 0;
-    transform: translateY(36px) perspective(1600px) rotateX(3deg);
-    transform-origin: top center;
-    transition: opacity 0.95s ease, transform 0.95s ease;
+    transform: translateY(36px);
+    transition:
+        opacity 0.95s ease,
+        transform 0.95s ease;
     transition-delay: 0.3s;
 }
 
-.hero-full.is-visible .hero-browser {
+.hero-full.is-visible .home-tour {
     opacity: 1;
-    transform: translateY(0) perspective(1600px) rotateX(3deg);
+    transform: translateY(0);
 }
 
 /* ─── Feature Sections ────────────────────────────────────── */
@@ -416,7 +435,9 @@ h1 {
 .feature-text {
     opacity: 0;
     transform: translateX(-28px);
-    transition: opacity 0.7s ease, transform 0.7s ease;
+    transition:
+        opacity 0.7s ease,
+        transform 0.7s ease;
     transition-delay: 0.1s;
 }
 
@@ -427,7 +448,9 @@ h1 {
 .feature-browser {
     opacity: 0;
     transform: translateX(28px);
-    transition: opacity 0.7s ease, transform 0.7s ease;
+    transition:
+        opacity 0.7s ease,
+        transform 0.7s ease;
     transition-delay: 0.25s;
 }
 
@@ -487,9 +510,15 @@ h1 {
     border-radius: 50%;
 }
 
-.dot-red    { background: #ff5f56; }
-.dot-yellow { background: #ffbd2e; }
-.dot-green  { background: #27c93f; }
+.dot-red {
+    background: #ff5f56;
+}
+.dot-yellow {
+    background: #ffbd2e;
+}
+.dot-green {
+    background: #27c93f;
+}
 
 .fake-browser-nav {
     display: flex;
@@ -530,11 +559,17 @@ h1 {
     justify-content: center;
 }
 
-.fake-browser-content--screenshot {
+.fake-browser-content--screenshot,
+.fake-browser-content--wireframe {
     min-height: unset;
     background: none;
     display: block;
     padding: 0;
+}
+
+.fake-browser--tour {
+    width: max-content;
+    max-width: none;
 }
 
 .fake-browser-screenshot {
@@ -579,7 +614,9 @@ h1 {
     border-radius: 0.9rem;
     background: var(--color-surface);
     box-shadow: 0 10px 28px -22px rgba(28, 67, 133, 0.5);
-    transition: box-shadow 0.2s ease, border-color 0.2s ease;
+    transition:
+        box-shadow 0.2s ease,
+        border-color 0.2s ease;
 }
 
 .platform-card:hover {
@@ -661,7 +698,9 @@ h1 {
     border-top: 1px solid var(--color-border);
     opacity: 0;
     transform: translateY(24px);
-    transition: opacity 0.7s ease, transform 0.7s ease;
+    transition:
+        opacity 0.7s ease,
+        transform 0.7s ease;
 }
 
 .faq-section.is-visible {
@@ -682,7 +721,9 @@ h1 {
     border-radius: 0.9rem;
     background: var(--color-surface);
     box-shadow: 0 10px 28px -22px rgba(28, 67, 133, 0.5);
-    transition: box-shadow 0.2s ease, border-color 0.2s ease;
+    transition:
+        box-shadow 0.2s ease,
+        border-color 0.2s ease;
     overflow: hidden;
 }
 
@@ -739,7 +780,7 @@ h1 {
 }
 
 .faq-code {
-    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
     font-size: 0.86em;
     padding: 0.1em 0.4em;
     border-radius: 0.35rem;
@@ -887,10 +928,6 @@ a:focus-visible {
         font-size: clamp(2rem, 9.5vw, 2.8rem);
     }
 
-    .hero-browser {
-        transform: none !important;
-    }
-
     .fake-browser-content {
         min-height: 240px;
     }
@@ -913,7 +950,9 @@ a:focus-visible {
     margin: 0 auto;
     opacity: 0;
     transform: translateY(24px);
-    transition: opacity 0.7s ease, transform 0.7s ease;
+    transition:
+        opacity 0.7s ease,
+        transform 0.7s ease;
 }
 
 .welcome-hero.is-visible {
@@ -1099,8 +1138,13 @@ a:focus-visible {
 }
 
 @keyframes pin-pulse {
-    0%, 100% { box-shadow: 0 0 0 2px rgba(61, 114, 244, 0.35); }
-    50%      { box-shadow: 0 0 0 5px rgba(61, 114, 244, 0.15); }
+    0%,
+    100% {
+        box-shadow: 0 0 0 2px rgba(61, 114, 244, 0.35);
+    }
+    50% {
+        box-shadow: 0 0 0 5px rgba(61, 114, 244, 0.15);
+    }
 }
 
 .pin-toolbar-popover {
@@ -1173,7 +1217,9 @@ a:focus-visible {
     border-top: 1px solid var(--color-border);
     opacity: 0;
     transform: translateY(28px);
-    transition: opacity 0.7s ease, transform 0.7s ease;
+    transition:
+        opacity 0.7s ease,
+        transform 0.7s ease;
 }
 
 .welcome-steps.is-visible {
@@ -1197,7 +1243,10 @@ a:focus-visible {
     border-radius: 0.9rem;
     background: var(--color-surface);
     box-shadow: 0 10px 28px -22px rgba(28, 67, 133, 0.5);
-    transition: box-shadow 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    transition:
+        box-shadow 0.2s ease,
+        border-color 0.2s ease,
+        transform 0.2s ease;
 }
 
 .step-card:hover {

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "Bundler",
-    "allowImportingTsExtensions": false,
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
@@ -15,5 +15,6 @@
     "types": ["vite/client"]
   },
   "include": ["src"],
+  "exclude": ["src/**/__test__/**"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/assets/extension/releaseNotes.json
+++ b/assets/extension/releaseNotes.json
@@ -1,5 +1,47 @@
 [
     {
+        "version": "2.1.1",
+        "date": "September 5th, 2026",
+        "sections": [
+            {
+                "title": "Enhancements",
+                "categories": [
+                    {
+                        "category": "AI Agent — Browser",
+                        "items": [
+                            "From the Chrome side panel, the Agent now knows which browser tab you are looking at and can inspect that page directly — quizzes, \"what's on this tab\", screenshots — without opening a new tab.",
+                            "Sandbox `js` scripts can call `getCurrentTab()` and `connectToPage()` with no tab id to attach to the visible tab. Multi-line scripts via heredoc (`js <<'EOF'`) are supported, and wrapping code in `(async () => { ... })()` no longer returns empty output."
+                        ]
+                    },
+                    {
+                        "category": "AI Agent — Models",
+                        "items": [
+                            "With an API key configured, the model picker now loads the live catalog from OpenAI, Anthropic, Gemini, Mistral, and xAI, so newly released models appear without a Workbench update."
+                        ]
+                    },
+                    {
+                        "category": "Overlay & SOQL Explorer",
+                        "items": [
+                            "Added hover tooltips to icon-only buttons in the overlay panel and SOQL Explorer toolbar. Thanks to @sachinho-oda for reporting (#53)."
+                        ]
+                    }
+                ]
+            },
+            {
+                "title": "Bug Fixes",
+                "categories": [
+                    {
+                        "category": "AI Agent",
+                        "items": [
+                            "Page snapshots no longer fail on file inputs and other form fields whose type cannot be read.",
+                            "Sandbox `js` evaluation no longer hangs on simple scripts, and a stale sandbox after the side panel remounts no longer swallows eval until timeout."
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
         "version": "2.1.0",
         "date": "August 10th, 2026",
         "sections": [

--- a/assets/server/data/announcements.json
+++ b/assets/server/data/announcements.json
@@ -1,13 +1,13 @@
 {
     "announcement": {
-        "id": "2026-08-10-2-1-0",
+        "id": "2026-09-05-2-1-1",
         "active": true,
         "variant": "brand",
-        "title": "Workbench 2.1.0 is here",
-        "message": "Workbench 2.1.0 adds form-data and binary file uploads in API Explorer and fixes GET requests being blocked before they were sent.",
+        "title": "Workbench 2.1.1 is here",
+        "message": "Workbench 2.1.1 lets the Agent inspect the tab beside the side panel, loads live model catalogs from your API keys, and adds hover tooltips to overlay and SOQL toolbar buttons.",
         "linkLabel": "View release notes",
         "linkUrl": "https://www.sf-workbench.com/app?applicationName=release",
-        "startsAt": "2026-08-10T00:00:00Z",
+        "startsAt": "2026-09-05T00:00:00Z",
         "endsAt": "2026-12-31T23:59:59Z"
     }
 }

--- a/assets/shared/skills/browser/chrome-tabs.SKILL.md
+++ b/assets/shared/skills/browser/chrome-tabs.SKILL.md
@@ -10,15 +10,16 @@ Use this skill for browser tab automation in Workbench.
 ## When to use
 
 - User asks to list tabs, open a tab, close a tab, activate a tab, or inspect page state.
-- User asks "what do you see" and you need a screenshot through `logImage`.
+- User asks "what do you see", to solve a quiz, or to read the current / visible tab.
 
 ## Available globals (inside `js`)
 
 - `listTabs(): Promise<Array<{ id, title, url, active }>>`
+- `getCurrentTab()` (active tab from `listTabs()`, or first listed tab)
 - `createTab(url?, { forceNew? })` (idempotent unless `forceNew: true`)
 - `closeTab(tabId)`
 - `activateTab(tabId)`
-- `connectToPage(tabId)` (Puppeteer page handle)
+- `connectToPage(tabId?)` (Puppeteer page handle; omits tabId → active tab)
 - `waitForPageLoad(page, options?)`
 - `waitForLightning(page, options?)`
 - `getSnapshot(page)`
@@ -27,13 +28,20 @@ Use this skill for browser tab automation in Workbench.
 
 ## Recipes
 
+- Inspect the user's current / visible tab (quiz, "this page", "what do you see"):
+    - `const tab = await getCurrentTab();`
+    - `const page = await connectToPage(tab.id);` (`connectToPage()` with no arg also attaches to the active tab)
+    - `const snapshot = await getSnapshot(page);` — returns ARIA YAML (a string). `console.log(snapshot)`.
+    - Do **not** call `createTab()` for an already-open page.
 - Open or reuse an automation tab:
-  - `const tab = await createTab('https://example.com');`
+    - `const tab = await createTab('https://example.com');`
 - Capture a screenshot for visual confirmation:
-  - `const shot = await page.screenshot({ encoding: 'base64' }); logImage(shot);`
+    - `const shot = await page.screenshot({ encoding: 'base64' }); logImage(shot);`
 - Keep tab usage clean:
-  - reuse `createTab()` default behavior for retries
-  - call `closeTab(tab.id)` for force-created temporary tabs
+    - reuse `createTab()` default behavior for retries
+    - call `closeTab(tab.id)` for force-created temporary tabs
+
+The `js` runtime already wraps scripts in async. Use top-level `await`. Do **not** wrap recipes in `(async () => { ... })();` — that returns immediately with empty output.
 
 ## Not available
 

--- a/assets/shared/skills/browser/tabs.SKILL.md
+++ b/assets/shared/skills/browser/tabs.SKILL.md
@@ -15,7 +15,7 @@ Use this skill for tab lifecycle decisions.
 
 ## Recommended patterns
 
-- Start with `listTabs()` when user refers to existing tabs.
+- Start with `listTabs()` or `getCurrentTab()` when the user refers to existing tabs, "this tab", or visible page content.
 - Reuse a single worker tab for sequential scraping/navigation.
 - Open extra tabs only when parallel/isolated context is required.
 - Close force-created tabs once work completes.
@@ -23,4 +23,5 @@ Use this skill for tab lifecycle decisions.
 ## Anti-patterns
 
 - Do not call `createTab(..., { forceNew: true })` in loops/retries.
-- Do not assume the currently active user tab is safe to mutate.
+- Do not call `createTab()` to inspect a page the user already has open — connect to that tab instead.
+- Do not mutate the user's active tab unless they asked you to change it. Inspecting (snapshot/screenshot/read) is always OK.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "workbench",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "workbench",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "hasInstallScript": true,
             "dependencies": {
                 "@ai-sdk/anthropic": "^3.0.68",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "workbench",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "scripts": {
         "start:dev:extension": "rm -rf dist/extension; npm-run-all --parallel watch:extension serve:extension",
         "start:dev:server": "npm run build:server && NODE_ENV=development DOTENV_CONFIG_PATH=.env.dev node -r dotenv/config packages/server/dist/server-dev.js",

--- a/packages/desktop/package-lock.json
+++ b/packages/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@workbench/desktop",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@workbench/desktop",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "bin": {
                 "workbench-desktop": "dist/cli/desktopCli.js"
             },

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@workbench/desktop",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "private": true,
     "description": "Electron desktop shell for Workbench",
     "productName": "Workbench Desktop",

--- a/packages/extension/src/modules/__tests__/sandboxEval.test.js
+++ b/packages/extension/src/modules/__tests__/sandboxEval.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+test('sandbox.js compiles every eval wrap then executes with SyntaxError fallback', async () => {
+    const sandboxPath = fileURLToPath(new URL('../sandbox.js', import.meta.url));
+    const src = await readFile(sandboxPath, 'utf8');
+    assert.match(src, /function compileSandboxEvalFns/);
+    assert.match(src, /function runCompiledSandboxEval/);
+    assert.match(src, /return await \$\{source\}/);
+    assert.match(src, /compileSandboxEvalFns\(code\)/);
+    assert.match(src, /trailing-semicolon/);
+});

--- a/packages/extension/src/modules/sandbox.js
+++ b/packages/extension/src/modules/sandbox.js
@@ -242,6 +242,10 @@ const SNAPSHOT_SCRIPT = `
     } catch { return []; }
   }
 
+  function safeInputType(element) {
+    try { return (element.type || "").toLowerCase(); } catch { return ""; }
+  }
+
   const kImplicitRoleByTagName = {
     A: e => e.hasAttribute("href") ? "link" : null,
     AREA: e => e.hasAttribute("href") ? "link" : null,
@@ -256,7 +260,7 @@ const SNAPSHOT_SCRIPT = `
     HR: () => "separator", HTML: () => "document",
     IMG: e => e.getAttribute("alt") === "" && !e.getAttribute("title") && !hasGlobalAriaAttribute(e) && !hasTabIndex(e) ? "presentation" : "img",
     INPUT: e => {
-      const type = e.type.toLowerCase();
+      const type = safeInputType(e);
       if (type === "search") return e.hasAttribute("list") ? "combobox" : "searchbox";
       if (["email","tel","text","url",""].includes(type)) {
         const list = getIdRefs(e, e.getAttribute("list"))[0];
@@ -390,15 +394,15 @@ const SNAPSHOT_SCRIPT = `
     if (ariaLabel.trim()) { options.visitedElements.add(element); return ariaLabel; }
 
     if (!["presentation","none"].includes(role)) {
-      if (tagName === "INPUT" && ["button","submit","reset"].includes(element.type)) {
+      if (tagName === "INPUT" && ["button","submit","reset"].includes(safeInputType(element))) {
         options.visitedElements.add(element);
         const value = element.value || "";
         if (value.trim()) return value;
-        if (element.type === "submit") return "Submit";
-        if (element.type === "reset") return "Reset";
+        if (safeInputType(element) === "submit") return "Submit";
+        if (safeInputType(element) === "reset") return "Reset";
         return element.getAttribute("title") || "";
       }
-      if (tagName === "INPUT" && element.type === "image") {
+      if (tagName === "INPUT" && safeInputType(element) === "image") {
         options.visitedElements.add(element);
         const alt = element.getAttribute("alt") || "";
         if (alt.trim()) return alt;
@@ -468,7 +472,7 @@ const SNAPSHOT_SCRIPT = `
   function getAriaChecked(element) {
     const tagName = elementSafeTagName(element);
     if (tagName === "INPUT" && element.indeterminate) return "mixed";
-    if (tagName === "INPUT" && ["checkbox","radio"].includes(element.type)) return element.checked;
+    if (tagName === "INPUT" && ["checkbox","radio"].includes(safeInputType(element))) return element.checked;
     if (kAriaCheckedRoles.includes(getAriaRole(element) || "")) {
       const checked = element.getAttribute("aria-checked");
       if (checked === "true") return true;
@@ -686,7 +690,9 @@ const SNAPSHOT_SCRIPT = `
     if (kAriaPressedRoles.includes(role)) result.pressed = getAriaPressed(element);
     if (kAriaSelectedRoles.includes(role)) result.selected = getAriaSelected(element);
     if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
-      if (element.type !== "checkbox" && element.type !== "radio" && element.type !== "file") result.children = [element.value];
+      const inputType = safeInputType(element);
+      if (inputType === "file") return null;
+      if (inputType !== "checkbox" && inputType !== "radio") result.children = [element.value];
     }
     return result;
   }
@@ -945,6 +951,23 @@ async function listTabs() {
 }
 
 /**
+ * The user's visible/active tab from listTabs(), or the first listed tab.
+ * @returns {Promise<{id:number,title:string,url:string,active:boolean}|null>}
+ */
+async function getCurrentTab() {
+    const tabs = await listTabs();
+    if (!Array.isArray(tabs) || tabs.length === 0) return null;
+    return tabs.find(t => t.active) || tabs[0] || null;
+}
+
+function resolveConnectTabId(tabId, tabs) {
+    if (Number.isInteger(tabId)) return tabId;
+    if (!Array.isArray(tabs) || tabs.length === 0) return null;
+    const active = tabs.find(t => t.active);
+    return active?.id ?? tabs[0]?.id ?? null;
+}
+
+/**
  * Open a new tab via extension host.
  *
  * Idempotent by default: if a previous createTab() call in this sandbox is
@@ -1152,11 +1175,22 @@ class SandboxCdpTransport {
 /**
  * Connect to a Chrome tab and return a Puppeteer Page. Caches one browser/page per tab;
  * reuses cache when tabId is unchanged, closes and reconnects when tabId changes.
- * @param {number} tabId - Chrome tab ID
+ * @param {number} [tabId] - Chrome tab ID. When omitted, attaches to the active tab from listTabs().
  * @returns {Promise<import('puppeteer-core').Page>}
  */
 async function connectToPage(tabId) {
     sandboxLog('connectToPage called with tabId:', tabId);
+
+    if (!Number.isInteger(tabId)) {
+        const tabs = await listTabs();
+        tabId = resolveConnectTabId(tabId, tabs);
+        if (!Number.isInteger(tabId)) {
+            throw new Error(
+                'No browser tab available. Pass a tabId from listTabs(), or open a tab first with createTab().'
+            );
+        }
+        sandboxLog('connectToPage defaulted to tab:', tabId);
+    }
 
     //await activateTab(tabId); (We don't activate the tab here otherwise it force the navigation)
 
@@ -1672,6 +1706,7 @@ function sendBashRequest(command, cwd, timeoutMs = 60000) {
 
 // Expose for code run via EVAL_REQUEST (e.g. browser automation tools)
 window.listTabs = listTabs;
+window.getCurrentTab = getCurrentTab;
 window.createTab = createTab;
 window.closeTab = closeTab;
 window.activateTab = activateTab;
@@ -1902,9 +1937,61 @@ function formatConsoleArg(value) {
     return String(value);
 }
 
+/**
+ * Compile agent `js` source so the sandbox awaits the completion value.
+ * `(async () => { ... })();` fails `return (${code})` because of the trailing
+ * semicolon; `return await ${code}` captures that promise instead of returning
+ * immediately with undefined.
+ *
+ * Compile-only fallback is not enough: pick every wrap that parses, then execute
+ * them in order so a wrap that parses but throws SyntaxError at runtime can fall
+ * through. Returning the first compiled Function used to hang simple scripts
+ * when that wrap produced a never-settling thenable.
+ */
+function compileSandboxEvalFns(code) {
+    const source = typeof code === 'string' ? code : '';
+    const attempts = [
+        `return (async () => { return (${source}); })()`,
+        `return (async () => { return await ${source}; })()`,
+        `return (async () => { ${source} })()`,
+    ];
+    const compiled = [];
+    let lastError;
+    for (const body of attempts) {
+        try {
+            compiled.push(new Function(body));
+        } catch (err) {
+            lastError = err;
+            if (!(err instanceof SyntaxError)) throw err;
+        }
+    }
+    if (compiled.length === 0) throw lastError;
+    return compiled;
+}
+
+async function runCompiledSandboxEval(evalFns, runWithTimeout) {
+    const run = async () => {
+        let execError;
+        for (const fn of evalFns) {
+            try {
+                return await fn();
+            } catch (err) {
+                execError = err;
+                if (!(err instanceof SyntaxError)) throw err;
+            }
+        }
+        throw execError;
+    };
+    return runWithTimeout(run);
+}
+
 async function runEval(id, code, timeoutMs) {
     aborted = false;
     currentEvalId = id;
+    if (imageContext) {
+        imageContext.images = [];
+        imageContext.counter = 0;
+    }
     const timeout = Math.max(1000, Math.min(timeoutMs || 45000, 120000));
 
     const chunks = [];
@@ -1993,15 +2080,12 @@ async function runEval(id, code, timeoutMs) {
     const finish = result => done({ startTime, ...result });
     finishCurrentEval = finish;
     try {
-        let value;
-        try {
-            const expressionFn = new Function(`return (async () => { return (${code}); })()`);
-            value = await runWithTimeout(() => expressionFn());
-        } catch (err) {
-            if (!(err instanceof SyntaxError)) throw err;
-            const statementFn = new Function(`return (async () => { ${code} })()`);
-            value = await runWithTimeout(() => statementFn());
-        }
+        // Prefer expression wrap, then `return await ${code}` so trailing-semicolon
+        // async IIFEs (`(async () => { ... })();`) are awaited. The statement
+        // fallback does not await a fire-and-forget IIFE, which used to finish in
+        // 0ms with undefined and no console output.
+        const evalFns = compileSandboxEvalFns(code);
+        const value = await runCompiledSandboxEval(evalFns, runWithTimeout);
 
         if (!settled && currentEvalId === id) {
             await finish({ output: formatReturnValue(value), hasError: false });

--- a/packages/extension/src/workers/background.js
+++ b/packages/extension/src/workers/background.js
@@ -23,6 +23,7 @@ import {
     isEmpty,
     isHostMatching,
     isNotNullOrUndefined,
+    mergePatternLines,
     normalizeUrlForPatternMatch,
     refreshContentScriptPatternsCache,
     safeDebug,
@@ -51,6 +52,7 @@ const PORT_INJECTED = 'sf-toolkit-injected';
 const PORT_SIDEPANEL = 'sf-toolkit-sidepanel';
 const MATCH_CONTENT_SCRIPT_URL = 'matchContentScriptUrl';
 const STABLE_SIDEPANEL_PATH = 'views/default.html';
+const OPENED_SIDE_PANEL_TAB_IDS_KEY = 'opened_side_panel_tab_ids';
 
 /** Default content-script patterns */
 const DEFAULT_INCLUDE_PATTERNS = [
@@ -69,6 +71,8 @@ const DEFAULT_INCLUDE_PATTERNS = [
     '/\.lightning\.force\.com\.mcas\.ms/',
     '/\.builder\.salesforce-experience\.com/',
 ];
+const PUBLIC_SALESFORCE_HOST_EXCLUDE =
+    '/https:\\/\\/(www|trailhead|help|developer|appearance)\\.salesforce\\.com/';
 const DEFAULT_EXCLUDE_PATTERNS = [
     '/\/setup\/secur\/RemoteAccessAuthorizationPage\.apexp/',
     '/\/_ui\/common\/apex\/debug\//',
@@ -77,7 +81,21 @@ const DEFAULT_EXCLUDE_PATTERNS = [
     'https:\/\/login\.salesforce\.com\//',
     '/\/loginflow\//',
     'salesforce\.com\/#\[^\/\]/',
+    // Public Salesforce sites are not Lightning orgs. Injecting the overlay's
+    // LWC runtime into them can trip Chrome's `upload` Permissions-Policy
+    // ("upload is not allowed in this document").
+    PUBLIC_SALESFORCE_HOST_EXCLUDE,
 ];
+
+async function ensurePublicSalesforceHostExclude() {
+    const data = await chrome.storage.local.get(['content_script_exclude_patterns']);
+    if (!data.content_script_exclude_patterns) return;
+    const mergedExcludes = mergePatternLines(data.content_script_exclude_patterns, [
+        PUBLIC_SALESFORCE_HOST_EXCLUDE,
+    ]);
+    if (mergedExcludes === data.content_script_exclude_patterns) return;
+    await chrome.storage.local.set({ content_script_exclude_patterns: mergedExcludes });
+}
 
 const redirectToUrlViaChrome = ({ baseUrl, sessionId, serverUrl, navigation }) => {
     let params = new URLSearchParams();
@@ -200,25 +218,46 @@ function hasSidePanelPortForTab(tabId) {
     return false;
 }
 
+function persistOpenedSidePanelTabIds() {
+    const setter = chrome.storage?.session?.set;
+    if (typeof setter !== 'function') return;
+    Promise.resolve(
+        setter.call(chrome.storage.session, {
+            [OPENED_SIDE_PANEL_TAB_IDS_KEY]: [...openedSidePanelTabIds],
+        })
+    ).catch(() => {});
+}
+
+async function restoreOpenedSidePanelTabIds() {
+    try {
+        const stored = await chrome.storage.session.get(OPENED_SIDE_PANEL_TAB_IDS_KEY);
+        const ids = stored?.[OPENED_SIDE_PANEL_TAB_IDS_KEY];
+        if (!Array.isArray(ids)) return;
+        for (const id of ids) {
+            if (Number.isInteger(id)) openedSidePanelTabIds.add(id);
+        }
+    } catch (e) {}
+}
+
 const handleTabOpening = async tab => {
     try {
         if (!tab?.id) return;
-        const now = Date.now();
         const last = _lastSidePanelOptionsByTabId.get(tab.id);
         const enabled = openedSidePanelTabIds.has(tab.id);
-        if (last && last.enabled === enabled && now - last.ts < 750) return;
+        if (last && last.enabled === enabled) return;
         await chrome.sidePanel.setOptions({
             tabId: tab.id,
             path: STABLE_SIDEPANEL_PATH,
             enabled,
         });
-        _lastSidePanelOptionsByTabId.set(tab.id, { enabled, ts: now });
+        _lastSidePanelOptionsByTabId.set(tab.id, { enabled, ts: Date.now() });
     } catch (e) {}
 };
 
 const openSideBar = async tab => {
     if (!tab?.id) return;
     openedSidePanelTabIds.add(tab.id);
+    persistOpenedSidePanelTabIds();
     _lastSidePanelOptionsByTabId.set(tab.id, { enabled: true, ts: Date.now() });
 
     const optionsPromise = chrome.sidePanel.setOptions({
@@ -236,6 +275,7 @@ const closeSideBar = async tabOrTabId => {
     const tabId = getTabId(tabOrTabId);
     if (!Number.isInteger(tabId)) return;
     openedSidePanelTabIds.delete(tabId);
+    persistOpenedSidePanelTabIds();
     _lastSidePanelOptionsByTabId.delete(tabId);
 
     await chrome.sidePanel.setOptions({
@@ -419,6 +459,7 @@ function handleSidePanelPort(port) {
             if (Number.isInteger(tabId)) {
                 sidePanelTabIdByPort.set(port, tabId);
                 openedSidePanelTabIds.add(tabId);
+                persistOpenedSidePanelTabIds();
                 _lastSidePanelOptionsByTabId.set(tabId, {
                     enabled: true,
                     ts: Date.now(),
@@ -626,7 +667,6 @@ async function handleTabUpdated(tabId, info, tab) {
             }
         );
     }
-    await handleTabOpening(tab);
 }
 
 /** Runtime message handlers. */
@@ -941,6 +981,7 @@ chrome.contextMenus.onClicked.addListener(handleContextMenuClick);
 chrome.tabs.onActivated.addListener(handleTabActivated);
 chrome.tabs.onRemoved.addListener(tabId => {
     openedSidePanelTabIds.delete(tabId);
+    persistOpenedSidePanelTabIds();
     _lastSidePanelOptionsByTabId.delete(tabId);
     injectingTabIds.delete(tabId);
 });
@@ -1038,6 +1079,8 @@ chrome.runtime.onInstalled.addListener(async details => {
         await chrome.storage.local.set({
             content_script_exclude_patterns: DEFAULT_EXCLUDE_PATTERNS.join('\n'),
         });
+    } else {
+        await ensurePublicSalesforceHostExclude();
     }
     await refreshContentScriptPatternsCache(DEFAULT_INCLUDE_PATTERNS, DEFAULT_EXCLUDE_PATTERNS);
 });
@@ -1056,6 +1099,7 @@ chrome.commands.onCommand.addListener((command, tab) => {
 
 /** Service worker bootstrap. */
 const init = async () => {
+    await restoreOpenedSidePanelTabIds();
     chrome.sidePanel
         .setPanelBehavior({ openPanelOnActionClick: false })
         .catch(error => console.error(error));
@@ -1063,9 +1107,11 @@ const init = async () => {
         .setOptions({ path: STABLE_SIDEPANEL_PATH, enabled: false })
         .catch(error => console.error(error));
     ensureContextMenu().catch(() => {});
-    refreshContentScriptPatternsCache(DEFAULT_INCLUDE_PATTERNS, DEFAULT_EXCLUDE_PATTERNS).catch(
-        () => {}
-    );
+    ensurePublicSalesforceHostExclude()
+        .then(() =>
+            refreshContentScriptPatternsCache(DEFAULT_INCLUDE_PATTERNS, DEFAULT_EXCLUDE_PATTERNS)
+        )
+        .catch(() => {});
 };
 
 chrome.runtime.setUninstallURL('https://forms.gle/cd8SkEPe5RGTVijJA');

--- a/packages/extension/src/workers/shared/__tests__/sidePanel.test.js
+++ b/packages/extension/src/workers/shared/__tests__/sidePanel.test.js
@@ -2,7 +2,8 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 function makeChrome() {
-    const calls = { setOptions: [], open: [] };
+    const sessionStore = {};
+    const calls = { setOptions: [], open: [], sessionSet: [] };
     globalThis.chrome = {
         sidePanel: {
             setOptions: opts => {
@@ -12,6 +13,20 @@ function makeChrome() {
             open: opts => {
                 calls.open.push(opts);
                 return Promise.resolve();
+            },
+        },
+        storage: {
+            session: {
+                get: async key => {
+                    if (typeof key === 'string') {
+                        return { [key]: sessionStore[key] };
+                    }
+                    return { ...sessionStore };
+                },
+                set: async obj => {
+                    Object.assign(sessionStore, obj);
+                    calls.sessionSet.push({ ...obj });
+                },
             },
         },
     };
@@ -108,25 +123,21 @@ test('toggleSideBar: no-ops when tab has no id', async () => {
     assert.equal(calls.setOptions.length, 0);
 });
 
-test('handleTabOpening: debounces a second call for the same tab+enabled state within 750ms', async () => {
+test('handleTabOpening: skips a second call for the same tab+enabled state', async () => {
     const calls = makeChrome();
     const controller = createSidePanelController('sidebar.html');
-    const origNow = Date.now;
-    let now = 1_000_000;
-    Date.now = () => now;
-    try {
-        await controller.handleTabOpening({ id: 4 });
-        assert.equal(calls.setOptions.length, 1);
+    await controller.handleTabOpening({ id: 4 });
+    assert.equal(calls.setOptions.length, 1);
 
-        now += 100; // well within 750ms window
-        await controller.handleTabOpening({ id: 4 });
-        assert.equal(calls.setOptions.length, 1, 'second call within window should be suppressed');
-    } finally {
-        Date.now = origNow;
-    }
+    await controller.handleTabOpening({ id: 4 });
+    assert.equal(
+        calls.setOptions.length,
+        1,
+        'second call with same enabled state should be skipped'
+    );
 });
 
-test('handleTabOpening: proceeds again once the debounce window has elapsed', async () => {
+test('handleTabOpening: does not re-apply setOptions after 750ms when enabled is unchanged', async () => {
     const calls = makeChrome();
     const controller = createSidePanelController('sidebar.html');
     const origNow = Date.now;
@@ -136,37 +147,37 @@ test('handleTabOpening: proceeds again once the debounce window has elapsed', as
         await controller.handleTabOpening({ id: 5 });
         assert.equal(calls.setOptions.length, 1);
 
-        now += 751; // past the 750ms debounce window
+        now += 751;
         await controller.handleTabOpening({ id: 5 });
-        assert.equal(calls.setOptions.length, 2, 'call after window should proceed');
+        assert.equal(
+            calls.setOptions.length,
+            1,
+            'same enabled state should still skip after 750ms'
+        );
     } finally {
         Date.now = origNow;
     }
 });
 
-test('handleTabOpening: stays debounced across an openSideBar call that records the same enabled state', async () => {
+test('handleTabOpening: does not re-apply enabled:true after openSideBar', async () => {
     const calls = makeChrome();
     const controller = createSidePanelController('sidebar.html');
-    const origNow = Date.now;
-    let now = 3_000_000;
-    Date.now = () => now;
-    try {
-        await controller.handleTabOpening({ id: 6 }); // enabled=false (not yet opened) -> writes once
-        assert.equal(calls.setOptions.length, 1);
+    await controller.handleTabOpening({ id: 6 }); // enabled=false (not yet opened) -> writes once
+    assert.equal(calls.setOptions.length, 1);
 
-        // openSideBar marks tab 6 as opened and records {enabled: true, ts: now} itself,
-        // issuing its own setOptions + open calls.
-        await controller.openSideBar({ id: 6 });
-        assert.equal(calls.setOptions.length, 2);
+    await controller.openSideBar({ id: 6 });
+    assert.equal(calls.setOptions.length, 2);
 
-        // handleTabOpening now computes enabled=true, matching the state openSideBar just
-        // recorded at the same `now`, so within the 750ms window it is debounced and skipped.
-        now += 10;
-        await controller.handleTabOpening({ id: 6 });
-        assert.equal(calls.setOptions.length, 2, 'debounced call should not add a setOptions call');
-    } finally {
-        Date.now = origNow;
-    }
+    await controller.handleTabOpening({ id: 6 });
+    assert.equal(calls.setOptions.length, 2, 'opened tab should not re-apply enabled:true');
+});
+
+test('handleTabOpening: writes enabled:false for an unopened tab', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    await controller.handleTabOpening({ id: 11 });
+    assert.equal(calls.setOptions.length, 1);
+    assert.deepEqual(calls.setOptions[0], { tabId: 11, path: 'sidebar.html', enabled: false });
 });
 
 test('handleTabOpening: no-ops when tab has no id', async () => {
@@ -269,26 +280,54 @@ test('registerSidePanelPort: tracks ports without a sender tab id gracefully (br
 test('handleTabRemoved: clears open tracking and last-options tracking for the tab', async () => {
     const calls = makeChrome();
     const controller = createSidePanelController('sidebar.html');
-    const origNow = Date.now;
-    let now = 5_000_000;
-    Date.now = () => now;
-    try {
-        await controller.openSideBar({ id: 42 });
-        assert.equal(calls.setOptions.length, 1);
+    await controller.openSideBar({ id: 42 });
+    assert.equal(calls.setOptions.length, 1);
 
-        controller.handleTabRemoved(42);
+    controller.handleTabRemoved(42);
 
-        // Before removal, handleTabOpening would have been debounced (enabled=true matches the
-        // state openSideBar recorded). After removal, lastSidePanelOptionsByTabId no longer has
-        // an entry for tab 42, so the very next handleTabOpening call is NOT debounced and writes.
-        now += 10;
-        await controller.handleTabOpening({ id: 42 });
-        assert.equal(
-            calls.setOptions.length,
-            2,
-            'stale debounce state should have been cleared by handleTabRemoved'
-        );
-    } finally {
-        Date.now = origNow;
-    }
+    // Before removal, handleTabOpening would skip (enabled=true matches the
+    // state openSideBar recorded). After removal, lastSidePanelOptionsByTabId no longer has
+    // an entry for tab 42, so the very next handleTabOpening call writes enabled:false.
+    await controller.handleTabOpening({ id: 42 });
+    assert.equal(
+        calls.setOptions.length,
+        2,
+        'stale debounce state should have been cleared by handleTabRemoved'
+    );
+    assert.deepEqual(calls.setOptions[1], { tabId: 42, path: 'sidebar.html', enabled: false });
+});
+
+test('openSideBar: persists opened tab ids to session storage', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    await controller.openSideBar({ id: 8 });
+    assert.deepEqual(calls.sessionSet.at(-1), { opened_side_panel_tab_ids: [8] });
+});
+
+test('closeSideBar: persists removal of the opened tab id', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    await controller.openSideBar({ id: 8 });
+    await controller.closeSideBar(8);
+    assert.deepEqual(calls.sessionSet.at(-1), { opened_side_panel_tab_ids: [] });
+});
+
+test('handleTabRemoved: persists removal of the opened tab id', async () => {
+    const calls = makeChrome();
+    const controller = createSidePanelController('sidebar.html');
+    await controller.openSideBar({ id: 8 });
+    controller.handleTabRemoved(8);
+    assert.deepEqual(calls.sessionSet.at(-1), { opened_side_panel_tab_ids: [] });
+});
+
+test('restoreOpenedTabIds: hydrates opened tabs so handleTabOpening writes enabled:true', async () => {
+    const calls = makeChrome();
+    const first = createSidePanelController('sidebar.html');
+    await first.openSideBar({ id: 8 });
+
+    const second = createSidePanelController('sidebar.html');
+    await second.restoreOpenedTabIds();
+    await second.handleTabOpening({ id: 8 });
+    const last = calls.setOptions.at(-1);
+    assert.deepEqual(last, { tabId: 8, path: 'sidebar.html', enabled: true });
 });

--- a/packages/extension/src/workers/shared/sidePanel.js
+++ b/packages/extension/src/workers/shared/sidePanel.js
@@ -1,3 +1,5 @@
+const OPENED_SIDE_PANEL_TAB_IDS_KEY = 'opened_side_panel_tab_ids';
+
 export function createSidePanelController(sidePanelPath) {
     const openedSidePanelTabIds = new Set();
     const sidePanelTabIdByPort = new Map();
@@ -18,25 +20,46 @@ export function createSidePanelController(sidePanelPath) {
         return false;
     }
 
+    function persistOpenedTabIds() {
+        const setter = chrome.storage?.session?.set;
+        if (typeof setter !== 'function') return;
+        Promise.resolve(
+            setter.call(chrome.storage.session, {
+                [OPENED_SIDE_PANEL_TAB_IDS_KEY]: [...openedSidePanelTabIds],
+            })
+        ).catch(() => {});
+    }
+
+    async function restoreOpenedTabIds() {
+        try {
+            const stored = await chrome.storage.session.get(OPENED_SIDE_PANEL_TAB_IDS_KEY);
+            const ids = stored?.[OPENED_SIDE_PANEL_TAB_IDS_KEY];
+            if (!Array.isArray(ids)) return;
+            for (const id of ids) {
+                if (Number.isInteger(id)) openedSidePanelTabIds.add(id);
+            }
+        } catch (e) {}
+    }
+
     async function handleTabOpening(tab) {
         try {
             if (!tab?.id) return;
-            const now = Date.now();
             const last = lastSidePanelOptionsByTabId.get(tab.id);
             const enabled = openedSidePanelTabIds.has(tab.id);
-            if (last && last.enabled === enabled && now - last.ts < 750) return;
+            if (last && last.enabled === enabled) return;
             await chrome.sidePanel.setOptions({
                 tabId: tab.id,
                 path: sidePanelPath,
                 enabled,
             });
-            lastSidePanelOptionsByTabId.set(tab.id, { enabled, ts: now });
+            lastSidePanelOptionsByTabId.set(tab.id, { enabled, ts: Date.now() });
         } catch (e) {}
     }
 
     async function openSideBar(tab) {
         if (!tab?.id) return;
         openedSidePanelTabIds.add(tab.id);
+        persistOpenedTabIds();
         lastSidePanelOptionsByTabId.set(tab.id, { enabled: true, ts: Date.now() });
         await chrome.sidePanel.setOptions({ tabId: tab.id, path: sidePanelPath, enabled: true });
         await chrome.sidePanel.open({ tabId: tab.id });
@@ -46,6 +69,7 @@ export function createSidePanelController(sidePanelPath) {
         const tabId = getTabId(tabOrTabId);
         if (!Number.isInteger(tabId)) return;
         openedSidePanelTabIds.delete(tabId);
+        persistOpenedTabIds();
         lastSidePanelOptionsByTabId.delete(tabId);
         await chrome.sidePanel.setOptions({ tabId, path: sidePanelPath, enabled: false });
     }
@@ -97,6 +121,7 @@ export function createSidePanelController(sidePanelPath) {
 
     function handleTabRemoved(tabId) {
         openedSidePanelTabIds.delete(tabId);
+        persistOpenedTabIds();
         lastSidePanelOptionsByTabId.delete(tabId);
     }
 
@@ -109,5 +134,6 @@ export function createSidePanelController(sidePanelPath) {
         sendMessageToSidePanelInTab,
         broadcastMessageToAllSidePanelInstances,
         handleTabRemoved,
+        restoreOpenedTabIds,
     };
 }

--- a/packages/extension/src/workers/utils/__tests__/utils.test.js
+++ b/packages/extension/src/workers/utils/__tests__/utils.test.js
@@ -11,6 +11,8 @@ const {
     compareMajorMinor,
     parsePatterns,
     normalizeUrlForPatternMatch,
+    mergePatternLines,
+    urlMatchesContentScriptPatterns,
 } = await import('../utils.js');
 
 test('toNumber: parses integer strings, passes numbers through', () => {
@@ -112,4 +114,57 @@ test('normalizeUrlForPatternMatch: non-http protocols → null', () => {
 test('normalizeUrlForPatternMatch: malformed URL → null', () => {
     assert.equal(normalizeUrlForPatternMatch('not a url'), null);
     assert.equal(normalizeUrlForPatternMatch(''), null);
+});
+
+test('mergePatternLines: appends missing required lines and preserves existing', () => {
+    const stored = '/foo/\n/bar/';
+    const merged = mergePatternLines(stored, [
+        '/bar/',
+        '/https:\\/\\/trailhead\\.salesforce\\.com/',
+    ]);
+    assert.equal(merged, '/foo/\n/bar/\n/https:\\/\\/trailhead\\.salesforce\\.com/');
+});
+
+test('mergePatternLines: no-op when required lines already present', () => {
+    const stored = '/foo/\n/bar/';
+    assert.equal(mergePatternLines(stored, ['/foo/']), '/foo/\n/bar/');
+});
+
+test('urlMatchesContentScriptPatterns: skips public Salesforce sites, keeps org hosts', () => {
+    const include = parsePatterns(
+        '/\\.salesforce(-com)?\\./\n/\\.lightning\\.force(-com)?\\./',
+        []
+    );
+    const exclude = parsePatterns(
+        '/https:\\/\\/(www|trailhead|help|developer|appearance)\\.salesforce\\.com/',
+        []
+    );
+    assert.equal(
+        urlMatchesContentScriptPatterns(
+            'https://trailhead.salesforce.com/content/learn/modules/x',
+            include,
+            exclude
+        ),
+        false
+    );
+    assert.equal(
+        urlMatchesContentScriptPatterns('https://help.salesforce.com/s/', include, exclude),
+        false
+    );
+    assert.equal(
+        urlMatchesContentScriptPatterns(
+            'https://na139.salesforce.com/lightning/o/Account/list',
+            include,
+            exclude
+        ),
+        true
+    );
+    assert.equal(
+        urlMatchesContentScriptPatterns(
+            'https://myorg.lightning.force.com/lightning/page/home',
+            include,
+            exclude
+        ),
+        true
+    );
 });

--- a/packages/extension/src/workers/utils/utils.js
+++ b/packages/extension/src/workers/utils/utils.js
@@ -303,6 +303,31 @@ export function parsePatterns(patternString, fallback) {
         .filter(Boolean);
 }
 
+export function mergePatternLines(stored, requiredLines) {
+    const existing = (stored || '')
+        .split('\n')
+        .map(line => line.trim())
+        .filter(Boolean);
+    const existingSet = new Set(existing);
+    const missing = (requiredLines || []).filter(line => line && !existingSet.has(line));
+    if (missing.length === 0) {
+        return existing.join('\n');
+    }
+    return [...existing, ...missing].join('\n');
+}
+
+export function urlMatchesContentScriptPatterns(url, includePatterns, excludePatterns) {
+    const normalizedUrl = normalizeUrlForPatternMatch(url);
+    if (!normalizedUrl) return false;
+    for (const pattern of excludePatterns || []) {
+        if (pattern.test(normalizedUrl)) return false;
+    }
+    for (const pattern of includePatterns || []) {
+        if (pattern.test(normalizedUrl)) return true;
+    }
+    return false;
+}
+
 export async function refreshContentScriptPatternsCache(
     defaultIncludePatterns,
     defaultExcludePatterns
@@ -348,18 +373,9 @@ export function normalizeUrlForPatternMatch(rawUrl) {
 }
 
 export async function isHostMatching(url, defaultIncludePatterns, defaultExcludePatterns) {
-    const normalizedUrl = normalizeUrlForPatternMatch(url);
-    if (!normalizedUrl) return false;
-
     const { includePatterns, excludePatterns } = await getContentScriptPatterns(
         defaultIncludePatterns,
         defaultExcludePatterns
     );
-    for (const pattern of excludePatterns) {
-        if (pattern.test(normalizedUrl)) return false;
-    }
-    for (const pattern of includePatterns) {
-        if (pattern.test(normalizedUrl)) return true;
-    }
-    return false;
+    return urlMatchesContentScriptPatterns(url, includePatterns, excludePatterns);
 }

--- a/packages/lwc/applications/anonymousApex/app/app.html
+++ b/packages/lwc/applications/anonymousApex/app/app.html
@@ -10,7 +10,7 @@
                     <lightning-button
                         class="slds-p-left_xx-small"
                         label={i18n.EDITOR_PANEL_SAVE}
-                        onclick={executeSave}
+                        onclick={handleSaveClick}
                         disabled={isSaveButtonDisabled}></lightning-button>
                     <template lwc:if={isExecuteButtonDisplayed}>
                         <lightning-button

--- a/packages/lwc/applications/anonymousApex/app/app.ts
+++ b/packages/lwc/applications/anonymousApex/app/app.ts
@@ -428,15 +428,50 @@ export default class App extends ToolkitElement {
         }
     };
 
+    handleSaveClick = () => {
+        const { apex } = store.getState();
+        const file = apex.currentTab.fileId
+            ? SELECTORS.apexFiles.selectById(store.getState(), lowerCaseKey(apex.currentTab.fileId))
+            : null;
+        SaveModal.open({
+            title: 'Save Apex Script',
+            _file: file,
+        }).then(async data => {
+            if (isUndefinedOrNull(data)) return;
+
+            const { name, isGlobal, folder, tags } = data;
+            store.dispatch(async (dispatch, getState) => {
+                await dispatch(
+                    DOCUMENT.reduxSlices.APEXFILE.actions.upsertOne({
+                        id: name,
+                        isGlobal,
+                        content: this.body,
+                        alias: this.alias,
+                        extra: {
+                            ...(file?.extra || {}),
+                            folder: folder || '',
+                            tags: Array.isArray(tags) ? tags : [],
+                        },
+                    })
+                );
+                await dispatch(
+                    APEX.reduxSlice.actions.linkFileToTab({
+                        fileId: name,
+                        alias: this.alias,
+                        apexFiles: getState().apexFiles,
+                    })
+                );
+            });
+        });
+    };
+
     executeSave = () => {
-        //console.log('---> executeSave');
         const { apex } = store.getState();
         const file = apex.currentTab.fileId
             ? SELECTORS.apexFiles.selectById(store.getState(), lowerCaseKey(apex.currentTab.fileId))
             : null;
 
         if (isNotUndefinedOrNull(file)) {
-            // Existing file
             store.dispatch(async (dispatch, getState) => {
                 await dispatch(
                     DOCUMENT.reduxSlices.APEXFILE.actions.upsertOne({
@@ -453,37 +488,7 @@ export default class App extends ToolkitElement {
                 );
             });
         } else {
-            // Create new file
-            SaveModal.open({
-                title: 'Save Apex Script',
-                _file: file,
-            }).then(async data => {
-                //console.log('Save Apex Script', data);
-                if (isUndefinedOrNull(data)) return;
-
-                const { name, isGlobal } = data;
-                store.dispatch(async (dispatch, getState) => {
-                    await dispatch(
-                        DOCUMENT.reduxSlices.APEXFILE.actions.upsertOne({
-                            id: name, // generic
-                            isGlobal, // generic
-                            content: this.body,
-                            alias: this.alias,
-                            extra: {
-                                //useToolingApi:this._useToolingApi === true, // Needed for queries
-                            },
-                        })
-                    );
-                    await dispatch(
-                        APEX.reduxSlice.actions.linkFileToTab({
-                            fileId: name,
-                            alias: this.alias,
-                            apexFiles: getState().apexFiles,
-                        })
-                    );
-                });
-                // Reset draft
-            });
+            this.handleSaveClick();
         }
     };
 

--- a/packages/lwc/extension/views/default/default.ts
+++ b/packages/lwc/extension/views/default/default.ts
@@ -10,10 +10,12 @@ import {
 } from 'shared/cacheManager';
 import {
     buildAvailableAgentModelOptions,
+    fetchApiKeyProviderModels,
     fetchLlmModelsEndpoint,
     fetchSubscriptionModels,
     getProviderForModel,
     normalizeModelSelection,
+    toNonEmptyProviderCatalogs,
 } from 'shared/llm';
 import LOGGER from 'shared/logger';
 import { store as legacyStore, store_application } from 'shared/store';
@@ -164,8 +166,17 @@ export default class Default extends LightningElement {
             APPLICATION.reduxSlice.actions.updateSubscriptionModels({ models: subscriptionModels })
         );
 
+        const apiKeyCatalogs = toNonEmptyProviderCatalogs(
+            await fetchApiKeyProviderModels(providerConfigs)
+        );
+        if (Object.keys(apiKeyCatalogs).length > 0) {
+            store.dispatch(
+                APPLICATION.reduxSlice.actions.updateProviderCatalogs({ catalogs: apiKeyCatalogs })
+            );
+        }
+
         const availableModels = buildAvailableAgentModelOptions({
-            availableModelsByProvider: serverCatalogs,
+            availableModelsByProvider: { ...(serverCatalogs || {}), ...apiKeyCatalogs },
             subscriptionModelsByProvider: subscriptionModels,
             providerConfigs,
         });

--- a/packages/lwc/main/agent/Agent/Agent.ts
+++ b/packages/lwc/main/agent/Agent/Agent.ts
@@ -1,10 +1,6 @@
 import type { ToolCall as AiToolCall, ToolResultOutput } from '@ai-sdk/provider-utils';
 import type { Store } from '@reduxjs/toolkit';
-import {
-    clearCdpHandlerForConversation,
-    ensureCdpHandlerInitialized,
-    getCdpHandlerForConversation,
-} from 'agent/cdpHandler';
+import { clearCdpHandlerForConversation, ensureCdpHandlerInitialized } from 'agent/cdpHandler';
 import {
     type CompactionSettings,
     createCompactionSummaryMessage,
@@ -332,18 +328,22 @@ export class Agent {
     }) {
         const id = conversationId || guid();
         const shell = getOrCreateBashInstanceForConversation(id);
-        if (!getCdpHandlerForConversation(id)) {
-            await ensureCdpHandlerInitialized(id, {
-                getBashInstance: () => shell,
-                brightDataApiKey: settings.brightDataApiKey ?? null,
-                googleSheetEnabled: settings.googleSheetEnabled ?? false,
-            });
-        }
-        const cdpHandler = getCdpHandlerForConversation(id);
+        const sandboxDeps = {
+            getBashInstance: () => shell,
+            brightDataApiKey: settings.brightDataApiKey ?? null,
+            googleSheetEnabled: settings.googleSheetEnabled ?? false,
+        };
+        await ensureCdpHandlerInitialized(id, sandboxDeps);
         const fs = getIndexedDbFileSystem();
 
         const bashTools = createBashTools(shell, fs, {
-            execInSandbox: (code, timeoutMs) => cdpHandler.execInSandbox(code, timeoutMs),
+            execInSandbox: async (code, timeoutMs) => {
+                const handler = await ensureCdpHandlerInitialized(id, sandboxDeps);
+                if (!handler || typeof handler.execInSandbox !== 'function') {
+                    throw new Error('Browser runtime is unavailable');
+                }
+                return handler.execInSandbox(code, timeoutMs);
+            },
             brightDataApiKey: settings.brightDataApiKey ?? null,
         });
         const currentModel = settings.selectedModel || DEFAULT_MODEL;

--- a/packages/lwc/main/agent/agents/instructions/browserAgentInstructions.ts
+++ b/packages/lwc/main/agent/agents/instructions/browserAgentInstructions.ts
@@ -17,6 +17,17 @@ You also have bash + filesystem access for scripting, data processing, and persi
 - Reuse tabs by default (\`createTab()\` is idempotent). Use \`forceNew: true\` only when isolation is required.
 - Avoid guessing selectors when refs are available.
 
+## Inspecting the user's current tab
+
+When the user refers to "this tab", "the current page", a quiz, or visible page content:
+1. \`const tabs = await listTabs()\` (or \`const tab = await getCurrentTab()\`)
+2. \`const page = await connectToPage(tab.id)\` — \`connectToPage()\` with no argument attaches to the active tab
+3. \`getSnapshot(page)\` (screenshot with \`page.screenshot\` + \`logImage\` if you need pixels)
+
+Do **not** call \`createTab()\` to inspect a page that is already open.
+There are no tools named \`chrome_screenshot\` or \`chrome_list_tabs\` — use the \`js\` sandbox globals above.
+The \`js\` runtime already wraps scripts in async and awaits the result. Use top-level \`await\`. Do **not** wrap scripts in an extra \`(async () => { ... })()\` — that returns immediately with empty output.
+
 ## Required Storage Conventions
 
 - Conversation-scoped temp files: \`/workspace/tmp/\${conversationId}/...\`
@@ -33,7 +44,7 @@ Use \`ask_user\` only for bounded choice questions:
 ## Tool Call Discipline
 
 - Provide all required parameters for every tool call.
-- Use heredoc (\`<<'EOF'\`) for multi-line \`js\` or shell snippets.
+- For multi-line \`js\`, use a heredoc (\`js <<'EOF'\` ... \`EOF\`) or \`js /path/to/file.js\`. Do not put literal \`\\n\` inside \`js -e\`.
 - Do not use the real Salesforce CLI; use Workbench shims exposed through \`bash\` (\`sf ...\`).
 
 ## File Links in Final Responses

--- a/packages/lwc/main/agent/aiSettings/aiSettings.ts
+++ b/packages/lwc/main/agent/aiSettings/aiSettings.ts
@@ -12,10 +12,12 @@ import {
     saveSingleExtensionConfigToCache,
 } from 'shared/cacheManager';
 import {
+    fetchApiKeyProviderModels,
     fetchLlmModelsEndpoint,
     fetchSubscriptionModels,
     isInternalProviderBaseUrl,
     normalizeProviderConfigMap,
+    toNonEmptyProviderCatalogs,
     type LlmProviderConfigMap,
 } from 'shared/llm';
 import LOGGER from 'shared/logger';
@@ -148,6 +150,14 @@ export default class AiSettings extends LightningElement {
         store.dispatch(
             APPLICATION.reduxSlice.actions.updateSubscriptionModels({ models: subscriptionModels })
         );
+        const apiKeyCatalogs = toNonEmptyProviderCatalogs(
+            await fetchApiKeyProviderModels(providerConfigs)
+        );
+        if (Object.keys(apiKeyCatalogs).length > 0) {
+            store.dispatch(
+                APPLICATION.reduxSlice.actions.updateProviderCatalogs({ catalogs: apiKeyCatalogs })
+            );
+        }
     }
 
     async reloadProviderConfigs() {

--- a/packages/lwc/main/agent/app/app.ts
+++ b/packages/lwc/main/agent/app/app.ts
@@ -20,6 +20,7 @@ import {
     getDefaultModelForAgentProvider,
     readFileContent,
     generateConversationTitle,
+    buildRunningEnvironmentContext,
 } from 'agent/utils';
 import { invokeCommand } from 'host-api/commands';
 import type { ModelMessage, UIMessage } from 'ai';
@@ -38,7 +39,7 @@ import {
     normalizeLlmProvider,
 } from 'shared/llm';
 import LOGGER from 'shared/logger';
-import { isEmpty, isNotUndefinedOrNull, classSet } from 'shared/utils';
+import { isEmpty, isNotUndefinedOrNull, classSet, getCurrentTab } from 'shared/utils';
 
 import { normalizeMcpServerConfigs } from '../mcp/mcpJsonParser';
 
@@ -228,16 +229,31 @@ export default class App extends ToolkitElement {
         Analytics.trackAppOpen('agent', { alias: this.alias });
         store.dispatch(AGENT.loadCacheSettingsAsync());
         window.addEventListener('agent:ask_user', this._handleAskUserEvent);
+        window.addEventListener('pagehide', this._flushConversationCache);
+        document.addEventListener('visibilitychange', this._handleVisibilityChange);
         // Session hydration is handled by storeChange once loadFromCache populates the store.
     }
 
     disconnectedCallback() {
+        this._flushConversationCache();
         this._teardownStreamingSubscription();
         window.removeEventListener('agent:ask_user', this._handleAskUserEvent);
+        window.removeEventListener('pagehide', this._flushConversationCache);
+        document.removeEventListener('visibilitychange', this._handleVisibilityChange);
         // Reject any outstanding questions so the tool's promise doesn't leak.
         this.pendingQuestions.forEach(q => rejectQuestion(q.id));
         this.pendingQuestions = [];
     }
+
+    _flushConversationCache = () => {
+        store.dispatch(AGENT.reduxSlice.actions.flushConversationCache());
+    };
+
+    _handleVisibilityChange = () => {
+        if (document.visibilityState === 'hidden') {
+            this._flushConversationCache();
+        }
+    };
 
     renderedCallback() {
         if (this.isEditingTitle && this.refs && this.refs.titleInput) {
@@ -332,7 +348,7 @@ export default class App extends ToolkitElement {
         });
     };
 
-    _buildRunningEnvironmentContext(): string {
+    async _buildRunningEnvironmentContext(): Promise<string> {
         const state = store.getState();
         const isSidePanel = state.application?.isSidePanel ?? false;
         const connector = state.application?.connector ?? null;
@@ -342,53 +358,15 @@ export default class App extends ToolkitElement {
         const loginStatus = isLoggedIn
             ? `Connected org: ${connector.toPublic?.()?.alias ?? connector.toPublic?.()?.instanceUrl ?? 'unknown'}`
             : 'Not connected to any Salesforce org.';
-        const appLine = currentApplication
-            ? `\nCurrently visible panel: ${currentApplication}`
-            : '';
 
-        if (isSidePanel) {
-            return `
+        const currentTab = isSidePanel ? await getCurrentTab() : null;
 
-## Environment Context
-
-**Running in: Chrome Side Panel**
-
-${loginStatus}${appLine}
-
-You are running inside the Chrome Side Panel, which is a narrow overlay beside the browser — the SF Toolkit LWC app is **not** the visible tab. This has important consequences for UI tools:
-
-**Avoid UI-navigation tools** unless the user explicitly asks to open the Toolkit app:
-- \`navigate_workbench_app\`, \`sf navigate\`, \`soql_query\` (with UI), \`apex_navigate\`, \`metadata_navigate\`, \`navigateToApiEditor\` — these dispatch to the store and will take effect once the user switches to the Toolkit tab, but they produce no immediate visible feedback.
-
-**Prefer background/incognito tools** — they work reliably from the side panel without touching the UI:
-- \`soql_query_incognito\` instead of \`soql_query\`
-- \`sf data query\` for SOQL
-- \`sf apex run --no-ui\` or \`apex_execute\` for Apex (\`--no-ui\` runs incognito and does not create/update Apex tabs)
-- For UI runs, reuse the last returned \`tabId\` via \`sf apex run --tab-id <tabId>\` to avoid creating a new tab each time
-- \`sf api request\` for REST API calls
-- \`sf metadata list-types / list-records / deploy / retrieve\` for metadata operations
-- \`metadata_list_types\`, \`metadata_list_records\`, \`metadata_get_record\` (all incognito)
-
-**Connecting to a new org** via \`connect_org\` or \`sf org connect\` will open the full Toolkit in a new browser tab.
-
-**Chrome tools** (\`chrome_screenshot\`, \`chrome_list_tabs\`, etc.) work normally.
-`;
-        }
-
-        return `
-
-## Environment Context
-
-**Running in: SF Toolkit Web App**
-
-${loginStatus}${appLine}
-
-You have full access to the toolkit UI. All navigation and display tools work normally:
-- Navigation tools (\`navigate_workbench_app\`, \`sf navigate\`, \`apex_navigate\`, etc.) update the visible UI in real time.
-- Tab management tools open and switch visible editor panels.
-- Use \`soql_query\` (not incognito) to show results in the SOQL editor for the user.
-- Use incognito variants (\`soql_query_incognito\`, \`sf data query\`) when you need data silently without navigating away.
-`;
+        return buildRunningEnvironmentContext({
+            isSidePanel,
+            loginStatus,
+            currentApplication,
+            currentTab,
+        });
     }
 
     async buildAgentExecutionContext(model = this.selectedModel) {
@@ -423,7 +401,7 @@ You have full access to the toolkit UI. All navigation and display tools work no
                     state.agent?.selectedModel ||
                     getDefaultModelForAgentProvider(activeProvider, isInternal),
                 selectedReasoning: state.agent?.selectedReasoning ?? DEFAULT_REASONING,
-                systemPrompt: `${browserAgentInstructions}${this._buildRunningEnvironmentContext()}`,
+                systemPrompt: `${browserAgentInstructions}${await this._buildRunningEnvironmentContext()}`,
                 isStoreEnabled: true,
                 store,
                 extraTools: [askUserTool, ...workbenchContextTools, ...agentforceTools],

--- a/packages/lwc/main/agent/cdpHandler/__tests__/sandboxIframe.test.ts
+++ b/packages/lwc/main/agent/cdpHandler/__tests__/sandboxIframe.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { isSandboxIframeAlive } from '../sandboxIframe.ts';
+
+test('isSandboxIframeAlive: false when iframe is missing', () => {
+    assert.equal(isSandboxIframeAlive(null), false);
+});
+
+test('isSandboxIframeAlive: false when contentWindow is gone', () => {
+    assert.equal(isSandboxIframeAlive({ contentWindow: null, isConnected: true }), false);
+});
+
+test('isSandboxIframeAlive: false when iframe was detached from the document', () => {
+    assert.equal(isSandboxIframeAlive({ contentWindow: {}, isConnected: false }), false);
+});
+
+test('isSandboxIframeAlive: true when window exists and iframe is connected', () => {
+    assert.equal(isSandboxIframeAlive({ contentWindow: {}, isConnected: true }), true);
+});
+
+test('isSandboxIframeAlive: true when isConnected is omitted but window exists', () => {
+    assert.equal(isSandboxIframeAlive({ contentWindow: {} }), true);
+});

--- a/packages/lwc/main/agent/cdpHandler/__tests__/tabQuery.test.ts
+++ b/packages/lwc/main/agent/cdpHandler/__tests__/tabQuery.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { mapTabForSandbox, queryActiveTabForAgent, queryTabsForAgent } from '../tabQuery.ts';
+
+function makeTabsApi(byQuery) {
+    return {
+        query: async queryInfo => {
+            const key = JSON.stringify(queryInfo);
+            if (!(key in byQuery)) {
+                throw new Error(`unexpected chrome.tabs.query: ${key}`);
+            }
+            return byQuery[key];
+        },
+    };
+}
+
+test('queryTabsForAgent: prefers lastFocusedWindow tabs over currentWindow', async () => {
+    const focused = [{ id: 7, title: 'Quiz', url: 'https://quiz.example', active: true }];
+    const tabs = await queryTabsForAgent(
+        makeTabsApi({
+            '{"lastFocusedWindow":true}': focused,
+            '{}': [{ id: 99, title: 'Other', url: 'https://other.example', active: true }],
+        })
+    );
+    assert.deepEqual(tabs, focused);
+});
+
+test('queryTabsForAgent: falls back to all tabs when lastFocusedWindow is empty', async () => {
+    const all = [
+        { id: 1, title: 'A', url: 'https://a.example', active: false },
+        { id: 2, title: 'B', url: 'https://b.example', active: true },
+    ];
+    const tabs = await queryTabsForAgent(
+        makeTabsApi({
+            '{"lastFocusedWindow":true}': [],
+            '{}': all,
+        })
+    );
+    assert.deepEqual(tabs, all);
+});
+
+test('queryTabsForAgent: returns [] when chrome.tabs is unavailable', async () => {
+    const tabs = await queryTabsForAgent(null);
+    assert.deepEqual(tabs, []);
+});
+
+test('queryActiveTabForAgent: uses lastFocusedWindow, not currentWindow', async () => {
+    const focused = { id: 42, title: 'Quiz', url: 'https://quiz.example', active: true };
+    const tab = await queryActiveTabForAgent(
+        makeTabsApi({
+            '{"active":true,"lastFocusedWindow":true}': [focused],
+        })
+    );
+    assert.deepEqual(tab, focused);
+});
+
+test('queryActiveTabForAgent: falls back to any active tab', async () => {
+    const fallback = { id: 8, title: 'Other', url: 'https://other.example', active: true };
+    const tab = await queryActiveTabForAgent(
+        makeTabsApi({
+            '{"active":true,"lastFocusedWindow":true}': [],
+            '{"active":true}': [fallback],
+        })
+    );
+    assert.deepEqual(tab, fallback);
+});
+
+test('mapTabForSandbox: keeps the fields the sandbox listTabs contract uses', () => {
+    assert.deepEqual(
+        mapTabForSandbox({
+            id: 3,
+            title: 'Quiz',
+            url: 'https://quiz.example',
+            active: true,
+            windowId: 1,
+        }),
+        { id: 3, title: 'Quiz', url: 'https://quiz.example', active: true }
+    );
+});

--- a/packages/lwc/main/agent/cdpHandler/cdpHandler.ts
+++ b/packages/lwc/main/agent/cdpHandler/cdpHandler.ts
@@ -2,6 +2,14 @@ import { GOOGLE_DRIVE_SCOPES } from 'agent/googleAuth';
 import LOGGER from 'shared/logger';
 
 import { decodeExecStdout } from '../tools/modules/execStdout';
+import {
+    DEFAULT_EVAL_TIMEOUT_MS,
+    IFRAME_LOAD_TIMEOUT_MS,
+    SANDBOX_PING_TIMEOUT_MS,
+    SANDBOX_READY_TIMEOUT_MS,
+    isSandboxIframeAlive,
+} from './sandboxIframe';
+import { mapTabForSandbox, queryActiveTabForAgent, queryTabsForAgent } from './tabQuery';
 
 /**
  * Chrome Debugger Bridge (CdpHandler)
@@ -86,19 +94,29 @@ function createSandboxIframe() {
         typeof chrome !== 'undefined' && chrome.runtime?.getURL
             ? chrome.runtime.getURL('views/sandbox.html')
             : '/views/sandbox.html';
+    iframe.allow = 'upload';
     iframe.style.display = 'none';
     iframe.title = 'Eval Sandbox';
     return iframe;
 }
 
-function waitForIframeLoad(iframe: HTMLIFrameElement) {
+function waitForIframeLoad(iframe: HTMLIFrameElement, timeoutMs = IFRAME_LOAD_TIMEOUT_MS) {
     return new Promise((resolve, reject) => {
         if (!iframe) {
             reject(new Error('Iframe not created'));
             return;
         }
-        iframe.onload = () => resolve();
-        iframe.onerror = () => reject(new Error('Iframe load error'));
+        const timer = window.setTimeout(() => {
+            reject(new Error('Sandbox iframe load timeout'));
+        }, timeoutMs);
+        iframe.onload = () => {
+            window.clearTimeout(timer);
+            resolve();
+        };
+        iframe.onerror = () => {
+            window.clearTimeout(timer);
+            reject(new Error('Iframe load error'));
+        };
     });
 }
 
@@ -134,23 +152,46 @@ if (typeof window !== 'undefined') {
 
 /**
  * Ensures a CdpHandler exists for the given conversation: if not, creates sandbox iframe, appends to parent,
- * creates CdpHandler for this conversation, and waits for sandbox ready. No-op if handler already exists or if
- * no parent element was set via setSandboxParentElement().
+ * creates CdpHandler for this conversation, and waits for sandbox ready.
+ *
+ * Reuses a live handler. A half-initialized or detached iframe (ready timeout after
+ * the handler was already stored, side-panel remount) is destroyed and recreated so
+ * `js` does not hang until Execution timeout.
  *
  * @param {string} conversationId
  * @param {Object} deps - optional deps for the handler
  * @returns {Promise<CdpHandler | null>}
  */
 export async function ensureCdpHandlerInitialized(conversationId: string, deps) {
-    if (getCdpHandlerForConversation(conversationId)) {
-        return cdpHandlersByConversationId.get(conversationId);
+    const existing = getCdpHandlerForConversation(conversationId);
+    if (existing?.isAlive()) {
+        existing.deps = deps ?? existing.deps;
+        try {
+            await existing.waitForSandboxReady(SANDBOX_PING_TIMEOUT_MS);
+            return existing;
+        } catch (error) {
+            LOGGER.log(
+                'Existing sandbox did not respond to ping, recreating',
+                error instanceof Error ? error.message : String(error)
+            );
+            clearCdpHandlerForConversation(conversationId);
+        }
+    } else if (existing) {
+        LOGGER.log('Existing sandbox iframe is dead, recreating');
+        clearCdpHandlerForConversation(conversationId);
     }
-    const iframe = createSandboxIframe();
-    document.body.appendChild(iframe);
-    await waitForIframeLoad(iframe);
-    const handler = getOrCreateCdpHandler(conversationId, iframe, deps);
-    await handler.waitForSandboxReady();
-    return handler;
+
+    try {
+        const iframe = createSandboxIframe();
+        document.body.appendChild(iframe);
+        await waitForIframeLoad(iframe);
+        const handler = getOrCreateCdpHandler(conversationId, iframe, deps);
+        await handler.waitForSandboxReady();
+        return handler;
+    } catch (error) {
+        clearCdpHandlerForConversation(conversationId);
+        throw error;
+    }
 }
 
 export class CdpHandler {
@@ -208,6 +249,10 @@ export class CdpHandler {
 
     getSandboxWindow() {
         return this.iframe?.contentWindow ?? null;
+    }
+
+    isAlive() {
+        return isSandboxIframeAlive(this.iframe);
     }
 
     registerDebuggerListeners() {
@@ -289,11 +334,15 @@ export class CdpHandler {
     }
 
     execInSandbox(code: string, timeoutMs?: number) {
+        if (!this.isAlive()) {
+            return Promise.reject(new Error('Browser runtime iframe is not available'));
+        }
+
         return new Promise((resolve, reject) => {
             const id = crypto.randomUUID();
             LOGGER.log('execInSandbox called, id:', id, 'timeout:', timeoutMs);
 
-            const timeout = timeoutMs ?? 30000;
+            const timeout = timeoutMs ?? DEFAULT_EVAL_TIMEOUT_MS;
             const timer = setTimeout(() => {
                 if (!this.pending.has(id)) return;
                 LOGGER.log('execInSandbox timeout, id:', id);
@@ -340,14 +389,19 @@ export class CdpHandler {
         this.pending.clear();
     }
 
-    waitForSandboxReady() {
+    waitForSandboxReady(timeoutMs = SANDBOX_READY_TIMEOUT_MS) {
         return new Promise((resolve, reject) => {
             LOGGER.log('waitForSandboxReady called');
+
+            if (!this.getSandboxWindow()) {
+                reject(new Error('Sandbox iframe is not available'));
+                return;
+            }
 
             const timer = window.setTimeout(() => {
                 window.removeEventListener('message', handler);
                 reject(new Error('Sandbox ready timeout'));
-            }, 10_000);
+            }, timeoutMs);
 
             const handler = event => {
                 LOGGER.log(
@@ -694,8 +748,7 @@ export class CdpHandler {
     async handleCdpAttach(tabId) {
         LOGGER.log('handleCdpAttach called, tabId:', tabId);
 
-        const targetTabId =
-            tabId ?? (await chrome.tabs.query({ active: true, currentWindow: true }))[0]?.id;
+        const targetTabId = tabId ?? (await queryActiveTabForAgent())?.id;
 
         if (!targetTabId) {
             LOGGER.log('handleCdpAttach: No active tab');
@@ -854,12 +907,7 @@ export class CdpHandler {
 
     async handleListTabsRequest(id) {
         try {
-            const tabs = (await chrome.tabs.query({ currentWindow: true })).map(tab => ({
-                id: tab.id,
-                title: tab.title,
-                url: tab.url,
-                active: tab.active,
-            }));
+            const tabs = (await queryTabsForAgent()).map(mapTabForSandbox);
 
             this.postToSandbox({ type: 'LIST_TABS_RESPONSE', id, success: true, tabs });
         } catch (error) {

--- a/packages/lwc/main/agent/cdpHandler/sandboxIframe.ts
+++ b/packages/lwc/main/agent/cdpHandler/sandboxIframe.ts
@@ -1,0 +1,21 @@
+export const SANDBOX_READY_TIMEOUT_MS = 10_000;
+export const SANDBOX_PING_TIMEOUT_MS = 2_000;
+export const IFRAME_LOAD_TIMEOUT_MS = 10_000;
+export const DEFAULT_EVAL_TIMEOUT_MS = 30_000;
+
+type SandboxIframeLike = {
+    contentWindow?: unknown;
+    isConnected?: boolean;
+} | null;
+
+/**
+ * True when the eval iframe is still attached and has a window we can postMessage to.
+ * A stale CdpHandler (side panel remount, failed init left in the map) otherwise
+ * swallows EVAL_REQUEST and the js command hangs until Execution timeout.
+ */
+export function isSandboxIframeAlive(iframe: SandboxIframeLike): boolean {
+    if (!iframe) return false;
+    if (!iframe.contentWindow) return false;
+    if (typeof iframe.isConnected === 'boolean' && !iframe.isConnected) return false;
+    return true;
+}

--- a/packages/lwc/main/agent/cdpHandler/tabQuery.ts
+++ b/packages/lwc/main/agent/cdpHandler/tabQuery.ts
@@ -1,0 +1,55 @@
+type AgentTab = {
+    id?: number;
+    title?: string;
+    url?: string;
+    active?: boolean;
+    windowId?: number;
+};
+
+type ChromeTabsApi = {
+    query: (queryInfo: Record<string, unknown>) => Promise<AgentTab[]>;
+};
+
+function getChromeTabsApi(): ChromeTabsApi | null {
+    if (typeof chrome === 'undefined' || !chrome.tabs?.query) return null;
+    return chrome.tabs as unknown as ChromeTabsApi;
+}
+
+/**
+ * List tabs the agent can inspect.
+ *
+ * Chrome side panels are not tabbed windows, so `currentWindow: true` often
+ * returns [] from this context. Prefer the last focused browser window, then
+ * fall back to every tab.
+ */
+export async function queryTabsForAgent(
+    tabsApi: ChromeTabsApi | null = getChromeTabsApi()
+): Promise<AgentTab[]> {
+    if (!tabsApi) return [];
+    const lastFocused = await tabsApi.query({ lastFocusedWindow: true });
+    if (lastFocused.length > 0) return lastFocused;
+    return tabsApi.query({});
+}
+
+/**
+ * Resolve the user's visible tab. Same lastFocusedWindow-first rule as
+ * `getCurrentTab()` elsewhere in the extension.
+ */
+export async function queryActiveTabForAgent(
+    tabsApi: ChromeTabsApi | null = getChromeTabsApi()
+): Promise<AgentTab | null> {
+    if (!tabsApi) return null;
+    const [tab] = await tabsApi.query({ active: true, lastFocusedWindow: true });
+    if (tab?.id != null) return tab;
+    const [fallback] = await tabsApi.query({ active: true });
+    return fallback ?? null;
+}
+
+export function mapTabForSandbox(tab: AgentTab) {
+    return {
+        id: tab.id,
+        title: tab.title,
+        url: tab.url,
+        active: !!tab.active,
+    };
+}

--- a/packages/lwc/main/agent/prompts/__tests__/prompts.test.ts
+++ b/packages/lwc/main/agent/prompts/__tests__/prompts.test.ts
@@ -74,3 +74,12 @@ test('browserAgentInstructions: reduced length stays within slim budget', () => 
     assert.ok(afterLength < beforeLength, `expected ${afterLength} to be < ${beforeLength}`);
     assert.ok(afterLength < 10000, `expected slimmed prompt < 10000 chars, got ${afterLength}`);
 });
+
+test('browserAgentInstructions: tells the agent how to inspect the current tab', () => {
+    assert.match(browserAgentInstructions, /listTabs\(\)/);
+    assert.match(browserAgentInstructions, /getCurrentTab\(\)/);
+    assert.match(browserAgentInstructions, /connectToPage/);
+    assert.match(browserAgentInstructions, /top-level `await`/);
+    assert.match(browserAgentInstructions, /js <<'EOF'/);
+    assert.doesNotMatch(browserAgentInstructions, /chrome_screenshot.*work normally/);
+});

--- a/packages/lwc/main/agent/tools/__tests__/constants.test.ts
+++ b/packages/lwc/main/agent/tools/__tests__/constants.test.ts
@@ -20,6 +20,13 @@ test('SHELL_TOOL_HELP: every entry is a non-empty string', () => {
         assert.ok(value.length > 0, `${key} must be non-empty`);
     }
     assert.ok(SHELL_TOOL_HELP.js.includes('js -e'), 'js help shows inline usage');
+    assert.ok(SHELL_TOOL_HELP.js.includes("js <<'EOF'"), 'js help shows heredoc usage');
+    assert.ok(
+        SHELL_TOOL_HELP.js.includes('top-level await'),
+        'js help tells agents to use top-level await'
+    );
+    assert.ok(SHELL_TOOL_HELP.js.includes('listTabs()'), 'js help lists listTabs');
+    assert.ok(SHELL_TOOL_HELP.js.includes('getCurrentTab()'), 'js help lists getCurrentTab');
     assert.ok(SHELL_TOOL_HELP.saveSkill.includes('save-skill'), 'saveSkill help mentions command');
 });
 

--- a/packages/lwc/main/agent/tools/constants.ts
+++ b/packages/lwc/main/agent/tools/constants.ts
@@ -1,14 +1,16 @@
 export const SHELL_TOOL_HELP = {
     js: `Execute JavaScript in the sandbox with Puppeteer browser automation and filesystem access.
-Use 'return' to get a result back.
+Use 'return' to get a result back. The runtime already wraps scripts in async — use top-level await.
+Do not wrap scripts in an extra (async () => { ... })(); that returns immediately with no output.
 
 Usage:
   js -e '<code>'              Inline code (like node -e)
   js <file>                    Run a script file from the filesystem
+  js <<'EOF'                   Multi-line code via stdin/heredoc
   js --timeout 30000 -e '...'  Custom timeout (default: 10000ms)
   js --help                    Show this help
 
-Available globals: connectToPage(tabId), getSnapshot(page), getElementByRef(page, ref), clearInput(handle),
+Available globals: listTabs(), getCurrentTab(), connectToPage(tabId?), getSnapshot(page), getElementByRef(page, ref), clearInput(handle),
 readFile(path), writeFile(path), listFiles(path), bash(command), logImage(base64), workspace.status(), etc.`,
     saveSkill: `Save a skill to the workspace.
 

--- a/packages/lwc/main/agent/tools/modules/__tests__/shellJs.test.ts
+++ b/packages/lwc/main/agent/tools/modules/__tests__/shellJs.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { loadJsCode, parseJsArgs } from '../jsCommand.ts';
+
+function mockCtx(overrides: { stdin?: string; files?: Record<string, string> } = {}) {
+    const files = overrides.files || {};
+    return {
+        cwd: '/workspace',
+        stdin: overrides.stdin,
+        fs: {
+            resolvePath: (_cwd: string, path: string) =>
+                path.startsWith('/') ? path : `/workspace/${path}`,
+            readFile: async (path: string) => {
+                const content = files[path];
+                if (content == null) throw new Error(`missing ${path}`);
+                return content;
+            },
+        },
+    };
+}
+
+test('loadJsCode: no args uses stdin (heredoc)', async () => {
+    const result = await loadJsCode([], mockCtx({ stdin: 'const x = 1;\nreturn x;' }));
+    assert.equal(result.error, null);
+    assert.equal(result.code, 'const x = 1;\nreturn x;');
+});
+
+test('loadJsCode: no args and empty stdin prints heredoc usage', async () => {
+    const result = await loadJsCode([], mockCtx({ stdin: '  ' }));
+    assert.equal(result.code, null);
+    assert.ok(result.error);
+    assert.equal(result.error.exitCode, 1);
+    assert.match(result.error.stderr, /js <<'EOF'/);
+});
+
+test('loadJsCode: -e runs inline code', async () => {
+    const result = await loadJsCode(['-e', 'return 1+2'], mockCtx());
+    assert.equal(result.error, null);
+    assert.equal(result.code, 'return 1+2');
+});
+
+test('loadJsCode: -e falls back to stdin when inline code is empty', async () => {
+    const result = await loadJsCode(['-e'], mockCtx({ stdin: 'return 9' }));
+    assert.equal(result.error, null);
+    assert.equal(result.code, 'return 9');
+});
+
+test('loadJsCode: file path reads the script', async () => {
+    const result = await loadJsCode(
+        ['/workspace/tmp/script.js'],
+        mockCtx({ files: { '/workspace/tmp/script.js': 'return 4;' } })
+    );
+    assert.equal(result.error, null);
+    assert.equal(result.code, 'return 4;');
+});
+
+test('parseJsArgs: --timeout is stripped from positional args', () => {
+    const parsed = parseJsArgs(['--timeout', '30000', '-e', 'return 1']);
+    assert.equal(parsed.error, null);
+    assert.equal(parsed.timeoutMs, 30000);
+    assert.deepEqual(parsed.argsWithoutFlags, ['-e', 'return 1']);
+});

--- a/packages/lwc/main/agent/tools/modules/jsCommand.ts
+++ b/packages/lwc/main/agent/tools/modules/jsCommand.ts
@@ -1,0 +1,100 @@
+export type JsCommandResult = {
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+};
+
+export type JsCodeLoadContext = {
+    cwd: string;
+    stdin?: string;
+    fs: {
+        resolvePath: (cwd: string, path: string) => string;
+        readFile: (path: string, encoding?: string) => Promise<string>;
+    };
+};
+
+export type JsArgsParseResult =
+    | { timeoutMs: number | undefined; argsWithoutFlags: string[]; error: null }
+    | { timeoutMs: undefined; argsWithoutFlags: []; error: JsCommandResult };
+
+export type JsCodeLoadResult =
+    | { code: string; error: null }
+    | { code: null; error: JsCommandResult };
+
+export function parseJsArgs(argv: string[]): JsArgsParseResult {
+    let timeoutMs: number | undefined;
+    const argsWithoutFlags: string[] = [];
+
+    for (let i = 0; i < argv.length; i++) {
+        if (argv[i] === '--timeout' && i + 1 < argv.length) {
+            timeoutMs = parseInt(argv[i + 1], 10);
+            if (Number.isNaN(timeoutMs)) {
+                return {
+                    timeoutMs: undefined,
+                    argsWithoutFlags: [],
+                    error: {
+                        stdout: '',
+                        stderr: 'Error: --timeout requires a numeric value\n',
+                        exitCode: 1,
+                    },
+                };
+            }
+            i += 1;
+            continue;
+        }
+        argsWithoutFlags.push(argv[i]);
+    }
+
+    return { timeoutMs, argsWithoutFlags, error: null };
+}
+
+export async function loadJsCode(
+    argsWithoutFlags: string[],
+    ctx: JsCodeLoadContext
+): Promise<JsCodeLoadResult> {
+    const inlineIndex = argsWithoutFlags.indexOf('-e');
+    if (inlineIndex !== -1) {
+        const inlineCode = argsWithoutFlags.slice(inlineIndex + 1).join(' ');
+        const code = inlineCode || ctx.stdin || '';
+        if (!code) {
+            return {
+                code: null,
+                error: { stdout: '', stderr: "Usage: js -e '<code>'\n", exitCode: 1 },
+            };
+        }
+        return { code, error: null };
+    }
+
+    const file = argsWithoutFlags[0];
+    if (!file) {
+        const stdinCode = ctx.stdin || '';
+        if (stdinCode.trim()) {
+            return { code: stdinCode, error: null };
+        }
+        return {
+            code: null,
+            error: {
+                stdout: '',
+                stderr:
+                    "Usage: js -e '<code>' or js <file> or js <<'EOF'\n" +
+                    'Run js --help for full documentation.\n',
+                exitCode: 1,
+            },
+        };
+    }
+
+    const resolvedPath = ctx.fs.resolvePath(ctx.cwd, file);
+    try {
+        const code = await ctx.fs.readFile(resolvedPath, 'utf-8');
+        return { code, error: null };
+    } catch {
+        return {
+            code: null,
+            error: {
+                stdout: '',
+                stderr: `Error: Cannot read file: ${resolvedPath}\n`,
+                exitCode: 1,
+            },
+        };
+    }
+}

--- a/packages/lwc/main/agent/tools/modules/shell.ts
+++ b/packages/lwc/main/agent/tools/modules/shell.ts
@@ -25,7 +25,7 @@ import { buildFrontDoorUrl, buildSalesforceNavigationPath } from 'shared/salesfo
 import { API as API_UTILS, compressImage } from 'shared/utils';
 import { z } from 'zod';
 
-import { SHELL_TOOL_HELP, SKILL_PATH_TEMPLATES, TOOL_OUTPUT_LIMITS } from '../constants';
+import { SHELL_TOOL_HELP, TOOL_OUTPUT_LIMITS } from '../constants';
 import {
     waitForLoaded,
     wrappedNavigate,
@@ -35,6 +35,7 @@ import {
 } from '../utils/utils';
 
 import { decodeExecStdout } from './execStdout';
+import { parseJsArgs, loadJsCode } from './jsCommand';
 import { saveSkillToFs } from './skillUtils';
 
 export type BashToolOptions = {
@@ -320,75 +321,6 @@ export function registerShellCommands({
 }) {
     if (opts.execInSandbox) {
         const execInSandbox = opts.execInSandbox;
-
-        const parseJsArgs = (argv: string[]) => {
-            let timeoutMs: number | undefined;
-            const argsWithoutFlags: string[] = [];
-
-            for (let i = 0; i < argv.length; i++) {
-                if (argv[i] === '--timeout' && i + 1 < argv.length) {
-                    timeoutMs = parseInt(argv[i + 1], 10);
-                    if (Number.isNaN(timeoutMs)) {
-                        return {
-                            timeoutMs: undefined,
-                            argsWithoutFlags: [],
-                            error: {
-                                stdout: '',
-                                stderr: 'Error: --timeout requires a numeric value\n',
-                                exitCode: 1,
-                            },
-                        };
-                    }
-                    i += 1;
-                    continue;
-                }
-                argsWithoutFlags.push(argv[i]);
-            }
-
-            return { timeoutMs, argsWithoutFlags, error: null };
-        };
-
-        const loadJsCode = async (argsWithoutFlags: string[], ctx: ShellCommandContext) => {
-            const inlineIndex = argsWithoutFlags.indexOf('-e');
-            if (inlineIndex !== -1) {
-                const inlineCode = argsWithoutFlags.slice(inlineIndex + 1).join(' ');
-                const code = inlineCode || ctx.stdin || '';
-                if (!code) {
-                    return {
-                        code: null,
-                        error: { stdout: '', stderr: "Usage: js -e '<code>'\n", exitCode: 1 },
-                    };
-                }
-                return { code, error: null };
-            }
-
-            const file = argsWithoutFlags[0];
-            if (!file) {
-                return {
-                    code: null,
-                    error: {
-                        stdout: '',
-                        stderr: "Usage: js -e '<code>' or js <file>\nRun js --help for full documentation.\n",
-                        exitCode: 1,
-                    },
-                };
-            }
-
-            const resolvedPath = ctx.fs.resolvePath(ctx.cwd, file);
-            try {
-                const code = await ctx.fs.readFile(resolvedPath, 'utf-8');
-                return { code, error: null };
-            } catch {
-                return {
-                    code: null,
-                    error: {
-                        stdout: '',
-                        stderr: `Error: Cannot read file: ${resolvedPath}\n`,
-                        exitCode: 1,
-                    },
-                };
-            }
-        };
 
         const jsCommand = createCommand('js', async (argv, ctx) => {
             if (argv.includes('--help') || argv.includes('-h')) {
@@ -1628,25 +1560,16 @@ export function createBashTools(shell, fs, opts: BashToolOptions = {}) {
                     };
                 }
 
-                const candidatePaths = SKILL_PATH_TEMPLATES.map(template =>
-                    template.replace('{name}', requestedName)
-                );
-
-                for (const skillPath of candidatePaths) {
-                    try {
-                        const content = await fs.readFile(skillPath, 'utf-8');
-                        const workingDirectory = skillPath.replace(/\/SKILL\.md$/, '');
-                        return {
-                            kind: 'load_skill_result',
-                            isError: false,
-                            skillName: requestedName,
-                            workingDirectory,
-                            content,
-                            text: `# Skill Loaded: ${requestedName}\nWorking Directory: ${workingDirectory}\n\n${content}`,
-                        };
-                    } catch (_) {
-                        // Try next candidate path.
-                    }
+                const skill = await fetchSkillByName(requestedName);
+                if (skill) {
+                    return {
+                        kind: 'load_skill_result',
+                        isError: false,
+                        skillName: skill.name,
+                        workingDirectory: skill.rootDir,
+                        content: skill.content,
+                        text: `# Skill Loaded: ${skill.name}\nWorking Directory: ${skill.rootDir}\n\n${skill.content}`,
+                    };
                 }
 
                 return {

--- a/packages/lwc/main/agent/utils/__tests__/environmentContext.test.ts
+++ b/packages/lwc/main/agent/utils/__tests__/environmentContext.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { buildRunningEnvironmentContext } from '../environmentContext.ts';
+
+test('side panel context: tells the agent how to inspect the current tab', () => {
+    const out = buildRunningEnvironmentContext({
+        isSidePanel: true,
+        loginStatus: 'Not connected to any Salesforce org.',
+        currentApplication: 'agent',
+        currentTab: {
+            id: 42,
+            title: 'Trailhead Quiz',
+            url: 'https://trailhead.salesforce.com/quiz',
+        },
+    });
+    assert.match(out, /Chrome Side Panel/);
+    assert.match(out, /id: 42/);
+    assert.match(out, /Trailhead Quiz/);
+    assert.match(out, /listTabs\(\)/);
+    assert.match(out, /connectToPage/);
+    assert.match(out, /getSnapshot/);
+    assert.match(out, /ARIA YAML/);
+    assert.match(out, /top-level `await`/);
+    assert.match(out, /There are \*\*no\*\* agent tools named `chrome_screenshot`/);
+    assert.doesNotMatch(out, /chrome_list_tabs.*work normally/);
+    assert.match(out, /Do \*\*not\*\* call `createTab\(\)`/);
+});
+
+test('side panel context: still explains how to inspect when tab id is missing', () => {
+    const out = buildRunningEnvironmentContext({
+        isSidePanel: true,
+        loginStatus: 'Not connected to any Salesforce org.',
+        currentApplication: null,
+        currentTab: null,
+    });
+    assert.match(out, /listTabs\(\)/);
+    assert.match(out, /active/);
+    assert.match(out, /There are \*\*no\*\* agent tools named `chrome_screenshot`/);
+});
+
+test('web app context: keeps toolkit UI guidance and omits side-panel tab recipe', () => {
+    const out = buildRunningEnvironmentContext({
+        isSidePanel: false,
+        loginStatus: 'Connected org: my-org',
+        currentApplication: 'soql',
+        currentTab: { id: 1, title: 'Unused', url: 'https://example.com' },
+    });
+    assert.match(out, /SF Toolkit Web App/);
+    assert.match(out, /Currently visible panel: soql/);
+    assert.doesNotMatch(out, /listTabs\(\)/);
+    assert.doesNotMatch(out, /chrome_screenshot/);
+});

--- a/packages/lwc/main/agent/utils/environmentContext.ts
+++ b/packages/lwc/main/agent/utils/environmentContext.ts
@@ -1,0 +1,90 @@
+export type EnvironmentTabInfo = {
+    id?: number | null;
+    title?: string | null;
+    url?: string | null;
+} | null;
+
+export type EnvironmentContextInput = {
+    isSidePanel: boolean;
+    loginStatus: string;
+    currentApplication: string | null;
+    currentTab?: EnvironmentTabInfo;
+};
+
+function formatCurrentTabBlock(currentTab?: EnvironmentTabInfo): string {
+    const tabId = currentTab?.id;
+    if (typeof tabId !== 'number') {
+        return `The user's visible browser tab was not resolved at prompt time. Call \`listTabs()\`, pick the \`active\` tab (or match by title/url), then \`connectToPage(tab.id)\`.`;
+    }
+    const title = currentTab?.title?.trim() || '(untitled)';
+    const url = currentTab?.url?.trim() || '(unknown url)';
+    return `User's visible browser tab (the page beside this side panel):
+- id: ${tabId}
+- title: ${title}
+- url: ${url}
+
+When the user refers to "this tab", "the current page", a quiz, or visible page content, inspect THAT tab:
+\`\`\`javascript
+const tabs = await listTabs();
+const tab = tabs.find(t => t.id === ${tabId}) || tabs.find(t => t.active) || tabs[0];
+const page = await connectToPage(tab.id);
+const snapshot = await getSnapshot(page);
+\`\`\`
+You may also call \`connectToPage()\` with no argument to attach to the active tab.
+
+Use top-level \`await\` as shown. Do **not** wrap this in an extra \`(async () => { ... })()\` — that returns immediately with empty output. \`getSnapshot(page)\` returns ARIA YAML (a string); \`console.log(snapshot)\` to inspect it.`;
+}
+
+export function buildRunningEnvironmentContext(input: EnvironmentContextInput): string {
+    const { isSidePanel, loginStatus, currentApplication, currentTab } = input;
+    const appLine = currentApplication ? `\nCurrently visible panel: ${currentApplication}` : '';
+
+    if (isSidePanel) {
+        return `
+
+## Environment Context
+
+**Running in: Chrome Side Panel**
+
+${loginStatus}${appLine}
+
+You are running inside the Chrome Side Panel, which is a narrow overlay beside the browser — the SF Toolkit LWC app is **not** the visible tab. This has important consequences for UI tools:
+
+**Avoid UI-navigation tools** unless the user explicitly asks to open the Toolkit app:
+- \`navigate_workbench_app\`, \`sf navigate\`, \`soql_query\` (with UI), \`apex_navigate\`, \`metadata_navigate\`, \`navigateToApiEditor\` — these dispatch to the store and will take effect once the user switches to the Toolkit tab, but they produce no immediate visible feedback.
+
+**Prefer background/incognito tools** — they work reliably from the side panel without touching the UI:
+- \`soql_query_incognito\` instead of \`soql_query\`
+- \`sf data query\` for SOQL
+- \`sf apex run --no-ui\` or \`apex_execute\` for Apex (\`--no-ui\` runs incognito and does not create/update Apex tabs)
+- For UI runs, reuse the last returned \`tabId\` via \`sf apex run --tab-id <tabId>\` to avoid creating a new tab each time
+- \`sf api request\` for REST API calls
+- \`sf metadata list-types / list-records / deploy / retrieve\` for metadata operations
+- \`metadata_list_types\`, \`metadata_list_records\`, \`metadata_get_record\` (all incognito)
+
+**Connecting to a new org** via \`connect_org\` or \`sf org connect\` will open the full Toolkit in a new browser tab.
+
+## Inspecting the current browser tab
+
+${formatCurrentTabBlock(currentTab)}
+
+There are **no** agent tools named \`chrome_screenshot\`, \`chrome_list_tabs\`, or \`chrome_open_tab\`. Use the sandboxed \`js\` command with \`listTabs()\`, \`connectToPage(tabId)\`, \`getSnapshot(page)\`, and \`logImage(...)\`.
+Do **not** call \`createTab()\` to inspect a page the user already has open.
+`;
+    }
+
+    return `
+
+## Environment Context
+
+**Running in: SF Toolkit Web App**
+
+${loginStatus}${appLine}
+
+You have full access to the toolkit UI. All navigation and display tools work normally:
+- Navigation tools (\`navigate_workbench_app\`, \`sf navigate\`, \`apex_navigate\`, etc.) update the visible UI in real time.
+- Tab management tools open and switch visible editor panels.
+- Use \`soql_query\` (not incognito) to show results in the SOQL editor for the user.
+- Use incognito variants (\`soql_query_incognito\`, \`sf data query\`) when you need data silently without navigating away.
+`;
+}

--- a/packages/lwc/main/agent/utils/utils.ts
+++ b/packages/lwc/main/agent/utils/utils.ts
@@ -1,4 +1,5 @@
 export * from './constants';
+export * from './environmentContext';
 export * from './errorMessage';
 export * from './generateTitle';
 export * from './models';

--- a/packages/lwc/main/component/skeleton/app/cache.ts
+++ b/packages/lwc/main/component/skeleton/app/cache.ts
@@ -10,10 +10,12 @@ import {
 } from 'shared/cacheManager';
 import {
     buildAvailableAgentModelOptions,
+    fetchApiKeyProviderModels,
     fetchLlmModelsEndpoint,
     fetchSubscriptionModels,
     getProviderForModel,
     normalizeModelSelection,
+    toNonEmptyProviderCatalogs,
 } from 'shared/llm';
 import LOGGER from 'shared/logger';
 import { isChromeExtension } from 'shared/utils';
@@ -97,8 +99,17 @@ async function refreshLlmCatalogInBackground(aiProvider, providerConfigs) {
         APPLICATION.reduxSlice.actions.updateSubscriptionModels({ models: subscriptionModels })
     );
 
+    const apiKeyCatalogs = toNonEmptyProviderCatalogs(
+        await fetchApiKeyProviderModels(providerConfigs)
+    );
+    if (Object.keys(apiKeyCatalogs).length > 0) {
+        store.dispatch(
+            APPLICATION.reduxSlice.actions.updateProviderCatalogs({ catalogs: apiKeyCatalogs })
+        );
+    }
+
     const availableModels = buildAvailableAgentModelOptions({
-        availableModelsByProvider: serverCatalogs,
+        availableModelsByProvider: { ...(serverCatalogs || {}), ...apiKeyCatalogs },
         subscriptionModelsByProvider: subscriptionModels,
         providerConfigs,
     });

--- a/packages/lwc/main/core/store/modules/__tests__/agent.test.ts
+++ b/packages/lwc/main/core/store/modules/__tests__/agent.test.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+function installStorage() {
+    const local: Record<string, string> = {};
+    const localStorage = {
+        getItem: (k: string) => (k in local ? local[k] : null),
+        setItem: (k: string, v: string) => {
+            local[k] = String(v);
+        },
+        removeItem: (k: string) => {
+            delete local[k];
+        },
+    };
+    const sessionStorage = {
+        getItem: () => null,
+        setItem: () => {},
+        removeItem: () => {},
+    };
+    (globalThis as any).window = { localStorage, sessionStorage };
+    (globalThis as any).localStorage = localStorage;
+    (globalThis as any).sessionStorage = sessionStorage;
+    return { local };
+}
+
+function removeStorage() {
+    delete (globalThis as any).localStorage;
+    delete (globalThis as any).sessionStorage;
+    delete (globalThis as any).window;
+}
+
+function readCachedConversationData(local: Record<string, string>) {
+    const raw = local.einstein_agent_conversation_data;
+    return raw ? JSON.parse(raw) : null;
+}
+
+async function flushPromises() {
+    await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+const HISTORY_MESSAGE = { role: 'user', content: 'hello from cache' };
+const LIVE_MESSAGE = { role: 'user', content: 'typed after load' };
+
+test('agent: initial state is not hydrated and has an empty default conversation', async () => {
+    installStorage();
+    try {
+        const { reduxSlice } = await import('../agent.ts');
+        const s = reduxSlice.reducer(undefined, { type: '@@INIT' } as any);
+        assert.equal(s.hasHydrated, false);
+        assert.equal(s.conversations.length, 1);
+        assert.equal(s.conversations[0].title, 'Conversation 1');
+        assert.deepEqual(s.conversations[0].streamHistory, []);
+        assert.deepEqual(s.messagesById, {});
+    } finally {
+        removeStorage();
+    }
+});
+
+test('agent: pre-hydrate save is a no-op and does not overwrite cached streamHistory', async () => {
+    const { local } = installStorage();
+    const cachedPayload = {
+        conversations: [
+            {
+                id: 'conv_cached',
+                title: 'Cached chat',
+                streamHistory: [HISTORY_MESSAGE],
+                compactionSummary: [],
+            },
+        ],
+        activeConversationId: 'conv_cached',
+        selectedModel: 'gpt-5-mini',
+        selectedReasoning: 'none',
+    };
+    local.einstein_agent_conversation_data = JSON.stringify(cachedPayload);
+    try {
+        const { reduxSlice } = await import('../agent.ts');
+        const r = reduxSlice.reducer;
+        let s = r(undefined, { type: '@@INIT' } as any);
+        s = r(s, reduxSlice.actions.setActiveConversationId({ id: 'default' }));
+        s = r(s, reduxSlice.actions.updateSelectedModel({ model: 'gpt-5-mini' }));
+        await flushPromises();
+        assert.equal(s.hasHydrated, false);
+        assert.deepEqual(readCachedConversationData(local), cachedPayload);
+    } finally {
+        removeStorage();
+    }
+});
+
+test('agent: post-hydrate save copies messagesById into streamHistory', async () => {
+    const { local } = installStorage();
+    try {
+        const { reduxSlice, loadCacheSettingsAsync } = await import('../agent.ts');
+        const r = reduxSlice.reducer;
+        let s = r(undefined, { type: '@@INIT' } as any);
+        s = r(s, {
+            type: loadCacheSettingsAsync.fulfilled.type,
+            payload: {
+                conversations: [
+                    {
+                        id: 'conv_1',
+                        title: 'Conversation 1',
+                        streamHistory: [HISTORY_MESSAGE],
+                        compactionSummary: [],
+                    },
+                ],
+                activeConversationId: 'conv_1',
+            },
+        });
+        assert.equal(s.hasHydrated, true);
+        assert.equal(s.messagesById.conv_1.length, 1);
+        assert.equal(s.messagesById.conv_1[0].content, HISTORY_MESSAGE.content);
+
+        s = r(
+            s,
+            reduxSlice.actions.addMessages({
+                id: 'conv_1',
+                messages: [LIVE_MESSAGE],
+            })
+        );
+        // Mid-run saves used to persist stale empty streamHistory. Switching
+        // conversations must now flush the live thread.
+        s = r(s, reduxSlice.actions.setActiveConversationId({ id: 'conv_1' }));
+        assert.equal(s.conversations[0].streamHistory.length, 2);
+        assert.equal(s.conversations[0].streamHistory[1].content, LIVE_MESSAGE.content);
+
+        await flushPromises();
+        const persisted = readCachedConversationData(local);
+        assert.equal(persisted.conversations[0].streamHistory.length, 2);
+        assert.equal(persisted.conversations[0].streamHistory[1].content, LIVE_MESSAGE.content);
+    } finally {
+        removeStorage();
+    }
+});
+
+test('agent: flushConversationCache is a no-op until hydrated', async () => {
+    const { local } = installStorage();
+    const cachedPayload = {
+        conversations: [
+            {
+                id: 'conv_cached',
+                title: 'Cached chat',
+                streamHistory: [HISTORY_MESSAGE],
+                compactionSummary: [],
+            },
+        ],
+        activeConversationId: 'conv_cached',
+    };
+    local.einstein_agent_conversation_data = JSON.stringify(cachedPayload);
+    try {
+        const { reduxSlice } = await import('../agent.ts');
+        const r = reduxSlice.reducer;
+        let s = r(undefined, { type: '@@INIT' } as any);
+        s = r(s, reduxSlice.actions.flushConversationCache());
+        await flushPromises();
+        assert.equal(s.hasHydrated, false);
+        assert.deepEqual(readCachedConversationData(local), cachedPayload);
+    } finally {
+        removeStorage();
+    }
+});

--- a/packages/lwc/main/core/store/modules/agent.ts
+++ b/packages/lwc/main/core/store/modules/agent.ts
@@ -1,10 +1,10 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
-import {
-    type ProcessMessageStepStart,
-    type ProcessMessageToolStart,
-    type ProcessMessageError,
-    type ProcessMessageStepFinish,
-    type ProcessMessageToolFinish,
+import type {
+    ProcessMessageStepStart,
+    ProcessMessageToolStart,
+    ProcessMessageError,
+    ProcessMessageStepFinish,
+    ProcessMessageToolFinish,
 } from 'agent/Agent';
 import {
     Constants,
@@ -45,6 +45,7 @@ export interface AgentState {
     messagesById: Record<string, ModelMessage[]>;
     debugMode: boolean;
     lastRunDebugByConversationId: Record<string, unknown>;
+    hasHydrated: boolean;
 }
 
 const DEFAULT_CONVERSATION = {
@@ -207,13 +208,30 @@ const initialState = {
     messagesById: {},
     debugMode: false,
     lastRunDebugByConversationId: {},
+    hasHydrated: false,
 };
 
-function saveCacheSettings(state) {
+function conversationsWithSyncedStreamHistory(state: AgentState): Conversation[] {
+    const messagesById = state.messagesById || {};
+    return (state.conversations || []).map(conversation => {
+        const live = messagesById[conversation.id];
+        if (!Array.isArray(live)) return conversation;
+        return {
+            ...conversation,
+            streamHistory: sanitizeMessagesForCache(live),
+        };
+    });
+}
+
+function saveCacheSettings(state: AgentState) {
     // Persist only cache-relevant fields; avoid serializing the full redux slice,
     // which may include non-serializable debug/runtime data.
     // Saves are fired immediately (not queued) so that writes reach chrome.storage
     // before the extension popup/panel is closed.
+    // Skip until the first cache load finishes so the empty initial state cannot
+    // overwrite persisted conversation history.
+    if (!state.hasHydrated) return;
+    state.conversations = conversationsWithSyncedStreamHistory(state);
     const payload = buildConversationDataFromState(state);
     saveSingleExtensionConfigToCache(CACHE_CONFIG.EINSTEIN_AGENT_CONVERSATION_DATA.key, payload)
         .then(() => {
@@ -483,6 +501,9 @@ const agentSlice = createSlice({
                 state.lastRunDebugByConversationId[id] = data;
             }
         },
+        flushConversationCache: state => {
+            saveCacheSettings(state);
+        },
     },
     extraReducers: builder => {
         builder
@@ -492,15 +513,18 @@ const agentSlice = createSlice({
                     loadCacheSettings(cachedConfig, state);
                 }
                 hydrateMessagesFromConversations(state);
+                state.hasHydrated = true;
             })
             .addCase(loadConversationsFromCache.fulfilled, (state, action) => {
-                if (!isNotUndefinedOrNull(action.payload)) return;
-                const normalized = normalizeAgentConversationData(action.payload);
-                state.conversations = normalized.conversations;
-                state.activeConversationId = normalized.activeConversationId;
-                state.selectedModel = normalized.selectedModel;
-                state.selectedReasoning = normalized.selectedReasoning;
-                hydrateMessagesFromConversations(state);
+                if (isNotUndefinedOrNull(action.payload)) {
+                    const normalized = normalizeAgentConversationData(action.payload);
+                    state.conversations = normalized.conversations;
+                    state.activeConversationId = normalized.activeConversationId;
+                    state.selectedModel = normalized.selectedModel;
+                    state.selectedReasoning = normalized.selectedReasoning;
+                    hydrateMessagesFromConversations(state);
+                }
+                state.hasHydrated = true;
             });
     },
 });
@@ -536,8 +560,11 @@ export const saveConversationsToCache = createAsyncThunk(
     'agent/saveConversationsToCache',
     async (_, { getState }) => {
         const state = getState();
+        if (!state.agent?.hasHydrated) {
+            return { count: 0 };
+        }
         const payload = normalizeAgentConversationData({
-            conversations: state.agent?.conversations,
+            conversations: conversationsWithSyncedStreamHistory(state.agent),
             activeConversationId: state.agent?.activeConversationId,
             selectedModel: state.agent?.selectedModel,
             selectedReasoning: state.agent?.selectedReasoning,

--- a/packages/lwc/shared/modules/cacheManager/__tests__/interfaces.test.ts
+++ b/packages/lwc/shared/modules/cacheManager/__tests__/interfaces.test.ts
@@ -29,6 +29,7 @@ const sessionStorage = new MemStorage();
 // callback-based in the real Chrome API.
 const chromeBags = { local: new Map<string, unknown>(), sync: new Map<string, unknown>() };
 (globalThis as any).chrome = {
+    runtime: {},
     storage: {
         local: {
             get(keys: string[], cb: (r: Record<string, unknown>) => void) {
@@ -144,4 +145,24 @@ test('chromeStore: sync variant targets chrome.storage.sync', async () => {
 
 test('chromeStore: rejects invalid variant', () => {
     assert.throws(() => chromeStore('bogus' as any), /Invalid variant/);
+});
+
+test('chromeStore: setItem rejects when chrome.runtime.lastError is set', async () => {
+    chromeBags.local.clear();
+    const store = chromeStore('local');
+    const originalSet = (globalThis as any).chrome.storage.local.set;
+    (globalThis as any).chrome.storage.local.set = (
+        _items: Record<string, unknown>,
+        cb: () => void
+    ) => {
+        (globalThis as any).chrome.runtime.lastError = { message: 'QUOTA_BYTES quota exceeded' };
+        cb();
+        (globalThis as any).chrome.runtime.lastError = undefined;
+    };
+    try {
+        await assert.rejects(() => store.setItem('ck', 'nope'), /QUOTA_BYTES quota exceeded/);
+        assert.equal(chromeBags.local.has('ck'), false);
+    } finally {
+        (globalThis as any).chrome.storage.local.set = originalSet;
+    }
 });

--- a/packages/lwc/shared/modules/cacheManager/interfaces.ts
+++ b/packages/lwc/shared/modules/cacheManager/interfaces.ts
@@ -43,6 +43,15 @@ const chromeStore = (variant: 'local' | 'sync' = 'local'): StorageStore => {
             // Custom implementation here...
             return new Promise((resolve, reject) => {
                 chrome.storage[variant].set({ [key]: value }, function () {
+                    const lastError = chrome.runtime?.lastError;
+                    if (lastError) {
+                        const message =
+                            typeof lastError.message === 'string' && lastError.message
+                                ? lastError.message
+                                : 'chrome.storage set failed';
+                        reject(new Error(message));
+                        return;
+                    }
                     if (callback) {
                         callback();
                     }

--- a/packages/lwc/shared/modules/llm/__tests__/constants.test.ts
+++ b/packages/lwc/shared/modules/llm/__tests__/constants.test.ts
@@ -15,6 +15,7 @@ import {
     WORKBENCH_MODEL_OPTIONS,
     GROK_MODEL_OPTIONS,
     PROVIDER_MODEL_OPTIONS,
+    API_KEY_LIVE_PROVIDERS,
 } from '../constants';
 
 test('LLM_PROVIDERS: includes the six known provider ids, no duplicates', () => {
@@ -135,4 +136,16 @@ test('model options: maxOutputTokens is a positive integer when set', () => {
             }
         }
     }
+});
+
+test('API_KEY_LIVE_PROVIDERS: every live-fetch provider is a known LLM provider except workbench', () => {
+    assert.ok(API_KEY_LIVE_PROVIDERS.includes('openai'));
+    assert.ok(API_KEY_LIVE_PROVIDERS.includes('anthropic'));
+    assert.ok(API_KEY_LIVE_PROVIDERS.includes('gemini'));
+    assert.ok(API_KEY_LIVE_PROVIDERS.includes('mistral'));
+    assert.ok(API_KEY_LIVE_PROVIDERS.includes('grok'));
+    assert.equal(
+        API_KEY_LIVE_PROVIDERS.includes('workbench' as (typeof API_KEY_LIVE_PROVIDERS)[number]),
+        false
+    );
 });

--- a/packages/lwc/shared/modules/llm/__tests__/llm.test.ts
+++ b/packages/lwc/shared/modules/llm/__tests__/llm.test.ts
@@ -17,9 +17,13 @@ import {
     getMaxOutputTokensForModel,
     getProviderForModel,
     buildAvailableAgentModelOptions,
+    inferProviderFromModelId,
     fetchCodexModels,
     fetchXaiModels,
     fetchSubscriptionModels,
+    fetchApiKeyProviderModels,
+    refineLiveModelOptions,
+    toNonEmptyProviderCatalogs,
     resolveCodexClientVersion,
     CODEX_MODELS_CLIENT_VERSION,
     hasUsableProviderCredentials,
@@ -798,4 +802,199 @@ test('buildAvailableAgentModelOptions: accepts { models } catalog shape', () => 
     });
     assert.equal(options.length, 1);
     assert.equal(options[0].value, 'wrapped');
+});
+
+test('refineLiveModelOptions: drops non-chat ids and dated pins when an alias exists', () => {
+    const refined = refineLiveModelOptions(
+        [
+            { label: 'gpt-5.4', value: 'gpt-5.4', provider: 'openai' },
+            { label: 'gpt-5.4-20260305', value: 'gpt-5.4-20260305', provider: 'openai' },
+            { label: 'whisper-1', value: 'whisper-1', provider: 'openai' },
+            {
+                label: 'text-embedding-3-large',
+                value: 'text-embedding-3-large',
+                provider: 'openai',
+            },
+            { label: 'gpt-5-mini', value: 'gpt-5-mini', provider: 'openai' },
+        ],
+        'openai'
+    );
+    assert.deepEqual(
+        refined.map(model => model.value),
+        ['gpt-5.4', 'gpt-5-mini']
+    );
+    const mini = refined.find(model => model.value === 'gpt-5-mini');
+    assert.equal(mini?.maxOutputTokens, 16000);
+    assert.equal(mini?.label, 'gpt-5-mini');
+});
+
+test('refineLiveModelOptions: keeps a dated pin when no alias is present', () => {
+    const refined = refineLiveModelOptions(
+        [{ label: 'gpt-5.4-20260305', value: 'gpt-5.4-20260305', provider: 'openai' }],
+        'openai'
+    );
+    assert.deepEqual(
+        refined.map(model => model.value),
+        ['gpt-5.4-20260305']
+    );
+    assert.equal(refined[0].maxOutputTokens, 16000);
+});
+
+test('inferProviderFromModelId: maps common gateway ids to a provider family', () => {
+    assert.equal(inferProviderFromModelId('claude-haiku-4-5-20251001'), 'anthropic');
+    assert.equal(inferProviderFromModelId('us.anthropic.claude-sonnet-4-6'), 'anthropic');
+    assert.equal(inferProviderFromModelId('gemini-3-flash-preview'), 'gemini');
+    assert.equal(inferProviderFromModelId('grok-4.6'), 'grok');
+    assert.equal(inferProviderFromModelId('mistral-large-2512'), 'mistral');
+    assert.equal(inferProviderFromModelId('gpt-5.6-sol'), 'openai');
+    assert.equal(inferProviderFromModelId('gpt-5.5-bedrock'), 'openai');
+    assert.equal(inferProviderFromModelId('custom-proxy-slug'), null);
+});
+
+test('refineLiveModelOptions: mixed gateway dump keeps only the requesting provider', () => {
+    const dump = [
+        { label: 'gpt-5.6-sol', value: 'gpt-5.6-sol', provider: 'openai' as const },
+        {
+            label: 'claude-haiku-4-5-20251001',
+            value: 'claude-haiku-4-5-20251001',
+            provider: 'openai' as const,
+        },
+        { label: 'gemini-2.0-flash', value: 'gemini-2.0-flash', provider: 'openai' as const },
+        { label: 'grok-4.6', value: 'grok-4.6', provider: 'openai' as const },
+        { label: 'my-gateway-custom', value: 'my-gateway-custom', provider: 'openai' as const },
+    ];
+    assert.deepEqual(
+        refineLiveModelOptions(dump, 'openai').map(model => model.value),
+        ['gpt-5.6-sol', 'my-gateway-custom']
+    );
+    assert.deepEqual(
+        refineLiveModelOptions(dump, 'anthropic').map(model => model.value),
+        ['claude-haiku-4-5-20251001', 'my-gateway-custom']
+    );
+});
+
+test('toNonEmptyProviderCatalogs: omits empty providers', () => {
+    const catalogs = toNonEmptyProviderCatalogs({
+        openai: [{ label: 'live', value: 'live', provider: 'openai' }],
+        anthropic: [],
+    });
+    assert.equal(catalogs.openai?.models[0].value, 'live');
+    assert.equal(catalogs.openai?.status, 'ok');
+    assert.equal(catalogs.anthropic, undefined);
+});
+
+function jsonResponse(body: unknown, ok = true): Response {
+    return {
+        ok,
+        status: ok ? 200 : 500,
+        json: async () => body,
+    } as Response;
+}
+
+test('fetchApiKeyProviderModels: maps OpenAI {data:[{id}]} and skips OAuth / workbench', async () => {
+    const configs = createDefaultProviderConfigMap();
+    configs.openai = { apiKey: 'sk-openai', baseUrl: DEFAULT_PROVIDER_BASE_URLS.openai };
+    configs.anthropic = {
+        apiKey: 'sk-ant',
+        baseUrl: DEFAULT_PROVIDER_BASE_URLS.anthropic,
+        authMode: 'oauth',
+        oauth: { access: 'tok', refresh: 'r', expires: 1 },
+    };
+    configs.workbench = { apiKey: 'free', baseUrl: DEFAULT_PROVIDER_BASE_URLS.workbench };
+    const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+    const mockFetch = (async (url: string | URL, options?: RequestInit) => {
+        calls.push({
+            url: String(url),
+            headers: (options?.headers ?? {}) as Record<string, string>,
+        });
+        return jsonResponse({
+            data: [{ id: 'gpt-5.4' }, { id: 'whisper-1' }, { id: 'gpt-5.4-20260305' }],
+        });
+    }) as unknown as typeof fetch;
+
+    const result = await fetchApiKeyProviderModels(configs, mockFetch);
+    assert.deepEqual(
+        result.openai?.map(model => model.value),
+        ['gpt-5.4']
+    );
+    assert.equal(result.anthropic, undefined);
+    assert.equal(result.workbench, undefined);
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].url, /api\.openai\.com\/v1\/models$/);
+    assert.equal(calls[0].headers.Authorization, 'Bearer sk-openai');
+});
+
+test('fetchApiKeyProviderModels: Anthropic uses x-api-key and display_name', async () => {
+    const configs = createDefaultProviderConfigMap();
+    configs.anthropic = { apiKey: 'sk-ant', baseUrl: DEFAULT_PROVIDER_BASE_URLS.anthropic };
+    const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+    const mockFetch = (async (url: string | URL, options?: RequestInit) => {
+        calls.push({
+            url: String(url),
+            headers: (options?.headers ?? {}) as Record<string, string>,
+        });
+        return jsonResponse({
+            data: [{ id: 'claude-sonnet-4-6', display_name: 'Claude Sonnet 4.6' }],
+        });
+    }) as unknown as typeof fetch;
+
+    const result = await fetchApiKeyProviderModels(configs, mockFetch);
+    assert.equal(result.anthropic?.[0].value, 'claude-sonnet-4-6');
+    assert.equal(result.anthropic?.[0].label, 'claude-sonnet-4-6');
+    assert.match(calls[0].url, /api\.anthropic\.com\/v1\/models$/);
+    assert.equal(calls[0].headers['x-api-key'], 'sk-ant');
+    assert.equal(calls[0].headers['anthropic-version'], '2023-06-01');
+});
+
+test('fetchApiKeyProviderModels: Gemini native list strips models/ and generateContent-only', async () => {
+    const configs = createDefaultProviderConfigMap();
+    configs.gemini = { apiKey: 'gem-key', baseUrl: DEFAULT_PROVIDER_BASE_URLS.gemini };
+    const calls: string[] = [];
+    const mockFetch = (async (url: string | URL) => {
+        calls.push(String(url));
+        return jsonResponse({
+            models: [
+                {
+                    name: 'models/gemini-3-flash-preview',
+                    displayName: 'Gemini 3 Flash',
+                    supportedGenerationMethods: ['generateContent'],
+                },
+                {
+                    name: 'models/embedding-001',
+                    supportedGenerationMethods: ['embedContent'],
+                },
+            ],
+        });
+    }) as unknown as typeof fetch;
+
+    const result = await fetchApiKeyProviderModels(configs, mockFetch);
+    assert.deepEqual(
+        result.gemini?.map(model => model.value),
+        ['gemini-3-flash-preview']
+    );
+    assert.match(calls[0], /generativelanguage\.googleapis\.com\/v1beta\/models\?key=gem-key$/);
+});
+
+test('fetchApiKeyProviderModels: Grok API-key uses /language-models', async () => {
+    const configs = createDefaultProviderConfigMap();
+    configs.grok = { apiKey: 'xai-key', baseUrl: DEFAULT_PROVIDER_BASE_URLS.grok };
+    const calls: string[] = [];
+    const mockFetch = (async (url: string | URL) => {
+        calls.push(String(url));
+        return jsonResponse({ models: [{ id: 'grok-4-1-fast-reasoning' }] });
+    }) as unknown as typeof fetch;
+
+    const result = await fetchApiKeyProviderModels(configs, mockFetch);
+    assert.equal(result.grok?.[0].value, 'grok-4-1-fast-reasoning');
+    assert.match(calls[0], /api\.x\.ai\/v1\/language-models$/);
+});
+
+test('fetchApiKeyProviderModels: failed fetch is omitted so the static seed remains', async () => {
+    const configs = createDefaultProviderConfigMap();
+    configs.mistral = { apiKey: 'm-key', baseUrl: DEFAULT_PROVIDER_BASE_URLS.mistral };
+    const mockFetch = (async () => jsonResponse({}, false)) as unknown as typeof fetch;
+    const result = await fetchApiKeyProviderModels(configs, mockFetch);
+    assert.deepEqual(result, {});
+    const fallback = buildAvailableAgentModelOptions({ providerConfigs: configs });
+    assert.ok(fallback.some(model => model.provider === 'mistral'));
 });

--- a/packages/lwc/shared/modules/llm/constants.ts
+++ b/packages/lwc/shared/modules/llm/constants.ts
@@ -98,6 +98,28 @@ export const CODEX_WHAM_BASE_URL = 'https://chatgpt.com/backend-api/wham';
  *  current Codex CLI version. Isolated here so it's a one-line bump when OpenAI moves forward. */
 export const CODEX_MODELS_CLIENT_VERSION = '0.137.0';
 
+/** Anthropic Models API required header. */
+export const ANTHROPIC_API_VERSION = '2023-06-01';
+
+/** Fallback max output tokens for live-catalog ids that are not in the static overlay. */
+export const LIVE_MODEL_MAX_OUTPUT_TOKENS = 16000;
+
+/** Drop non-chat entries from raw `/models` dumps (whisper, embeddings, image, …). */
+export const NON_CHAT_MODEL_PATTERN =
+    /embedding|whisper|tts|dall-e|image|moderation|realtime|transcribe|computer-use/i;
+
+/** Dated pin suffix (`gpt-5.4-20260305`). Dropped when a shorter alias is in the same list. */
+export const DATED_MODEL_SUFFIX_PATTERN = /-\d{8}$/;
+
+/** Providers whose native `/models` (or equivalent) we live-fetch with an API key. */
+export const API_KEY_LIVE_PROVIDERS = [
+    'openai',
+    'anthropic',
+    'gemini',
+    'mistral',
+    'grok',
+] as const satisfies readonly LlmProvider[];
+
 export const INTERNAL_PROVIDER_BASE_URLS = {
     openai: 'https://eng-ai-model-gateway.sfproxy.devx-preprod.aws-esvc1-useast2.aws.sfdc.cl/v1',
     anthropic:

--- a/packages/lwc/shared/modules/llm/llm.ts
+++ b/packages/lwc/shared/modules/llm/llm.ts
@@ -1,18 +1,23 @@
 import { isRecord } from 'shared/utils';
 
 import {
+    ANTHROPIC_API_VERSION,
+    API_KEY_LIVE_PROVIDERS,
     CODEX_MODELS_CLIENT_VERSION,
     CODEX_WHAM_BASE_URL,
+    DATED_MODEL_SUFFIX_PATTERN,
     DEFAULT_LLM_PROVIDER,
     DEFAULT_PROVIDER_BASE_URLS,
     INTERNAL_MODEL_OPTIONS,
+    LIVE_MODEL_MAX_OUTPUT_TOKENS,
     LLM_PROVIDERS,
     LLM_PROVIDER_OPTIONS,
-    OPENAI_MODEL_OPTIONS,
+    NON_CHAT_MODEL_PATTERN,
     PROVIDER_MODEL_OPTIONS,
     type LlmModelOption,
-    type LlmProvider,
     type LlmModelsEndpointResponse,
+    type LlmProvider,
+    type LlmProviderCatalog,
     type LlmProviderConfig,
     type LlmProviderConfigMap,
     type OAuthCredentials,
@@ -261,6 +266,33 @@ export function getProviderForModel(
     return aliasMatch?.provider || DEFAULT_LLM_PROVIDER;
 }
 
+/** Guess which picker bucket a raw model id belongs to. Mixed OpenAI-compatible gateways
+ *  (Salesforce eng-ai-model-gateway, LiteLLM) return Claude/Gemini/Grok ids from `/v1/models`;
+ *  those must not be tagged as the requesting provider. Returns null when the id is unknown
+ *  so a custom/proxy slug can still appear in the catalog that listed it. */
+export function inferProviderFromModelId(modelId: unknown): LlmProvider | null {
+    const id = normalizeString(modelId).toLowerCase();
+    if (!id) return null;
+    if (id.includes('claude') || id.includes('anthropic')) return 'anthropic';
+    if (id.includes('gemini')) return 'gemini';
+    if (id.includes('grok')) return 'grok';
+    if (/(^|[^a-z])(mistral|codestral|pixtral|ministral|devstral|magistral)/.test(id)) {
+        return 'mistral';
+    }
+    if (
+        id.startsWith('gpt-') ||
+        id.startsWith('chatgpt') ||
+        id.startsWith('openai') ||
+        id.startsWith('ft:') ||
+        id.includes('davinci') ||
+        id.includes('babbage') ||
+        /(?:^|[^a-z])(o1|o3|o4)(?:-|$)/.test(id)
+    ) {
+        return 'openai';
+    }
+    return null;
+}
+
 export function buildAvailableAgentModelOptions({
     availableModelsByProvider,
     subscriptionModelsByProvider,
@@ -374,7 +406,19 @@ export async function resolveCodexClientVersion(fetchImpl: typeof fetch = fetch)
     return CODEX_MODELS_CLIENT_VERSION;
 }
 
-const SUBSCRIPTION_MODEL_MAX_OUTPUT_TOKENS = 16000;
+function toCatalogBaseUrl(baseUrl: string) {
+    return normalizeString(baseUrl).replace(/\/+$/, '');
+}
+
+function entryDisplayLabel(entry: Record<string, unknown>, fallbackId: string) {
+    if (typeof entry.display_name === 'string' && entry.display_name.trim()) {
+        return entry.display_name.trim();
+    }
+    if (typeof entry.displayName === 'string' && entry.displayName.trim()) {
+        return entry.displayName.trim();
+    }
+    return fallbackId;
+}
 
 /** Parse an OpenAI-compatible model-listing response into picker options. Handles every list
  *  shape the subscription backends return: `{ data: [{ id }] }` (OpenAI / xAI `/v1/models`),
@@ -400,14 +444,101 @@ function parseModelCatalogResponse(data: unknown, provider: LlmProvider): LlmMod
         if (id && !seen.has(id)) {
             seen.add(id);
             options.push({
-                label: id,
+                label: entryDisplayLabel(entry, id),
                 value: id,
                 provider,
-                maxOutputTokens: SUBSCRIPTION_MODEL_MAX_OUTPUT_TOKENS,
+                maxOutputTokens: LIVE_MODEL_MAX_OUTPUT_TOKENS,
             });
         }
     }
     return options;
+}
+
+function parseGeminiModelsResponse(data: unknown, provider: LlmProvider): LlmModelOption[] {
+    if (!isRecord(data) || !Array.isArray(data.models)) return [];
+    const options: LlmModelOption[] = [];
+    const seen = new Set<string>();
+    for (const entry of data.models) {
+        if (!isRecord(entry)) continue;
+        const methods = Array.isArray(entry.supportedGenerationMethods)
+            ? entry.supportedGenerationMethods
+            : [];
+        if (methods.length > 0 && !methods.includes('generateContent')) {
+            continue;
+        }
+        const rawName =
+            typeof entry.name === 'string'
+                ? entry.name
+                : typeof entry.id === 'string'
+                  ? entry.id
+                  : '';
+        const id = rawName.replace(/^models\//, '').trim();
+        if (!id || seen.has(id)) continue;
+        seen.add(id);
+        const maxOutputTokens =
+            typeof entry.outputTokenLimit === 'number' && Number.isFinite(entry.outputTokenLimit)
+                ? entry.outputTokenLimit
+                : LIVE_MODEL_MAX_OUTPUT_TOKENS;
+        options.push({
+            label: entryDisplayLabel(entry, id),
+            value: id,
+            provider,
+            maxOutputTokens,
+        });
+    }
+    return options;
+}
+
+function dropDatedPinsWhenAliasExists(models: LlmModelOption[]): LlmModelOption[] {
+    const ids = new Set(models.map(model => model.value));
+    return models.filter(model => {
+        if (!DATED_MODEL_SUFFIX_PATTERN.test(model.value)) return true;
+        const alias = model.value.replace(DATED_MODEL_SUFFIX_PATTERN, '');
+        return !ids.has(alias);
+    });
+}
+
+function overlayKnownModelMetadata(
+    models: LlmModelOption[],
+    provider: LlmProvider
+): LlmModelOption[] {
+    const known = [...getProviderModelOptions(provider), ...getInternalModelsForProvider(provider)];
+    const byValue = new Map(known.map(model => [model.value, model]));
+    return models.map(model => {
+        const match = byValue.get(model.value);
+        if (!match) {
+            return {
+                ...model,
+                maxOutputTokens: model.maxOutputTokens ?? LIVE_MODEL_MAX_OUTPUT_TOKENS,
+            };
+        }
+        return {
+            ...model,
+            label: match.label || model.label,
+            maxOutputTokens:
+                match.maxOutputTokens ?? model.maxOutputTokens ?? LIVE_MODEL_MAX_OUTPUT_TOKENS,
+        };
+    });
+}
+
+/** Drop non-chat / other-provider / dated-pin noise and overlay static label + maxOutputTokens. */
+export function refineLiveModelOptions(
+    models: LlmModelOption[],
+    provider: LlmProvider
+): LlmModelOption[] {
+    const chatModels = models.filter(model => {
+        if (NON_CHAT_MODEL_PATTERN.test(model.value)) return false;
+        const inferred = inferProviderFromModelId(model.value);
+        return inferred === null || inferred === provider;
+    });
+    return overlayKnownModelMetadata(dropDatedPinsWhenAliasExists(chatModels), provider);
+}
+
+function resolveGeminiNativeModelsUrl(baseUrl: string): string {
+    const root = toCatalogBaseUrl(baseUrl) || DEFAULT_PROVIDER_BASE_URLS.gemini;
+    if (root.endsWith('/v1beta')) return `${root}/models`;
+    if (root.includes('generativelanguage.googleapis.com')) return `${root}/v1beta/models`;
+    return `${root}/models`;
 }
 
 /** Fetch + parse a provider's model catalog from an OpenAI-compatible `/models`-style endpoint.
@@ -519,6 +650,123 @@ export async function fetchSubscriptionModels(
     ]);
 
     return { openai, grok };
+}
+
+function usesOpenAiCompatibleCatalog(provider: LlmProvider, baseUrl: string) {
+    return (
+        provider === 'openai' ||
+        provider === 'mistral' ||
+        isOpenAiCompatibleGateway(provider, baseUrl)
+    );
+}
+
+async function fetchJsonCatalog(
+    url: string,
+    headers: Record<string, string>,
+    fetchImpl: typeof fetch
+): Promise<unknown> {
+    const response = await fetchImpl(url, { headers });
+    if (!response.ok) {
+        throw new Error(`Model catalog request to ${url} failed with status ${response.status}.`);
+    }
+    return response.json();
+}
+
+async function fetchOneApiKeyProvider(
+    provider: (typeof API_KEY_LIVE_PROVIDERS)[number],
+    config: LlmProviderConfig,
+    fetchImpl: typeof fetch
+): Promise<LlmModelOption[]> {
+    if (!config.apiKey || config.authMode === 'oauth') return [];
+    const root = toCatalogBaseUrl(config.baseUrl) || DEFAULT_PROVIDER_BASE_URLS[provider];
+    const openAiCompatible = usesOpenAiCompatibleCatalog(provider, config.baseUrl);
+
+    try {
+        if (provider === 'gemini' && !openAiCompatible) {
+            const url = `${resolveGeminiNativeModelsUrl(config.baseUrl)}?key=${encodeURIComponent(config.apiKey)}`;
+            const data = await fetchJsonCatalog(url, { Accept: 'application/json' }, fetchImpl);
+            return refineLiveModelOptions(parseGeminiModelsResponse(data, provider), provider);
+        }
+        if (provider === 'anthropic' && !openAiCompatible) {
+            const data = await fetchJsonCatalog(
+                `${root}/models`,
+                {
+                    Accept: 'application/json',
+                    'x-api-key': config.apiKey,
+                    'anthropic-version': ANTHROPIC_API_VERSION,
+                },
+                fetchImpl
+            );
+            return refineLiveModelOptions(parseModelCatalogResponse(data, provider), provider);
+        }
+        if (provider === 'grok' && !openAiCompatible) {
+            const models = await fetchOAuthModelCatalog({
+                url: `${root}/language-models`,
+                bearer: config.apiKey,
+                provider,
+                fetchImpl,
+            });
+            return refineLiveModelOptions(models, provider);
+        }
+        const data = await fetchJsonCatalog(
+            `${root}/models`,
+            {
+                Authorization: `Bearer ${config.apiKey}`,
+                Accept: 'application/json',
+            },
+            fetchImpl
+        );
+        let models = parseModelCatalogResponse(data, provider);
+        if (provider === 'gemini' && models.length === 0) {
+            models = parseGeminiModelsResponse(data, provider);
+        }
+        return refineLiveModelOptions(models, provider);
+    } catch {
+        return [];
+    }
+}
+
+/** Fetch live `/models` catalogs for API-key providers (not Codex/xAI OAuth, not workbench).
+ *  Each provider degrades to `[]` on failure; empty results are omitted so callers can leave an
+ *  existing catalog untouched. Never throws. */
+export async function fetchApiKeyProviderModels(
+    providerConfigs: LlmProviderConfigMap,
+    fetchImpl: typeof fetch = fetch
+): Promise<Partial<Record<LlmProvider, LlmModelOption[]>>> {
+    const configs = normalizeProviderConfigMap(providerConfigs);
+    const entries = await Promise.all(
+        API_KEY_LIVE_PROVIDERS.map(async provider => {
+            const models = await fetchOneApiKeyProvider(provider, configs[provider], fetchImpl);
+            return [provider, models] as const;
+        })
+    );
+    const result: Partial<Record<LlmProvider, LlmModelOption[]>> = {};
+    for (const [provider, models] of entries) {
+        if (models.length > 0) {
+            result[provider] = models;
+        }
+    }
+    return result;
+}
+
+/** Catalog dispatch payload for live API-key fetches. Empty lists are omitted so
+ *  `updateProviderCatalogs` cannot wipe a previous (e.g. server) catalog. */
+export function toNonEmptyProviderCatalogs(
+    modelsByProvider: Partial<Record<LlmProvider, LlmModelOption[]>>
+): Partial<Record<LlmProvider, LlmProviderCatalog>> {
+    const catalogs: Partial<Record<LlmProvider, LlmProviderCatalog>> = {};
+    for (const provider of LLM_PROVIDERS) {
+        const models = modelsByProvider[provider];
+        if (!models || models.length === 0) continue;
+        catalogs[provider] = {
+            provider,
+            status: 'ok',
+            models,
+            defaultModel: models[0]?.value || null,
+            error: null,
+        };
+    }
+    return catalogs;
 }
 
 /** Fetch the server-driven model catalog (all providers). OAuth tokens are stripped from the body

--- a/packages/lwc/shared/modules/types/global.d.ts
+++ b/packages/lwc/shared/modules/types/global.d.ts
@@ -8,6 +8,7 @@ declare const chrome: {
     runtime?: {
         getURL: (path: string) => string;
         id?: string;
+        lastError?: { message?: string };
     };
     storage: {
         local: ChromeStorageArea;

--- a/packages/lwc/shared/modules/utils/chrome.ts
+++ b/packages/lwc/shared/modules/utils/chrome.ts
@@ -141,6 +141,10 @@ export const getVscodeEditorUrl = (seed: VscodeEditorUrlParams): string | null =
 
 type ChromeTab = {
     id?: number;
+    title?: string;
+    url?: string;
+    active?: boolean;
+    windowId?: number;
 };
 
 export async function getCurrentTab(): Promise<ChromeTab | null> {

--- a/packages/server/modules/__tests__/llmModels.test.ts
+++ b/packages/server/modules/__tests__/llmModels.test.ts
@@ -3,8 +3,33 @@ import { test } from 'node:test';
 
 import { __testables } from '../llmModels.ts';
 
-const { normalizeProviderConfigMap, getStaticProviderCatalog, getOpenAiCatalog, buildCatalogs } =
-    __testables;
+const {
+    normalizeProviderConfigMap,
+    getStaticProviderCatalog,
+    getOpenAiCatalog,
+    getProviderCatalog,
+    buildCatalogs,
+} = __testables;
+
+function jsonFetch(body: unknown, ok = true) {
+    return (async () =>
+        ({
+            ok,
+            status: ok ? 200 : 502,
+            json: async () => body,
+        }) as Response) as unknown as typeof fetch;
+}
+
+function jsonFetchByUrl(handler: (url: string) => { ok?: boolean; body: unknown }) {
+    return (async (url: string | URL) => {
+        const result = handler(String(url));
+        return {
+            ok: result.ok !== false,
+            status: result.ok === false ? 502 : 200,
+            json: async () => result.body,
+        } as Response;
+    }) as unknown as typeof fetch;
+}
 
 test('normalizeProviderConfigMap: default baseUrls and null apiKey when empty', () => {
     const out = normalizeProviderConfigMap({});
@@ -46,6 +71,7 @@ test('getStaticProviderCatalog: baseUrl but no apiKey → missing_key', () => {
     });
     assert.equal(out.status, 'missing_key');
     assert.match(out.error || '', /API key/);
+    assert.ok(out.models.length > 0);
 });
 
 test('getStaticProviderCatalog: internal gateway baseUrl suppresses static models', () => {
@@ -71,21 +97,164 @@ test('getOpenAiCatalog: no apiKey with public baseUrl → missing_key, static mo
     assert.ok(out.models.length > 0);
 });
 
-test('getOpenAiCatalog: apiKey with public baseUrl → ok + defaultModel set', async () => {
-    const out = await getOpenAiCatalog({
-        apiKey: 'sk-123',
-        baseUrl: 'https://api.openai.com/v1',
-    });
+test('getOpenAiCatalog: mixed gateway dump drops non-OpenAI ids', async () => {
+    const out = await getOpenAiCatalog(
+        {
+            apiKey: 'sk-123',
+            baseUrl: 'https://api.openai.com/v1',
+        },
+        jsonFetch({
+            data: [
+                { id: 'gpt-5.6-sol' },
+                { id: 'claude-haiku-4-5-20251001' },
+                { id: 'gemini-2.0-flash' },
+            ],
+        })
+    );
+    assert.deepEqual(
+        out.models.map(model => model.value),
+        ['gpt-5.6-sol']
+    );
+});
+
+test('getOpenAiCatalog: apiKey with public baseUrl uses the live catalog', async () => {
+    const out = await getOpenAiCatalog(
+        {
+            apiKey: 'sk-123',
+            baseUrl: 'https://api.openai.com/v1',
+        },
+        jsonFetch({ data: [{ id: 'gpt-live' }, { id: 'whisper-1' }] })
+    );
     assert.equal(out.status, 'ok');
-    assert.ok(out.defaultModel);
+    assert.deepEqual(
+        out.models.map(model => model.value),
+        ['gpt-live']
+    );
+    assert.equal(out.defaultModel, 'gpt-live');
+});
+
+test('getOpenAiCatalog: upstream error falls back to static models', async () => {
+    const out = await getOpenAiCatalog(
+        {
+            apiKey: 'sk-123',
+            baseUrl: 'https://api.openai.com/v1',
+        },
+        jsonFetch({}, false)
+    );
+    assert.equal(out.status, 'upstream_error');
+    assert.ok(out.models.length > 0);
+    assert.ok(out.models.some(model => model.value === 'gpt-5-mini'));
+});
+
+test('getProviderCatalog: Anthropic live list with a key', async () => {
+    const out = await getProviderCatalog(
+        'anthropic',
+        { apiKey: 'sk-ant', baseUrl: 'https://api.anthropic.com/v1' },
+        jsonFetch({ data: [{ id: 'claude-opus-4-6', display_name: 'Claude Opus 4.6' }] })
+    );
+    assert.equal(out.status, 'ok');
+    assert.equal(out.models[0].value, 'claude-opus-4-6');
+});
+
+test('getProviderCatalog: Gemini live list filters embed-only models', async () => {
+    const out = await getProviderCatalog(
+        'gemini',
+        { apiKey: 'gem', baseUrl: 'https://generativelanguage.googleapis.com' },
+        jsonFetch({
+            models: [
+                {
+                    name: 'models/gemini-3.1-pro-preview',
+                    supportedGenerationMethods: ['generateContent'],
+                },
+                {
+                    name: 'models/embedding-001',
+                    supportedGenerationMethods: ['embedContent'],
+                },
+            ],
+        })
+    );
+    assert.deepEqual(
+        out.models.map(model => model.value),
+        ['gemini-3.1-pro-preview']
+    );
+});
+
+test('getProviderCatalog: Mistral and Grok live lists', async () => {
+    const mistral = await getProviderCatalog(
+        'mistral',
+        { apiKey: 'm', baseUrl: 'https://api.mistral.ai/v1' },
+        jsonFetch({ data: [{ id: 'mistral-large-live' }] })
+    );
+    assert.equal(mistral.models[0].value, 'mistral-large-live');
+
+    const grok = await getProviderCatalog(
+        'grok',
+        { apiKey: 'x', baseUrl: 'https://api.x.ai/v1' },
+        jsonFetch({ models: [{ id: 'grok-4-live' }] })
+    );
+    assert.equal(grok.models[0].value, 'grok-4-live');
+});
+
+test('getProviderCatalog: no key still returns static models + missing_key', async () => {
+    const out = await getProviderCatalog('anthropic', {
+        apiKey: null,
+        baseUrl: 'https://api.anthropic.com/v1',
+    });
+    assert.equal(out.status, 'missing_key');
+    assert.ok(out.models.some(model => model.value === 'claude-sonnet-4-6'));
+});
+
+test('getProviderCatalog: empty live list falls back to static', async () => {
+    const out = await getProviderCatalog(
+        'openai',
+        { apiKey: 'sk', baseUrl: 'https://api.openai.com/v1' },
+        jsonFetch({ data: [{ id: 'whisper-1' }] })
+    );
+    assert.equal(out.status, 'ok');
+    assert.ok(out.models.some(model => model.value === 'gpt-5-mini'));
+});
+
+test('getProviderCatalog: internal gateway error does not leak the public static list', async () => {
+    const out = await getProviderCatalog(
+        'anthropic',
+        {
+            apiKey: 'sk',
+            baseUrl: 'https://eng-ai-model-gateway.example.com/bedrock',
+        },
+        jsonFetch({}, false)
+    );
+    assert.equal(out.status, 'upstream_error');
+    assert.equal(out.models.length, 0);
 });
 
 test('buildCatalogs: returns catalog for every supported provider', async () => {
     const configs = normalizeProviderConfigMap({});
-    const out = await buildCatalogs(configs);
+    const out = await buildCatalogs(configs, jsonFetch({ data: [] }));
     assert.ok(out.openai);
     assert.ok(out.anthropic);
     assert.ok(out.gemini);
     assert.ok(out.mistral);
     assert.ok(out.grok);
+});
+
+test('buildCatalogs: live-fetches configured providers independently', async () => {
+    const configs = normalizeProviderConfigMap({
+        openai: { apiKey: 'sk-o', baseUrl: 'https://api.openai.com/v1' },
+        anthropic: { apiKey: 'sk-a', baseUrl: 'https://api.anthropic.com/v1' },
+    });
+    const out = await buildCatalogs(
+        configs,
+        jsonFetchByUrl(url => {
+            if (url.includes('api.openai.com')) {
+                return { body: { data: [{ id: 'gpt-live' }] } };
+            }
+            if (url.includes('api.anthropic.com')) {
+                return { body: { data: [{ id: 'claude-live' }] } };
+            }
+            return { ok: false, body: {} };
+        })
+    );
+    assert.equal(out.openai.models[0].value, 'gpt-live');
+    assert.equal(out.anthropic.models[0].value, 'claude-live');
+    assert.equal(out.mistral.status, 'missing_key');
 });

--- a/packages/server/modules/llmModels.ts
+++ b/packages/server/modules/llmModels.ts
@@ -28,6 +28,16 @@ const DEFAULT_PROVIDER_BASE_URLS: Record<LlmProvider, string> = {
     mistral: 'https://api.mistral.ai/v1',
     grok: 'https://api.x.ai/v1',
 };
+const ANTHROPIC_API_VERSION = '2023-06-01';
+const NON_CHAT_MODEL_PATTERN =
+    /embedding|whisper|tts|dall-e|image|moderation|realtime|transcribe|computer-use/i;
+const DATED_MODEL_SUFFIX_PATTERN = /-\d{8}$/;
+const NATIVE_PROVIDER_DOMAINS: Partial<Record<LlmProvider, string>> = {
+    anthropic: 'api.anthropic.com',
+    gemini: 'generativelanguage.googleapis.com',
+    grok: 'api.x.ai',
+    mistral: 'api.mistral.ai',
+};
 const OPENAI_MODEL_OPTIONS: LlmModelOption[] = [
     { label: 'gpt-5-mini', value: 'gpt-5-mini', provider: 'openai' },
     { label: 'gpt-5', value: 'gpt-5-2025-08-07', provider: 'openai' },
@@ -135,6 +145,14 @@ function isInternalProviderBaseUrl(baseUrl: unknown) {
     return normalizeString(baseUrl).includes('eng-ai-model-gateway');
 }
 
+function isOpenAiCompatibleGateway(provider: LlmProvider, baseUrl: unknown) {
+    if (isInternalProviderBaseUrl(baseUrl)) return true;
+    const normalized = normalizeString(baseUrl).toLowerCase();
+    if (!normalized) return false;
+    const nativeDomain = NATIVE_PROVIDER_DOMAINS[provider];
+    return !!nativeDomain && !normalized.includes(nativeDomain);
+}
+
 type LlmModelsRequestBody = {
     provider?: string;
     providerConfigs?: LlmProviderConfigMap;
@@ -144,96 +162,187 @@ function toBaseUrl(baseUrl: string) {
     return baseUrl.replace(/\/+$/, '');
 }
 
-async function fetchGatewayModels(
-    config: LlmProviderConfigMap['openai']
-): Promise<Awaited<ReturnType<typeof getOpenAiCatalog>>> {
-    if (!config.apiKey) {
-        return {
-            provider: 'openai',
-            status: 'missing_key',
-            models: [],
-            defaultModel: null,
-            error: 'OpenAI API key is required to load models.',
-        };
-    }
-
-    try {
-        const response = await fetch(`${toBaseUrl(config.baseUrl)}/models`, {
-            method: 'GET',
-            headers: {
-                Authorization: `Bearer ${config.apiKey}`,
-                'Content-Type': 'application/json',
-            },
-        });
-        if (!response.ok) {
-            return {
-                provider: 'openai',
-                status: 'upstream_error',
-                models: [],
-                defaultModel: null,
-                error: `Gateway model lookup failed with status ${response.status}.`,
-            };
-        }
-        const payload = (await response.json()) as { data?: Array<{ id?: unknown }> } | null;
-        const upstreamModels: LlmModelOption[] = Array.isArray(payload?.data)
-            ? payload.data
-                  .map((item): LlmModelOption | null => {
-                      const id = typeof item?.id === 'string' ? item.id.trim() : '';
-                      return id ? { label: id, value: id, provider: 'openai' as const } : null;
-                  })
-                  .filter((item): item is LlmModelOption => item !== null)
-            : [];
-        return {
-            provider: 'openai',
-            status: 'ok',
-            models: upstreamModels,
-            defaultModel: upstreamModels[0]?.value || null,
-            error: null,
-        };
-    } catch (error) {
-        return {
-            provider: 'openai',
-            status: 'upstream_error',
-            models: [],
-            defaultModel: null,
-            error: error instanceof Error ? error.message : 'Unable to load gateway models.',
-        };
-    }
+function overlayStaticMetadata(models: LlmModelOption[], provider: LlmProvider): LlmModelOption[] {
+    const known = new Map(getProviderModelOptions(provider).map(model => [model.value, model]));
+    return models.map(model => {
+        const match = known.get(model.value);
+        return match ? { ...model, label: match.label || model.label } : model;
+    });
 }
 
-async function getOpenAiCatalog(
-    config: LlmProviderConfigMap['openai']
-): Promise<LlmProviderCatalog> {
-    if (!config.baseUrl) {
-        return {
-            provider: 'openai',
-            status: 'invalid_config',
-            models: [],
-            defaultModel: null,
-            error: 'OpenAI base URL is required.',
-        };
+function inferProviderFromModelId(modelId: string): LlmProvider | null {
+    const id = modelId.toLowerCase();
+    if (!id) return null;
+    if (id.includes('claude') || id.includes('anthropic')) return 'anthropic';
+    if (id.includes('gemini')) return 'gemini';
+    if (id.includes('grok')) return 'grok';
+    if (/(^|[^a-z])(mistral|codestral|pixtral|ministral|devstral|magistral)/.test(id)) {
+        return 'mistral';
     }
-
-    if (isInternalProviderBaseUrl(config.baseUrl)) {
-        return fetchGatewayModels(config);
+    if (
+        id.startsWith('gpt-') ||
+        id.startsWith('chatgpt') ||
+        id.startsWith('openai') ||
+        id.startsWith('ft:') ||
+        id.includes('davinci') ||
+        id.includes('babbage') ||
+        /(?:^|[^a-z])(o1|o3|o4)(?:-|$)/.test(id)
+    ) {
+        return 'openai';
     }
+    return null;
+}
 
-    const models = getProviderModelOptions('openai');
-    return {
-        provider: 'openai',
-        status: config.apiKey ? 'ok' : 'missing_key',
-        models,
-        defaultModel: getDefaultModelForProvider('openai'),
-        error: config.apiKey ? null : 'OpenAI API key is required to load models.',
-    };
+function refineLiveModels(models: LlmModelOption[], provider: LlmProvider): LlmModelOption[] {
+    const chatModels = models.filter(model => {
+        if (NON_CHAT_MODEL_PATTERN.test(model.value)) return false;
+        const inferred = inferProviderFromModelId(model.value);
+        return inferred === null || inferred === provider;
+    });
+    const ids = new Set(chatModels.map(model => model.value));
+    const withoutDatedPins = chatModels.filter(model => {
+        if (!DATED_MODEL_SUFFIX_PATTERN.test(model.value)) return true;
+        const alias = model.value.replace(DATED_MODEL_SUFFIX_PATTERN, '');
+        return !ids.has(alias);
+    });
+    return overlayStaticMetadata(withoutDatedPins, provider);
+}
+
+function parseOpenAiShapedCatalog(data: unknown, provider: LlmProvider): LlmModelOption[] {
+    if (!isRecord(data)) return [];
+    const rawList = Array.isArray(data.models)
+        ? data.models
+        : Array.isArray(data.data)
+          ? data.data
+          : [];
+    const options: LlmModelOption[] = [];
+    const seen = new Set<string>();
+    for (const entry of rawList) {
+        if (!isRecord(entry)) continue;
+        const id =
+            typeof entry.slug === 'string'
+                ? entry.slug
+                : typeof entry.id === 'string'
+                  ? entry.id
+                  : '';
+        if (!id || seen.has(id)) continue;
+        seen.add(id);
+        const label =
+            typeof entry.display_name === 'string' && entry.display_name.trim()
+                ? entry.display_name.trim()
+                : id;
+        options.push({ label, value: id, provider });
+    }
+    return options;
+}
+
+function parseGeminiCatalog(data: unknown, provider: LlmProvider): LlmModelOption[] {
+    if (!isRecord(data) || !Array.isArray(data.models)) return [];
+    const options: LlmModelOption[] = [];
+    const seen = new Set<string>();
+    for (const entry of data.models) {
+        if (!isRecord(entry)) continue;
+        const methods = Array.isArray(entry.supportedGenerationMethods)
+            ? entry.supportedGenerationMethods
+            : [];
+        if (methods.length > 0 && !methods.includes('generateContent')) continue;
+        const rawName =
+            typeof entry.name === 'string'
+                ? entry.name
+                : typeof entry.id === 'string'
+                  ? entry.id
+                  : '';
+        const id = rawName.replace(/^models\//, '').trim();
+        if (!id || seen.has(id)) continue;
+        seen.add(id);
+        const label =
+            typeof entry.displayName === 'string' && entry.displayName.trim()
+                ? entry.displayName.trim()
+                : id;
+        options.push({ label, value: id, provider });
+    }
+    return options;
+}
+
+function resolveGeminiNativeModelsUrl(baseUrl: string): string {
+    const root = toBaseUrl(baseUrl);
+    if (root.endsWith('/v1beta')) return `${root}/models`;
+    if (root.includes('generativelanguage.googleapis.com')) return `${root}/v1beta/models`;
+    return `${root}/models`;
+}
+
+async function fetchJsonCatalog(
+    url: string,
+    headers: Record<string, string>,
+    fetchImpl: typeof fetch
+): Promise<unknown> {
+    const response = await fetchImpl(url, { method: 'GET', headers });
+    if (!response.ok) {
+        throw new Error(`Model catalog request to ${url} failed with status ${response.status}.`);
+    }
+    return response.json();
+}
+
+async function fetchLiveModels(
+    provider: LlmProvider,
+    config: LlmProviderConfig,
+    fetchImpl: typeof fetch
+): Promise<LlmModelOption[]> {
+    const apiKey = config.apiKey;
+    if (!apiKey) return [];
+    const root = toBaseUrl(config.baseUrl || DEFAULT_PROVIDER_BASE_URLS[provider]);
+    const openAiCompatible =
+        provider === 'openai' ||
+        provider === 'mistral' ||
+        isOpenAiCompatibleGateway(provider, config.baseUrl);
+
+    if (provider === 'gemini' && !openAiCompatible) {
+        const url = `${resolveGeminiNativeModelsUrl(config.baseUrl)}?key=${encodeURIComponent(apiKey)}`;
+        const data = await fetchJsonCatalog(url, { Accept: 'application/json' }, fetchImpl);
+        return refineLiveModels(parseGeminiCatalog(data, provider), provider);
+    }
+    if (provider === 'anthropic' && !openAiCompatible) {
+        const data = await fetchJsonCatalog(
+            `${root}/models`,
+            {
+                Accept: 'application/json',
+                'x-api-key': apiKey,
+                'anthropic-version': ANTHROPIC_API_VERSION,
+            },
+            fetchImpl
+        );
+        return refineLiveModels(parseOpenAiShapedCatalog(data, provider), provider);
+    }
+    if (provider === 'grok' && !openAiCompatible) {
+        const data = await fetchJsonCatalog(
+            `${root}/language-models`,
+            {
+                Authorization: `Bearer ${apiKey}`,
+                Accept: 'application/json',
+            },
+            fetchImpl
+        );
+        return refineLiveModels(parseOpenAiShapedCatalog(data, provider), provider);
+    }
+    const data = await fetchJsonCatalog(
+        `${root}/models`,
+        {
+            Authorization: `Bearer ${apiKey}`,
+            Accept: 'application/json',
+        },
+        fetchImpl
+    );
+    let models = parseOpenAiShapedCatalog(data, provider);
+    if (provider === 'gemini' && models.length === 0) {
+        models = parseGeminiCatalog(data, provider);
+    }
+    return refineLiveModels(models, provider);
 }
 
 function getStaticProviderCatalog(
-    provider: Exclude<LlmProvider, 'openai'>,
+    provider: LlmProvider,
     config: LlmProviderConfig
 ): LlmProviderCatalog {
-    // When the provider points at the internal gateway, defer to the client-side
-    // INTERNAL_MODEL_OPTIONS fallback so we don't duplicate the catalog on the server.
     if (isInternalProviderBaseUrl(config.baseUrl)) {
         return {
             provider,
@@ -258,15 +367,84 @@ function getStaticProviderCatalog(
     };
 }
 
-async function buildCatalogs(providerConfigs: LlmProviderConfigMap) {
-    const catalogs = {} as Record<LlmProvider, LlmProviderCatalog>;
-    for (const provider of LLM_PROVIDERS) {
-        if (provider === 'openai') {
-            catalogs.openai = await getOpenAiCatalog(providerConfigs.openai);
-            continue;
-        }
-        catalogs[provider] = getStaticProviderCatalog(provider, providerConfigs[provider]);
+function fallbackCatalog(
+    provider: LlmProvider,
+    config: LlmProviderConfig,
+    status: LlmProviderCatalog['status'],
+    error: string | null
+): LlmProviderCatalog {
+    const isInternal = isInternalProviderBaseUrl(config.baseUrl);
+    const models = isInternal ? [] : getProviderModelOptions(provider);
+    return {
+        provider,
+        status,
+        models,
+        defaultModel: models[0]?.value || null,
+        error,
+    };
+}
+
+async function getProviderCatalog(
+    provider: LlmProvider,
+    config: LlmProviderConfig,
+    fetchImpl: typeof fetch = fetch
+): Promise<LlmProviderCatalog> {
+    if (!config.baseUrl) {
+        return {
+            provider,
+            status: 'invalid_config',
+            models: [],
+            defaultModel: null,
+            error: `${provider} base URL is required.`,
+        };
     }
+    if (!config.apiKey) {
+        return getStaticProviderCatalog(provider, config);
+    }
+
+    try {
+        const liveModels = await fetchLiveModels(provider, config, fetchImpl);
+        if (liveModels.length > 0) {
+            return {
+                provider,
+                status: 'ok',
+                models: liveModels,
+                defaultModel: liveModels[0]?.value || null,
+                error: null,
+            };
+        }
+        return fallbackCatalog(provider, config, 'ok', null);
+    } catch (error) {
+        return fallbackCatalog(
+            provider,
+            config,
+            'upstream_error',
+            error instanceof Error ? error.message : `Unable to load ${provider} models.`
+        );
+    }
+}
+
+async function getOpenAiCatalog(
+    config: LlmProviderConfigMap['openai'],
+    fetchImpl: typeof fetch = fetch
+): Promise<LlmProviderCatalog> {
+    return getProviderCatalog('openai', config, fetchImpl);
+}
+
+async function buildCatalogs(
+    providerConfigs: LlmProviderConfigMap,
+    fetchImpl: typeof fetch = fetch
+) {
+    const catalogs = {} as Record<LlmProvider, LlmProviderCatalog>;
+    await Promise.all(
+        LLM_PROVIDERS.map(async provider => {
+            catalogs[provider] = await getProviderCatalog(
+                provider,
+                providerConfigs[provider],
+                fetchImpl
+            );
+        })
+    );
     return catalogs;
 }
 
@@ -291,6 +469,7 @@ export default function llmModels(app: Application, path = '/api/llm/models') {
 export const __testables = {
     buildCatalogs,
     getOpenAiCatalog,
+    getProviderCatalog,
     getStaticProviderCatalog,
     normalizeProviderConfigMap,
 };

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > The modern replacement for **Salesforce Workbench** and **Benchpress**
 
-Latest release: **v2.1.0**
+Latest release: **v2.1.1**
 
 Workbench is a Salesforce administration toolkit that embeds directly into your browser — bringing an overlay panel, a VS Code editor, a full metadata explorer, a SOQL editor, and an AI agent capable of controlling your browser, all from a single Chrome extension.
 

--- a/tools/testing/__tests__/releaseDocsSync.test.mjs
+++ b/tools/testing/__tests__/releaseDocsSync.test.mjs
@@ -62,4 +62,14 @@ test('docs/release: README, docs, and release metadata stay version-synced', () 
         expectedVersionPattern,
         'Announcement message should reference current package version'
     );
+
+    const landingLocales = ['en', 'fr', 'de', 'es', 'ja'];
+    for (const locale of landingLocales) {
+        const localePayload = JSON.parse(readRepoFile(`apps/ui/src/locales/${locale}.json`));
+        assert.match(
+            String(localePayload?.chrome?.announce || ''),
+            expectedVersionPattern,
+            `Landing announce bar (${locale}.json) should reference current package version`
+        );
+    }
 });


### PR DESCRIPTION
## Summary
- Ship Workbench 2.1.1: the Agent can inspect the visible Chrome tab from the side panel, sandbox `js` scripts attach to that tab (heredoc / async IIFE fixes included), and the model picker loads live catalogs from OpenAI, Anthropic, Gemini, Mistral, and xAI when an API key is set.
- Fix page snapshots failing on unreadable form field types, sandbox eval hangs on simple scripts, and stale sandbox iframes after side-panel remounts.
- Bump version to 2.1.1 across package metadata, release notes, announcements, and docs.
- Replace landing-site screenshots with an interactive product tour (overlay, VS Code, SOQL, agent) and retitle the hero to "The toolkit built by Salesforce Engineers".

## Test plan
- [ ] From the Chrome side panel, ask the Agent about the current tab (quiz / "what's on this page" / screenshot) and confirm it uses the visible tab without opening a new one
- [ ] Run a sandbox `js` heredoc that calls `getCurrentTab()` / `connectToPage()` with no tab id; confirm async IIFE wrappers return output
- [ ] With an API key configured, open the model picker and confirm live catalogs load from each provider
- [ ] Confirm page snapshots succeed on pages with file inputs and other form fields
- [ ] Remount the side panel, then run a simple `js` eval and confirm it does not hang or time out
- [ ] Confirm overlay and SOQL Explorer icon-only buttons still show hover tooltips
- [ ] Smoke-check release notes / in-app announcement for 2.1.1
- [ ] Open the landing site and confirm the hero reads "The toolkit built by Salesforce Engineers" and the product tour plays through overlay → editor → SOQL → agent