### PR TITLE
feat(ui): polish the landing product tour to match Workbench

### DIFF
--- a/apps/ui/src/product-tour/ProductDemo.tsx
+++ b/apps/ui/src/product-tour/ProductDemo.tsx
@@ -45,19 +45,40 @@ export function ProductDemo(): ReactNode {
     const { t } = useTranslation();
     const reduceMotion = usePrefersReducedMotion();
     const elapsed = useTourElapsed(FLOW_LOOP_MS, !reduceMotion);
+    const lastElapsed = useRef(elapsed);
+    const [loopGen, setLoopGen] = useState(0);
     const scene = reduceMotion ? completedScene() : sceneForElapsed(elapsed);
     const heading = headingForView(scene.view);
+
+    useEffect(() => {
+        if (reduceMotion) {
+            lastElapsed.current = elapsed;
+            return;
+        }
+        if (elapsed + 200 < lastElapsed.current) {
+            setLoopGen(gen => gen + 1);
+        }
+        lastElapsed.current = elapsed;
+    }, [elapsed, reduceMotion]);
 
     return (
         <div className="product-tour" data-tour-demo>
             <section aria-label={t('home.demo.ariaLabel')}>
                 <header className="product-tour-heading">
-                    <h2>{t(`home.demo.headings.${heading}`)}</h2>
-                    <p>{t(`home.demo.captions.${scene.captionKey}`)}</p>
+                    <h2 key={heading} className="pt-copy-fade">
+                        {t(`home.demo.headings.${heading}`)}
+                    </h2>
+                    <p key={scene.captionKey} className="pt-copy-fade">
+                        {t(`home.demo.captions.${scene.captionKey}`)}
+                    </p>
                 </header>
                 <SpatialFixture>
                     <FakeBrowser url={demoUrlForView(scene.view)}>
-                        <HomeFlowWireframe scene={scene} />
+                        <HomeFlowWireframe
+                            scene={scene}
+                            loopGen={loopGen}
+                            showCursor={!reduceMotion}
+                        />
                     </FakeBrowser>
                 </SpatialFixture>
                 <p className="product-tour-more">
@@ -96,7 +117,11 @@ export function FeatureSlide({ slideId, url }: { slideId: TourSlideId; url: stri
         <div ref={rootRef}>
             <SpatialFixture>
                 <FakeBrowser url={url}>
-                    <SlideWireframe slideId={slideId} play={play} />
+                    <SlideWireframe
+                        slideId={slideId}
+                        play={play}
+                        showCursor={inView && !reduceMotion}
+                    />
                 </FakeBrowser>
             </SpatialFixture>
         </div>

--- a/apps/ui/src/product-tour/SpatialFixture.tsx
+++ b/apps/ui/src/product-tour/SpatialFixture.tsx
@@ -1,63 +1,50 @@
 import { useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
-import { spatialFixtureScale } from './slides';
+import { AUTHORED_HEIGHT, AUTHORED_WIDTH, spatialFixtureScale } from './slides';
 
 export function SpatialFixture({ children }: { children: ReactNode }): ReactNode {
     const frameRef = useRef<HTMLDivElement>(null);
-    const fixtureRef = useRef<HTMLDivElement>(null);
     const [geometry, setGeometry] = useState({
         scale: 1,
-        height: null as number | null,
-        width: null as number | null,
+        height: AUTHORED_HEIGHT,
         offsetX: 0,
     });
 
     useLayoutEffect(() => {
         const frame = frameRef.current;
-        const fixture = fixtureRef.current;
-        if (!frame || !fixture) return;
+        if (!frame) return;
         const measure = () => {
-            const authoredWidth = fixture.scrollWidth;
-            const authoredHeight = fixture.scrollHeight;
-            const scale = spatialFixtureScale(frame.clientWidth, authoredWidth);
-            const scaled = Math.abs(scale - 1) >= 0.0001;
-            const height = scaled ? authoredHeight * scale : null;
-            const width = scaled ? authoredWidth : null;
-            const offsetX = scaled ? (frame.clientWidth - authoredWidth) / 2 : 0;
+            const scale = spatialFixtureScale(frame.clientWidth, AUTHORED_WIDTH);
+            const height = AUTHORED_HEIGHT * scale;
+            const offsetX = (frame.clientWidth - AUTHORED_WIDTH) / 2;
             setGeometry(current =>
                 Math.abs(current.scale - scale) < 0.0001 &&
-                current.height === height &&
-                current.width === width &&
+                Math.abs(current.height - height) < 0.5 &&
                 Math.abs(current.offsetX - offsetX) < 0.5
                     ? current
-                    : { scale, height, width, offsetX }
+                    : { scale, height, offsetX }
             );
         };
         measure();
         const observer = new ResizeObserver(measure);
         observer.observe(frame);
-        observer.observe(fixture);
         return () => observer.disconnect();
     }, []);
 
-    const scaled = geometry.height !== null;
     return (
         <div
             ref={frameRef}
             data-tour-scale={geometry.scale.toFixed(4)}
             className="product-tour-spatial"
-            style={scaled ? { height: geometry.height ?? undefined } : undefined}
+            style={{ height: geometry.height }}
         >
             <div
-                ref={fixtureRef}
                 className="product-tour-spatial-inner"
                 style={
-                    scaled
-                        ? ({
-                              transform: `scale(${geometry.scale})`,
-                              width: geometry.width ?? undefined,
-                              marginLeft: geometry.offsetX,
-                          } as CSSProperties)
-                        : undefined
+                    {
+                        width: AUTHORED_WIDTH,
+                        transform: `scale(${geometry.scale})`,
+                        marginLeft: geometry.offsetX,
+                    } as CSSProperties
                 }
             >
                 {children}

--- a/apps/ui/src/product-tour/TourCursor.tsx
+++ b/apps/ui/src/product-tour/TourCursor.tsx
@@ -1,0 +1,66 @@
+import { useLayoutEffect, useState, type ReactNode, type RefObject } from 'react';
+import type { CursorTarget } from './flow-scene';
+
+export function TourCursor({
+    stageRef,
+    target,
+    clicking,
+    hidden,
+}: {
+    stageRef: RefObject<HTMLElement | null>;
+    target: CursorTarget;
+    clicking: boolean;
+    hidden: boolean;
+}): ReactNode {
+    const [pos, setPos] = useState({ x: 48, y: 120 });
+    const [clickGen, setClickGen] = useState(0);
+
+    useLayoutEffect(() => {
+        if (clicking) setClickGen(gen => gen + 1);
+    }, [clicking]);
+
+    useLayoutEffect(() => {
+        const stage = stageRef.current;
+        if (!stage || !target) return;
+        const measure = () => {
+            const el =
+                stage.querySelector(`.pt-view-layer.is-current [data-pt-target="${target}"]`) ??
+                stage.querySelector(`[data-pt-target="${target}"]`);
+            if (!(el instanceof HTMLElement)) return;
+            const stageBox = stage.getBoundingClientRect();
+            const box = el.getBoundingClientRect();
+            const x = box.left - stageBox.left + box.width * 0.65;
+            const y = box.top - stageBox.top + box.height * 0.55;
+            setPos(current =>
+                Math.abs(current.x - x) < 0.5 && Math.abs(current.y - y) < 0.5 ? current : { x, y }
+            );
+        };
+        measure();
+        const frame = requestAnimationFrame(measure);
+        const observer = new ResizeObserver(measure);
+        observer.observe(stage);
+        return () => {
+            cancelAnimationFrame(frame);
+            observer.disconnect();
+        };
+    }, [stageRef, target]);
+
+    return (
+        <div
+            className={`pt-cursor${hidden || !target ? ' is-hidden' : ''}${clicking ? ' is-click' : ''}`}
+            data-click={clickGen}
+            style={{ transform: `translate(${pos.x}px, ${pos.y}px)` }}
+            aria-hidden
+        >
+            <svg viewBox="0 0 24 24" width="18" height="18">
+                <path
+                    d="M4.2 2.4 19.6 14.2l-6.4.4 3.1 7.2-2.9 1.2-3.1-7.1L4.2 21.6V2.4Z"
+                    fill="#fff"
+                    stroke="#032d60"
+                    strokeWidth="1.4"
+                    strokeLinejoin="round"
+                />
+            </svg>
+        </div>
+    );
+}

--- a/apps/ui/src/product-tour/__test__/flow-scene.test.ts
+++ b/apps/ui/src/product-tour/__test__/flow-scene.test.ts
@@ -17,12 +17,14 @@ import {
     T_ACTION,
     T_BUNDLE,
     T_EDITOR,
+    T_FORM_EMAIL,
     T_FORM_NAME,
     T_HTML_DONE,
     T_LOADING_EDITOR,
     T_LOADING_SOQL,
     T_PALETTE,
     T_RESULTS,
+    T_RUN,
     T_SIDEPANEL,
     T_SOQL,
     T_STREAM,
@@ -117,15 +119,18 @@ test('sceneForElapsed: opens a side panel and fills the Acme support form', () =
     assert.ok(streaming.assistant.length > 0);
     const filling = sceneForElapsed(T_FORM_NAME + 10);
     assert.equal(filling.formFocus, 'name');
-    assert.equal(filling.formName, FORM_NAME);
     assert.equal(filling.captionKey, 'stream');
+    assert.ok(filling.formName.length > 0);
+    assert.ok(filling.formName.length < FORM_NAME.length);
+    assert.equal(filling.formName, FORM_NAME.slice(0, filling.formName.length));
+    assert.equal(sceneForElapsed(T_FORM_EMAIL).formName, FORM_NAME);
     const submitted = sceneForElapsed(T_ACTION + 10);
     assert.equal(submitted.assistant, ASSISTANT_REPLY);
     assert.equal(submitted.formFocus, 'submit');
     assert.equal(submitted.formEmail, FORM_EMAIL);
     assert.equal(submitted.formOrder, FORM_ORDER);
     assert.equal(submitted.formMessage, FORM_MESSAGE);
-    assert.equal(submitted.formSubmitPulse, true);
+    assert.equal(submitted.formSubmitPulse, false);
     assert.equal(submitted.captionKey, 'action');
 });
 
@@ -172,6 +177,10 @@ test('slidePlayForElapsed: agent fills the Acme support form', () => {
     const start = slidePlayForElapsed('agent', 0);
     assert.equal(start.formName, '');
     assert.equal(start.formFocus, null);
+    const typing = slidePlayForElapsed('agent', 700);
+    assert.equal(typing.formFocus, 'name');
+    assert.ok(typing.formName.length > 0);
+    assert.ok(typing.formName.length < FORM_NAME.length);
     const done = completedSlidePlay('agent');
     assert.equal(done.formName, FORM_NAME);
     assert.equal(done.formEmail, FORM_EMAIL);
@@ -179,4 +188,16 @@ test('slidePlayForElapsed: agent fills the Acme support form', () => {
     assert.equal(done.formMessage, FORM_MESSAGE);
     assert.equal(done.formFocus, 'submit');
     assert.equal(done.assistant, ASSISTANT_REPLY);
+});
+
+test('cursorTargetForScene: follows the beat and hides while loading', () => {
+    assert.equal(sceneForElapsed(0).cursorTarget, 'dock-vscode');
+    assert.equal(sceneForElapsed(T.typeSearch + 10).cursorTarget, 'overlay-search');
+    assert.equal(sceneForElapsed(T_VSCODE_PULSE + 10).cursorTarget, 'dock-vscode');
+    assert.equal(sceneForElapsed(T_LOADING_EDITOR + 10).cursorTarget, null);
+    assert.equal(sceneForElapsed(T_PALETTE + 10).cursorTarget, 'palette');
+    assert.equal(sceneForElapsed(T_RUN + 10).cursorTarget, 'run');
+    assert.equal(sceneForElapsed(T_SIDEPANEL + 10).cursorTarget, null);
+    assert.equal(sceneForElapsed(T_FORM_NAME + 10).cursorTarget, null);
+    assert.equal(sceneForElapsed(T_ACTION + 10).cursorTarget, null);
 });

--- a/apps/ui/src/product-tour/flow-scene.ts
+++ b/apps/ui/src/product-tour/flow-scene.ts
@@ -24,6 +24,23 @@ export type PalettePhase = 'command' | 'name' | null;
 
 export type FormFocus = 'name' | 'email' | 'order' | 'message' | 'submit' | null;
 
+export type CursorTarget =
+    | 'dock-vscode'
+    | 'overlay-search'
+    | 'palette'
+    | 'editor'
+    | 'soql'
+    | 'run'
+    | 'meta-filter'
+    | 'form-name'
+    | 'form-email'
+    | 'form-order'
+    | 'form-message'
+    | 'form-submit'
+    | null;
+
+export const VIEW_FADE_MS = 400;
+
 export interface FlowScene {
     view: FlowView;
     overlayOpen: boolean;
@@ -51,6 +68,7 @@ export interface FlowScene {
     formMessage: string;
     formSubmitPulse: boolean;
     captionKey: CaptionKey;
+    cursorTarget: CursorTarget;
 }
 
 export const SEARCH_QUERY = 'Account';
@@ -114,6 +132,14 @@ export function typed(text: string, start: number, now: number, msPerChar: numbe
     return text.slice(0, Math.max(0, Math.min(text.length, chars)));
 }
 
+export function typedToward(text: string, start: number, end: number, now: number): string {
+    if (now < start) return '';
+    if (text.length === 0 || now >= end) return text;
+    const span = Math.max(1, end - start);
+    const chars = Math.min(text.length, Math.floor(((now - start) / span) * text.length) + 1);
+    return text.slice(0, chars);
+}
+
 export function inRange(now: number, start: number, end: number): boolean {
     return now >= start && now < end;
 }
@@ -154,6 +180,27 @@ function formFocusFor(now: number): FormFocus {
     return null;
 }
 
+export function cursorTargetForScene(scene: {
+    loading: boolean;
+    view?: FlowView;
+    formFocus: FormFocus;
+    sendPulse: boolean;
+    caret: CaretTarget;
+    paletteOpen: boolean;
+    vscodeHot: boolean;
+    overlayOpen: boolean;
+}): CursorTarget {
+    if (scene.loading) return null;
+    if (scene.view === 'sidepanel' || scene.formFocus) return null;
+    if (scene.sendPulse) return 'run';
+    if (scene.caret === 'soql') return 'soql';
+    if (scene.caret === 'editor') return 'editor';
+    if (scene.caret === 'palette' || scene.paletteOpen) return 'palette';
+    if (scene.vscodeHot) return 'dock-vscode';
+    if (scene.caret === 'search' || scene.overlayOpen) return 'overlay-search';
+    return 'dock-vscode';
+}
+
 export function sceneForElapsed(ms: number): FlowScene {
     const now = Number.isFinite(ms) ? Math.max(0, ms) : 0;
     const loadingTarget: LoadingTarget = inRange(now, T_LOADING_EDITOR, T_EDITOR)
@@ -181,8 +228,7 @@ export function sceneForElapsed(ms: number): FlowScene {
     else if (inRange(now, T_TYPE_QUERY, T_RUN)) caret = 'soql';
 
     const focus = formFocusFor(now);
-
-    return {
+    const scene = {
         view,
         overlayOpen: now >= T.overlayOpen,
         overlaySearch: typed(SEARCH_QUERY, T.typeSearch, now, CHAR_MS),
@@ -203,13 +249,14 @@ export function sceneForElapsed(ms: number): FlowScene {
         editorTyped: typed(LWC_HTML, T_TYPE_HTML, now, STREAM_MS),
         editorDirty: now >= T_TYPE_HTML && now < T_HTML_DONE + 350,
         formFocus: focus,
-        formName: now >= T_FORM_NAME ? FORM_NAME : '',
-        formEmail: now >= T_FORM_EMAIL ? FORM_EMAIL : '',
-        formOrder: now >= T_FORM_ORDER ? FORM_ORDER : '',
-        formMessage: now >= T_FORM_MESSAGE ? FORM_MESSAGE : '',
-        formSubmitPulse: inRange(now, T_FORM_SUBMIT, T_FORM_SUBMIT + 900),
+        formName: typedToward(FORM_NAME, T_FORM_NAME, T_FORM_EMAIL, now),
+        formEmail: typedToward(FORM_EMAIL, T_FORM_EMAIL, T_FORM_ORDER, now),
+        formOrder: typedToward(FORM_ORDER, T_FORM_ORDER, T_FORM_MESSAGE, now),
+        formMessage: typedToward(FORM_MESSAGE, T_FORM_MESSAGE, T_FORM_SUBMIT, now),
+        formSubmitPulse: false,
         captionKey: captionFor(now),
     };
+    return { ...scene, cursorTarget: cursorTargetForScene(scene) };
 }
 
 export function completedScene(): FlowScene {

--- a/apps/ui/src/product-tour/product-tour.css
+++ b/apps/ui/src/product-tour/product-tour.css
@@ -6,14 +6,19 @@
     --pt-blue: #0176d3;
     --pt-blue-dark: #014486;
     --pt-text: #181818;
-    --pt-muted: #3e3e3c;
-    --pt-border: #c9c7c5;
-    --pt-bg: #f3f2f2;
+    --pt-muted: #747474;
+    --pt-border: #e5e5e5;
+    --pt-border-legacy: #dddbda;
+    --pt-bg: #f3f3f3;
     --pt-white: #ffffff;
     --pt-cloud: #1b96ff;
     --pt-success: #2e844a;
-    --pt-font: 'Salesforce Sans', 'Segoe UI', system-ui, sans-serif;
-    --pt-mono: 'SF Mono', ui-monospace, Menlo, Consolas, monospace;
+    --pt-error: #c23934;
+    --pt-soft: #eef4ff;
+    --pt-composer: #f7f8fa;
+    --pt-font:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    --pt-mono: ui-monospace, Menlo, Consolas, monospace;
     width: 100%;
     max-width: 1120px;
     margin: 0 auto;
@@ -34,6 +39,26 @@
     letter-spacing: -0.02em;
 }
 
+.product-tour-heading h2,
+.product-tour-heading p {
+    min-height: 1.2em;
+}
+
+.pt-copy-fade {
+    animation: pt-copy-in 280ms ease;
+}
+
+@keyframes pt-copy-in {
+    from {
+        opacity: 0;
+        transform: translateY(4px);
+    }
+    to {
+        opacity: 1;
+        transform: none;
+    }
+}
+
 .product-tour-heading p {
     margin: 6px 0 0;
     max-width: 42rem;
@@ -51,7 +76,8 @@
 
 .product-tour-spatial {
     width: 100%;
-    overflow-x: clip;
+    max-width: 100%;
+    overflow: hidden;
 }
 
 .product-tour-spatial-inner {
@@ -68,9 +94,108 @@
     background: var(--pt-bg);
     color: var(--pt-text);
     font-family: var(--pt-font);
-    font-size: 12px;
+    font-size: 0.8125rem;
     line-height: 1.35;
     user-select: none;
+}
+
+.pt-stage[data-loop-gen] {
+    animation: pt-loop-blend 420ms ease;
+}
+
+@keyframes pt-loop-blend {
+    0% {
+        opacity: 1;
+    }
+    30% {
+        opacity: 0.55;
+    }
+    100% {
+        opacity: 1;
+    }
+}
+
+.pt-view-layer {
+    position: absolute;
+    inset: 0;
+}
+
+.pt-view-layer.is-current {
+    z-index: 1;
+}
+
+.pt-view-layer.is-enter {
+    animation: pt-view-in 400ms ease both;
+}
+
+.pt-view-layer.is-exit {
+    z-index: 0;
+    animation: pt-view-out 400ms ease both;
+    pointer-events: none;
+}
+
+@keyframes pt-view-in {
+    from {
+        opacity: 0;
+        transform: translateY(8px) scale(0.985);
+    }
+    to {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+@keyframes pt-view-out {
+    from {
+        opacity: 1;
+        transform: none;
+    }
+    to {
+        opacity: 0;
+        transform: translateY(-6px) scale(1.01);
+    }
+}
+
+.pt-cursor {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 8;
+    width: 18px;
+    height: 18px;
+    margin: -2px 0 0 -3px;
+    pointer-events: none;
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
+    transition:
+        transform 350ms cubic-bezier(0.22, 1, 0.36, 1),
+        opacity 180ms ease;
+}
+
+.pt-cursor.is-hidden {
+    opacity: 0;
+}
+
+.pt-cursor.is-click::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 10px;
+    height: 10px;
+    border: 2px solid var(--pt-blue);
+    border-radius: 50%;
+    animation: pt-click-ring 420ms ease-out;
+}
+
+@keyframes pt-click-ring {
+    from {
+        opacity: 0.9;
+        transform: scale(0.4);
+    }
+    to {
+        opacity: 0;
+        transform: scale(2.4);
+    }
 }
 
 .pt-caret {
@@ -298,8 +423,8 @@
 
 .pt-overlay-dock {
     position: absolute;
-    top: 88px;
-    right: 0;
+    top: 120px;
+    right: -10px;
     display: flex;
     flex-direction: column;
     gap: 2px;
@@ -308,6 +433,13 @@
     border: 1px solid var(--pt-navy);
     border-radius: 6px 0 0 6px;
     z-index: 3;
+    opacity: 0.7;
+}
+
+.pt-overlay-dock.is-open,
+.pt-overlay-dock:has(.is-hot) {
+    opacity: 1;
+    right: 0;
 }
 
 .pt-overlay-dock span,
@@ -333,32 +465,33 @@
 
 .pt-overlay {
     position: absolute;
-    top: 78px;
-    right: 28px;
-    width: 320px;
+    top: 72px;
+    right: 36px;
+    width: 420px;
     height: calc(100% - 96px);
+    max-height: 420px;
     display: flex;
     flex-direction: column;
-    background: rgba(255, 255, 255, 0.82);
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
+    background: rgba(255, 255, 255, 0.78);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
     border: 1px solid rgba(3, 45, 96, 0.35);
-    border-radius: 12px;
+    border-radius: 0.875rem;
     box-shadow: 0 18px 45px rgba(0, 0, 0, 0.22);
     overflow: hidden;
     z-index: 2;
-    animation: pt-fade-in 280ms ease;
+    opacity: 0;
+    transform: translateX(14px);
+    pointer-events: none;
+    transition:
+        opacity 280ms ease,
+        transform 280ms ease;
 }
 
-@keyframes pt-fade-in {
-    from {
-        opacity: 0;
-        transform: translateX(12px);
-    }
-    to {
-        opacity: 1;
-        transform: none;
-    }
+.pt-overlay.is-open {
+    opacity: 1;
+    transform: none;
+    pointer-events: auto;
 }
 
 .pt-overlay-bar {
@@ -367,6 +500,35 @@
     gap: 8px;
     padding: 8px 10px;
     border-bottom: 1px solid var(--pt-border);
+}
+
+.pt-overlay-brand {
+    flex: 0 0 auto;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--pt-navy);
+}
+
+.pt-overlay-pills {
+    display: flex;
+    gap: 6px;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--pt-border);
+}
+
+.pt-overlay-pills span {
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: #f3f3f3;
+    color: var(--pt-muted);
+    font-size: 10px;
+    font-weight: 600;
+}
+
+.pt-overlay-pills span.is-active {
+    background: var(--pt-soft);
+    color: var(--pt-blue-dark);
 }
 
 .pt-overlay-search {
@@ -412,6 +574,8 @@
     gap: 10px;
     padding: 10px;
     overflow: auto;
+    flex: 1;
+    min-height: 0;
 }
 
 .pt-info-card {
@@ -452,6 +616,8 @@
     padding: 6px 0;
     list-style: none;
     overflow: auto;
+    flex: 1;
+    min-height: 0;
 }
 
 .pt-overlay-list li {
@@ -461,8 +627,51 @@
     padding: 7px 12px;
 }
 
+.pt-obj-name {
+    flex: 1;
+    min-width: 0;
+}
+
+.pt-obj-badges {
+    display: flex;
+    gap: 3px;
+    margin-left: auto;
+}
+
+.pt-obj-badge {
+    width: 16px;
+    height: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.25rem;
+    font-size: 10px;
+    font-weight: 600;
+    font-style: normal;
+    line-height: 1;
+    border: 1px solid transparent;
+}
+
+.pt-obj-badge.is-q {
+    color: #0b5cab;
+    background: #eaf3fc;
+    border-color: #cfe3f7;
+}
+
+.pt-obj-badge.is-c {
+    color: #1b6b39;
+    background: #ebf6ee;
+    border-color: #cce8d5;
+}
+
+.pt-obj-badge.is-u {
+    color: #a85b15;
+    background: #fdf1e3;
+    border-color: #f6dcbd;
+}
+
 .pt-overlay-list li.is-hot {
-    background: #eef4ff;
+    background: var(--pt-soft);
     color: var(--pt-blue-dark);
     font-weight: 600;
 }
@@ -470,7 +679,9 @@
 /* ── Toolkit shell ───────────────────────────────────────── */
 
 .pt-toolkit {
-    display: flex;
+    display: grid;
+    grid-template-columns: 168px 1fr;
+    grid-template-rows: 1fr auto;
     width: 100%;
     height: 100%;
     background: var(--pt-white);
@@ -479,36 +690,14 @@
 .pt-nav {
     display: flex;
     flex-direction: column;
-    width: 168px;
-    flex: 0 0 168px;
-    padding: 8px 8px 10px;
+    grid-row: 1;
+    padding: 10px 6px 10px;
     background: #f7f7f7;
     border-right: 1px solid var(--pt-border);
 }
 
-.pt-nav-brand {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 6px 8px 10px;
-    font-weight: 700;
-    font-size: 13px;
-}
-
-.pt-beta {
-    padding: 1px 6px;
-    border-radius: 999px;
-    background: #f2f2f2;
-    border: 1px solid var(--pt-border);
-    color: var(--pt-muted);
-    font-size: 9px;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-}
-
 .pt-nav-group {
-    margin-bottom: 8px;
+    margin-bottom: 10px;
 }
 
 .pt-nav-group p {
@@ -529,7 +718,7 @@
     color: var(--pt-text);
     font: inherit;
     padding: 5px 8px;
-    border-radius: 4px;
+    border-radius: 0;
     text-align: left;
 }
 
@@ -541,28 +730,32 @@
     cursor: pointer;
 }
 
+.pt-nav-item:hover,
 .pt-nav-item.is-active {
-    background: #eef4ff;
-    color: var(--pt-blue-dark);
-    font-weight: 600;
+    box-shadow: inset 2px 0 0 var(--pt-blue);
 }
 
-.pt-nav-agent {
-    margin-top: auto;
+.pt-nav-item.is-active {
+    color: var(--pt-text);
+    font-weight: 600;
 }
 
 .pt-toolkit-main {
     display: flex;
     flex-direction: column;
     min-width: 0;
-    flex: 1;
+    grid-row: 1;
+}
+
+.pt-toolkit > .pt-util-footer {
+    grid-column: 1 / -1;
 }
 
 .pt-context {
     display: flex;
     align-items: center;
     gap: 8px;
-    height: 40px;
+    height: 2.5rem;
     padding: 0 12px;
     border-bottom: 1px solid var(--pt-border);
     background: var(--pt-white);
@@ -570,6 +763,20 @@
 
 .pt-context-name {
     font-weight: 700;
+}
+
+.pt-beta {
+    display: inline-block;
+    padding: 0.1rem 0.5rem;
+    border-radius: 0.4rem;
+    background: #eef4ff;
+    color: var(--pt-error);
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    transform: rotate(-8deg);
+    box-shadow: 0 1px 2px #0176d3;
 }
 
 .pt-tab {
@@ -604,7 +811,7 @@
 
 .pt-agent-toggle.is-active {
     color: var(--pt-blue);
-    background: #eef4ff;
+    background: var(--pt-soft);
 }
 
 .pt-canvas {
@@ -618,6 +825,36 @@
     min-width: 0;
 }
 
+.pt-util-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex: 0 0 1.5rem;
+    height: 1.5rem;
+    padding: 0 10px;
+    background: var(--pt-navy);
+    color: #fff;
+    font-size: 10px;
+}
+
+.pt-keycaps {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.pt-key {
+    display: inline-block;
+    padding: 1px 5px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.15);
+    color: #fff;
+    font-family: var(--pt-mono);
+    font-size: 0.85em;
+    font-weight: 600;
+}
+
 /* ── SOQL ────────────────────────────────────────────────── */
 
 .pt-soql {
@@ -626,11 +863,46 @@
     background: var(--pt-white);
 }
 
+.pt-soql-pagehead {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--pt-border);
+}
+
+.pt-soql-icon {
+    display: grid;
+    place-items: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 4px;
+    background: #e0f3fe;
+    color: var(--pt-blue-dark);
+}
+
+.pt-soql-pagehead p {
+    margin: 0;
+    color: var(--pt-muted);
+    font-size: 10px;
+    font-weight: 600;
+}
+
+.pt-soql-pagehead h3 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.pt-soql-pagehead .pt-run {
+    margin-left: auto;
+}
+
 .pt-soql-toolbar {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 8px 12px;
+    padding: 6px 12px;
     border-bottom: 1px solid var(--pt-border);
     color: var(--pt-muted);
 }
@@ -666,28 +938,110 @@
     color: #969492;
 }
 
+.pt-soql-empty {
+    padding: 18px 12px;
+    color: var(--pt-muted);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 220ms ease;
+}
+
+.pt-soql-empty.is-open {
+    opacity: 1;
+}
+
+.pt-soql-outcome {
+    position: relative;
+    min-height: 96px;
+    padding: 8px;
+}
+
+.pt-soql-outcome .pt-soql-empty {
+    position: absolute;
+    inset: 8px;
+}
+
 .pt-results {
     width: 100%;
     border-collapse: collapse;
     font-size: 11px;
+    border: 1px solid var(--pt-border-legacy);
+    border-radius: 4px;
+    overflow: hidden;
 }
 
 .pt-results th,
 .pt-results td {
     padding: 6px 12px;
-    border-bottom: 1px solid var(--pt-border);
+    border-bottom: 1px solid var(--pt-border-legacy);
     text-align: left;
 }
 
 .pt-results th {
-    background: #f3f3f3;
+    background: #f8f7f6;
     color: var(--pt-muted);
     font-weight: 600;
 }
 
-.pt-soql-empty {
-    padding: 18px 12px;
-    color: var(--pt-muted);
+.pt-results tbody tr {
+    opacity: 0;
+    transform: translateY(6px);
+}
+
+.pt-results:not(.is-open) {
+    height: 0;
+    overflow: hidden;
+    visibility: hidden;
+}
+
+.pt-results.is-open tbody tr {
+    animation: pt-row-in 280ms ease both;
+}
+
+.pt-results.is-open tbody tr:nth-child(2) {
+    animation-delay: 70ms;
+}
+
+.pt-results.is-open tbody tr:nth-child(3) {
+    animation-delay: 140ms;
+}
+
+@keyframes pt-row-in {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+.pt-fade-panel {
+    opacity: 0;
+    transform: translateY(6px);
+    pointer-events: none;
+    transition:
+        opacity 280ms ease,
+        transform 280ms ease;
+}
+
+.pt-fade-panel.is-open {
+    opacity: 1;
+    transform: none;
+    pointer-events: auto;
+}
+
+.pt-vscode-files .is-muted {
+    display: none;
+}
+
+.pt-vscode-files .is-muted.is-open {
+    display: block;
+}
+
+.pt-vscode-files .pt-fade-panel:not(.is-open) {
+    display: none;
 }
 
 /* ── Metadata ────────────────────────────────────────────── */
@@ -745,8 +1099,14 @@
 }
 
 .pt-meta-detail {
+    position: relative;
     flex: 1;
     padding: 14px 16px;
+}
+
+.pt-meta-detail .pt-soql-empty {
+    position: absolute;
+    inset: 14px 16px auto;
 }
 
 .pt-meta-detail header {
@@ -936,11 +1296,22 @@
     left: 50%;
     z-index: 3;
     width: min(420px, calc(100% - 24px));
-    transform: translateX(-50%);
+    transform: translateX(-50%) translateY(-8px);
     border: 1px solid #3c3c3c;
     border-radius: 6px;
     background: #252526;
     box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+    opacity: 0;
+    pointer-events: none;
+    transition:
+        opacity 240ms ease,
+        transform 240ms ease;
+}
+
+.pt-palette.is-open {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+    pointer-events: auto;
 }
 
 .pt-palette-input {
@@ -995,33 +1366,67 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 10px 18px;
+    height: 48px;
+    padding: 0 20px;
     background: #fff;
     border-bottom: 1px solid #e4e6e8;
 }
 
-.pt-acme-header strong {
+.pt-acme-logo {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
     font-size: 15px;
+    font-weight: 700;
     letter-spacing: -0.03em;
+    color: #14233f;
+}
+
+.pt-acme-mark {
+    display: grid;
+    place-items: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+    background: #14233f;
+    color: #fff;
+    font-size: 11px;
+    font-style: normal;
+    font-weight: 700;
 }
 
 .pt-acme-header nav {
     display: flex;
-    gap: 14px;
+    gap: 16px;
     color: var(--pt-muted);
+    font-size: 12px;
 }
 
 .pt-acme-header .is-active {
-    color: var(--pt-navy);
+    color: #14233f;
     font-weight: 600;
 }
 
 .pt-acme-form {
     display: flex;
+    flex: 1;
+    align-items: flex-start;
+    padding: 22px 24px;
+    background:
+        linear-gradient(180deg, #f4f6f8 0%, #eef1f4 100%);
+}
+
+.pt-acme-form-card {
+    display: flex;
     flex-direction: column;
-    gap: 8px;
-    max-width: 420px;
-    padding: 18px 22px;
+    gap: 10px;
+    width: 100%;
+    max-width: 460px;
+    padding: 18px 20px 16px;
+    border: 1px solid #e4e6e8;
+    border-radius: 12px;
+    background: #fff;
+    box-shadow: 0 10px 28px rgba(16, 24, 40, 0.07);
 }
 
 .pt-acme-kicker {
@@ -1034,52 +1439,77 @@
 }
 
 .pt-acme-form h3 {
-    margin: 0 0 6px;
+    margin: 0;
     font-size: 20px;
     letter-spacing: -0.03em;
+    color: #14233f;
+}
+
+.pt-acme-lede {
+    margin: -2px 0 4px;
+    color: var(--pt-muted);
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.45;
+}
+
+.pt-form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
 }
 
 .pt-form-field {
     display: flex;
     flex-direction: column;
-    gap: 4px;
-    color: var(--pt-muted);
+    gap: 5px;
+    color: #5c5c5c;
     font-size: 11px;
     font-weight: 600;
 }
 
 .pt-form-field span {
-    min-height: 28px;
-    padding: 6px 8px;
-    border: 1px solid var(--pt-border);
+    display: flex;
+    align-items: center;
+    min-height: 34px;
+    padding: 7px 10px;
+    border: 1px solid var(--pt-border-legacy);
     border-radius: 6px;
     background: #fff;
     color: var(--pt-text);
     font-weight: 500;
 }
 
+.pt-form-field span.is-placeholder {
+    color: #969492;
+    font-weight: 400;
+}
+
 .pt-form-field.is-area span {
-    min-height: 56px;
+    align-items: flex-start;
+    min-height: 72px;
 }
 
 .pt-form-field.is-focus span {
     border-color: var(--pt-blue);
-    box-shadow: 0 0 0 3px rgba(1, 118, 211, 0.18);
-    animation: pt-pulse 0.7s ease-in-out 2;
+    box-shadow: 0 0 0 3px rgba(1, 118, 211, 0.16);
 }
 
 .pt-form-submit {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     align-self: flex-start;
-    margin-top: 6px;
-    padding: 7px 16px;
+    margin-top: 4px;
+    padding: 8px 14px;
     border-radius: 6px;
     background: var(--pt-navy);
     color: #fff;
     font-weight: 700;
 }
 
-.pt-form-submit.is-pulse {
-    animation: pt-pulse 0.6s ease-in-out 3;
+.pt-form-submit.is-sent {
+    background: var(--pt-success);
 }
 
 .pt-sidepanel {
@@ -1148,8 +1578,8 @@
 }
 
 .pt-bubble.is-assistant {
-    background: var(--pt-white);
-    border: 1px solid var(--pt-border);
+    background: #f3f3f3;
+    border: 0;
 }
 
 .pt-bubble.is-pending {
@@ -1163,28 +1593,58 @@
     display: flex;
     align-items: center;
     gap: 6px;
-    padding: 5px 8px;
-    border-radius: 6px;
-    background: #eef4ff;
-    color: var(--pt-blue-dark);
+    padding: 4px 8px;
+    border-left: 2px solid var(--pt-border-legacy);
+    color: var(--pt-muted);
+    font-family: var(--pt-mono);
     font-size: 11px;
+    font-style: italic;
 }
 
 .pt-tool.is-action {
-    background: #eef8f0;
+    border-left-color: var(--pt-success);
     color: var(--pt-success);
 }
 
 .pt-composer {
     display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin: 8px;
+    padding: 8px 10px 6px;
+    border: 1px solid var(--pt-border-legacy);
+    border-radius: 10px;
+    background: var(--pt-composer);
+    color: var(--pt-muted);
+}
+
+.pt-composer-model {
+    align-self: flex-start;
+    padding: 2px 8px;
+    border: 1px solid var(--pt-border-legacy);
+    border-radius: 6px;
+    background: #f3f2f2;
+    color: var(--pt-muted);
+    font-size: 10px;
+    font-weight: 600;
+}
+
+.pt-composer-row {
+    display: flex;
     align-items: center;
     justify-content: space-between;
-    margin: 8px;
-    padding: 7px 10px;
-    border: 1px solid var(--pt-border);
-    border-radius: 8px;
-    background: var(--pt-white);
-    color: var(--pt-muted);
+    gap: 8px;
+}
+
+.pt-composer-send {
+    display: grid;
+    place-items: center;
+    width: 24px;
+    height: 24px;
+    flex: 0 0 24px;
+    border-radius: 6px;
+    background: var(--pt-blue);
+    color: #fff;
 }
 
 /* ── Loading ─────────────────────────────────────────────── */
@@ -1220,14 +1680,43 @@
         display: none;
     }
 
+    .pt-toolkit {
+        grid-template-columns: 1fr;
+    }
+
     .pt-overlay {
         width: 240px;
         right: 12px;
     }
 
+    .pt-sidepanel-scene {
+        flex-direction: column;
+    }
+
+    .pt-acme-form {
+        padding: 12px 14px;
+    }
+
+    .pt-form-row {
+        grid-template-columns: 1fr;
+    }
+
     .pt-sidepanel {
-        width: 220px;
-        flex-basis: 220px;
+        width: 100%;
+        flex: 1 1 auto;
+        min-height: 170px;
+        border-left: 0;
+        border-top: 1px solid var(--pt-border);
+    }
+
+    .pt-cursor {
+        display: none;
+    }
+}
+
+@media (pointer: coarse) {
+    .pt-cursor {
+        display: none;
     }
 }
 
@@ -1236,9 +1725,32 @@
     .pt-pulse,
     .pt-run.is-pulse,
     .pt-form-field.is-focus span,
-    .pt-form-submit.is-pulse,
     .pt-spinner,
-    .pt-overlay {
-        animation: none;
+    .pt-overlay,
+    .pt-palette,
+    .pt-copy-fade,
+    .pt-view-layer.is-enter,
+    .pt-view-layer.is-exit,
+    .pt-cursor,
+    .pt-cursor.is-click::after,
+    .pt-fade-panel,
+    .pt-results tbody tr,
+    .pt-soql-empty,
+    .pt-stage,
+    .pt-stage[data-loop-gen] {
+        animation: none !important;
+        transition: none !important;
+    }
+
+    .pt-results.is-open tbody tr,
+    .pt-fade-panel.is-open,
+    .pt-overlay.is-open,
+    .pt-palette.is-open {
+        opacity: 1;
+        transform: none;
+    }
+
+    .pt-cursor {
+        display: none;
     }
 }

--- a/apps/ui/src/product-tour/slide-scene.ts
+++ b/apps/ui/src/product-tour/slide-scene.ts
@@ -13,6 +13,8 @@ import {
     STREAM_MS,
     inRange,
     typed,
+    typedToward,
+    type CursorTarget,
     type FormFocus,
     type PalettePhase,
 } from './flow-scene.ts';
@@ -187,11 +189,11 @@ function agentLoop(now: number): { play: SlidePlay; loopMs: number } {
             assistant,
             streaming: inRange(now, streamAt, submitAt),
             formFocus,
-            formName: now >= nameAt ? FORM_NAME : '',
-            formEmail: now >= emailAt ? FORM_EMAIL : '',
-            formOrder: now >= orderAt ? FORM_ORDER : '',
-            formMessage: now >= messageAt ? FORM_MESSAGE : '',
-            formSubmitPulse: inRange(now, submitAt, submitAt + 900),
+            formName: typedToward(FORM_NAME, nameAt, emailAt, now),
+            formEmail: typedToward(FORM_EMAIL, emailAt, orderAt, now),
+            formOrder: typedToward(FORM_ORDER, orderAt, messageAt, now),
+            formMessage: typedToward(FORM_MESSAGE, messageAt, submitAt, now),
+            formSubmitPulse: false,
         },
     };
 }
@@ -215,4 +217,16 @@ export function slidePlayForElapsed(id: TourSlideId, ms: number): SlidePlay {
 
 export function completedSlidePlay(id: TourSlideId): SlidePlay {
     return slidePlayForElapsed(id, slideLoopMs(id) - HOLD_MS + 200);
+}
+
+export function cursorTargetForPlay(play: SlidePlay): CursorTarget {
+    if (play.formFocus) return null;
+    if (play.sendPulse) return 'run';
+    if (play.soqlCaret) return 'soql';
+    if (play.editorCaret) return 'editor';
+    if (play.paletteCaret || play.paletteOpen) return 'palette';
+    if (play.vscodeHot) return 'dock-vscode';
+    if (play.overlayCaret || play.overlayOpen) return 'overlay-search';
+    if (play.metaCaret) return 'meta-filter';
+    return null;
 }

--- a/apps/ui/src/product-tour/wireframes.tsx
+++ b/apps/ui/src/product-tour/wireframes.tsx
@@ -1,8 +1,9 @@
-import type { ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import {
     Bell,
     Bot,
     Building2,
+    Check,
     ChevronDown,
     ChevronRight,
     Cloud,
@@ -12,9 +13,7 @@ import {
     FileCode2,
     Filter,
     Folder,
-    Globe,
     LayoutGrid,
-    MousePointerClick,
     Package,
     PanelRight,
     Pencil,
@@ -25,11 +24,17 @@ import {
     Settings,
     Share2,
     SquareTerminal,
-    Table2,
 } from 'lucide-react';
-import type { FlowScene, FormFocus, PalettePhase } from './flow-scene';
+import {
+    VIEW_FADE_MS,
+    type FlowScene,
+    type FlowView,
+    type FormFocus,
+    type PalettePhase,
+} from './flow-scene';
 import { AUTHORED_HEIGHT, AUTHORED_WIDTH, type TourSlideId } from './slides';
-import { completedSlidePlay, type SlidePlay } from './slide-scene';
+import { completedSlidePlay, cursorTargetForPlay, type SlidePlay } from './slide-scene';
+import { TourCursor } from './TourCursor';
 import { useTourNav } from './tour-nav';
 
 function classNames(...parts: Array<string | false | null | undefined>): string {
@@ -38,6 +43,31 @@ function classNames(...parts: Array<string | false | null | undefined>): string 
 
 function Caret(): ReactNode {
     return <span className="pt-caret" aria-hidden />;
+}
+
+function BetaBadge(): ReactNode {
+    return <span className="pt-beta">Beta</span>;
+}
+
+function UtilityFooter({ org = 'Acme' }: { org?: string }): ReactNode {
+    return (
+        <footer className="pt-util-footer">
+            <span>{org}</span>
+            <span className="pt-keycaps">
+                <kbd className="pt-key">⌘K</kbd>
+            </span>
+        </footer>
+    );
+}
+
+function ObjectBadges(): ReactNode {
+    return (
+        <span className="pt-obj-badges" aria-hidden>
+            <i className="pt-obj-badge is-q">Q</i>
+            <i className="pt-obj-badge is-c">C</i>
+            <i className="pt-obj-badge is-u">U</i>
+        </span>
+    );
 }
 
 function SalesforceHeader(): ReactNode {
@@ -105,6 +135,7 @@ function OverlayDock({
             <button
                 type="button"
                 className={classNames('pt-overlay-soql', vscodeHot && 'is-hot')}
+                data-pt-target="dock-vscode"
                 onClick={onOpenEditor}
                 aria-label="Open VS Code Editor"
             >
@@ -125,6 +156,7 @@ function OverlayDock({
 function OverlayPanel({
     search,
     caret,
+    overlayOpen,
     soqlHot,
     vscodeHot,
     onOpenSoql,
@@ -132,6 +164,7 @@ function OverlayPanel({
 }: {
     search: string;
     caret: boolean;
+    overlayOpen: boolean;
     soqlHot?: boolean;
     vscodeHot?: boolean;
     onOpenSoql?: () => void;
@@ -142,9 +175,13 @@ function OverlayPanel({
         name => !q || name.toLowerCase().includes(q)
     );
     return (
-        <aside className="pt-overlay" aria-label="Workbench overlay">
+        <aside
+            className={classNames('pt-overlay', overlayOpen && 'is-open')}
+            aria-label="Workbench overlay"
+        >
             <div className="pt-overlay-bar">
-                <span className="pt-overlay-search">
+                <strong className="pt-overlay-brand">Workbench</strong>
+                <span className="pt-overlay-search" data-pt-target="overlay-search">
                     <Filter size={11} strokeWidth={2} aria-hidden />
                     <span className="pt-overlay-search-value">
                         {search || 'Search Object, Profiles and more'}
@@ -171,6 +208,11 @@ function OverlayPanel({
                     <Share2 size={12} strokeWidth={2} aria-hidden />
                 </span>
             </div>
+            <div className="pt-overlay-pills" aria-hidden>
+                <span className={search ? undefined : 'is-active'}>Org</span>
+                <span className={search ? 'is-active' : undefined}>Objects</span>
+                <span>Profiles</span>
+            </div>
             <div className="pt-overlay-meta">
                 48 objects • Refreshed just now
                 <RefreshCw size={11} strokeWidth={2} aria-hidden />
@@ -180,7 +222,8 @@ function OverlayPanel({
                     {objects.map(name => (
                         <li key={name} className={name === 'Account' ? 'is-hot' : undefined}>
                             <Building2 size={12} strokeWidth={2} aria-hidden />
-                            {name}
+                            <span className="pt-obj-name">{name}</span>
+                            <ObjectBadges />
                         </li>
                     ))}
                 </ul>
@@ -217,6 +260,7 @@ function OverlayPanel({
                     </fieldset>
                 </div>
             )}
+            <UtilityFooter />
         </aside>
     );
 }
@@ -283,16 +327,15 @@ function SalesforcePage({
                 onOpenSoql={interactive ? () => goToSlide?.('soql') : undefined}
                 onOpenEditor={interactive ? () => goToSlide?.('editor') : undefined}
             />
-            {overlayOpen ? (
-                <OverlayPanel
-                    search={overlaySearch}
-                    caret={caret}
-                    soqlHot={soqlHot}
-                    vscodeHot={vscodeHot}
-                    onOpenSoql={interactive ? () => goToSlide?.('soql') : undefined}
-                    onOpenEditor={interactive ? () => goToSlide?.('editor') : undefined}
-                />
-            ) : null}
+            <OverlayPanel
+                search={overlaySearch}
+                caret={caret}
+                overlayOpen={overlayOpen}
+                soqlHot={soqlHot}
+                vscodeHot={vscodeHot}
+                onOpenSoql={interactive ? () => goToSlide?.('soql') : undefined}
+                onOpenEditor={interactive ? () => goToSlide?.('editor') : undefined}
+            />
         </div>
     );
 }
@@ -305,31 +348,42 @@ const NAV_ITEMS: Array<{
         group: 'Data',
         items: [
             { id: 'soql', label: 'SOQL Explorer', icon: <Database size={12} strokeWidth={2} /> },
-            { id: 'overlay', label: 'Record Viewer', icon: <Table2 size={12} strokeWidth={2} /> },
         ],
     },
     {
         group: 'Code',
         items: [
-            { id: 'editor', label: 'VS Code', icon: <SquareTerminal size={12} strokeWidth={2} /> },
-            { id: 'soql', label: 'API Explorer', icon: <Globe size={12} strokeWidth={2} /> },
+            {
+                id: 'editor',
+                label: 'VS Code Editor',
+                icon: <SquareTerminal size={12} strokeWidth={2} />,
+            },
+        ],
+    },
+    {
+        group: 'Agentforce',
+        items: [
+            { id: 'agent', label: 'Next Gen Agent', icon: <Bot size={12} strokeWidth={2} /> },
         ],
     },
     {
         group: 'Admin',
         items: [
-            { id: 'workbench', label: 'Metadata', icon: <Package size={12} strokeWidth={2} /> },
-            { id: 'workbench', label: 'SObject', icon: <Building2 size={12} strokeWidth={2} /> },
+            {
+                id: 'workbench',
+                label: 'Metadata Explorer',
+                icon: <Package size={12} strokeWidth={2} />,
+            },
         ],
     },
 ];
 
 const ACTIVE_NAV_LABEL: Record<TourSlideId, string> = {
-    overlay: 'Record Viewer',
+    overlay: 'SOQL Explorer',
     soql: 'SOQL Explorer',
-    editor: 'VS Code',
-    workbench: 'Metadata',
-    agent: 'Agent',
+    editor: 'VS Code Editor',
+    workbench: 'Metadata Explorer',
+    agent: 'Next Gen Agent',
 };
 
 function ToolkitShell({
@@ -351,10 +405,6 @@ function ToolkitShell({
     return (
         <div className={classNames('pt-toolkit', agentOpen && 'is-agent')}>
             <aside className="pt-nav">
-                <div className="pt-nav-brand">
-                    <span>Workbench</span>
-                    <span className="pt-beta">Beta</span>
-                </div>
                 {NAV_ITEMS.map(section => (
                     <div key={section.group} className="pt-nav-group">
                         <p>{section.group}</p>
@@ -374,22 +424,11 @@ function ToolkitShell({
                         ))}
                     </div>
                 ))}
-                <button
-                    type="button"
-                    className={classNames(
-                        'pt-nav-item pt-nav-agent',
-                        activeApp === 'agent' && 'is-active'
-                    )}
-                    onClick={interactive ? () => goToSlide?.('agent') : undefined}
-                >
-                    <Bot size={12} strokeWidth={2} />
-                    Agent
-                </button>
             </aside>
             <div className="pt-toolkit-main">
                 <header className="pt-context">
                     <span className="pt-context-name">Workbench</span>
-                    <span className="pt-beta">Beta</span>
+                    <BetaBadge />
                     <span className="pt-tab is-active">{tabLabel}</span>
                     <span className="pt-context-end">
                         <Settings size={13} strokeWidth={1.75} aria-hidden />
@@ -408,6 +447,7 @@ function ToolkitShell({
                     {agentOpen ? agent : null}
                 </div>
             </div>
+            <UtilityFooter />
         </div>
     );
 }
@@ -425,19 +465,34 @@ function SoqlBody({
 }): ReactNode {
     return (
         <div className="pt-soql">
-            <div className="pt-soql-toolbar">
-                <span>Acme · API 62.0</span>
-                <span className={classNames('pt-run', sendPulse && 'is-pulse')}>
+            <div className="pt-soql-pagehead">
+                <span className="pt-soql-icon" aria-hidden>
+                    <Database size={16} strokeWidth={1.75} />
+                </span>
+                <div>
+                    <p>Tools</p>
+                    <h3>SOQL Explorer</h3>
+                </div>
+                <span
+                    className={classNames('pt-run', sendPulse && 'is-pulse')}
+                    data-pt-target="run"
+                >
                     <Play size={11} strokeWidth={2.2} aria-hidden />
                     Run
                 </span>
             </div>
-            <pre className="pt-soql-editor">
+            <div className="pt-soql-toolbar">
+                <span>Acme · API 62.0</span>
+            </div>
+            <pre className="pt-soql-editor" data-pt-target="soql">
                 {draft || <span className="pt-placeholder">SELECT Id, Name FROM Account</span>}
                 {caret ? <Caret /> : null}
             </pre>
-            {resultsVisible ? (
-                <table className="pt-results">
+            <div className="pt-soql-outcome">
+                <div className={classNames('pt-soql-empty', !resultsVisible && 'is-open')}>
+                    Run a query to see records
+                </div>
+                <table className={classNames('pt-results', resultsVisible && 'is-open')}>
                     <thead>
                         <tr>
                             <th>Id</th>
@@ -463,9 +518,7 @@ function SoqlBody({
                         </tr>
                     </tbody>
                 </table>
-            ) : (
-                <div className="pt-soql-empty">Run a query to see records</div>
-            )}
+            </div>
         </div>
     );
 }
@@ -486,7 +539,7 @@ function MetadataBody({
     return (
         <div className="pt-meta">
             <div className="pt-meta-tree">
-                <div className="pt-meta-filter">
+                <div className="pt-meta-filter" data-pt-target="meta-filter">
                     <Search size={11} strokeWidth={2} aria-hidden />
                     <span>
                         {filter || 'Filter metadata'}
@@ -520,40 +573,39 @@ function MetadataBody({
                 </div>
             </div>
             <div className="pt-meta-detail">
-                {selected ? (
-                    <>
-                        <header>
-                            <Package size={14} strokeWidth={1.75} />
-                            Account
-                            <span className="pt-pill">CustomObject</span>
-                        </header>
-                        <dl>
-                            <div>
-                                <dt>Label</dt>
-                                <dd>Account</dd>
-                            </div>
-                            <div>
-                                <dt>API Name</dt>
-                                <dd>Account</dd>
-                            </div>
-                            <div>
-                                <dt>Fields</dt>
-                                <dd>186</dd>
-                            </div>
-                            <div>
-                                <dt>Last modified</dt>
-                                <dd>Alex Rivera · 2h ago</dd>
-                            </div>
-                        </dl>
-                        <div className="pt-skel-block">
-                            <i />
-                            <i />
-                            <i />
+                <div className={classNames('pt-fade-panel', selected && 'is-open')}>
+                    <header>
+                        <Package size={14} strokeWidth={1.75} />
+                        Account
+                        <span className="pt-pill">CustomObject</span>
+                    </header>
+                    <dl>
+                        <div>
+                            <dt>Label</dt>
+                            <dd>Account</dd>
                         </div>
-                    </>
-                ) : (
-                    <p className="pt-soql-empty">Select a component to inspect it</p>
-                )}
+                        <div>
+                            <dt>API Name</dt>
+                            <dd>Account</dd>
+                        </div>
+                        <div>
+                            <dt>Fields</dt>
+                            <dd>186</dd>
+                        </div>
+                        <div>
+                            <dt>Last modified</dt>
+                            <dd>Alex Rivera · 2h ago</dd>
+                        </div>
+                    </dl>
+                    <div className="pt-skel-block">
+                        <i />
+                        <i />
+                        <i />
+                    </div>
+                </div>
+                <p className={classNames('pt-soql-empty', !selected && 'is-open')}>
+                    Select a component to inspect it
+                </p>
             </div>
         </div>
     );
@@ -597,19 +649,18 @@ function EditorBody({
             <div className="pt-vscode-files">
                 <p>FORCE-APP</p>
                 <span className="pt-tree-row">force-app/main/default/lwc</span>
-                {bundleReady ? (
-                    <>
-                        <span className="pt-tree-row is-folder">accountHighlight</span>
-                        <span className="pt-tree-row is-file is-active">
-                            {dirty ? <i className="pt-dirty" aria-hidden /> : null}
-                            accountHighlight.html
-                        </span>
-                        <span className="pt-tree-row is-file">accountHighlight.js</span>
-                        <span className="pt-tree-row is-file">accountHighlight.js-meta.xml</span>
-                    </>
-                ) : (
-                    <span className="pt-tree-row is-muted">No components yet</span>
-                )}
+                <span className={classNames('pt-tree-row is-muted', !bundleReady && 'is-open')}>
+                    No components yet
+                </span>
+                <div className={classNames('pt-fade-panel', bundleReady && 'is-open')}>
+                    <span className="pt-tree-row is-folder">accountHighlight</span>
+                    <span className="pt-tree-row is-file is-active">
+                        {dirty ? <i className="pt-dirty" aria-hidden /> : null}
+                        accountHighlight.html
+                    </span>
+                    <span className="pt-tree-row is-file">accountHighlight.js</span>
+                    <span className="pt-tree-row is-file">accountHighlight.js-meta.xml</span>
+                </div>
             </div>
             <div className="pt-vscode-main">
                 <div className="pt-vscode-tabs">
@@ -622,7 +673,7 @@ function EditorBody({
                         <span className="pt-vscode-tab is-empty">Welcome</span>
                     )}
                 </div>
-                <div className="pt-vscode-editor">
+                <div className="pt-vscode-editor" data-pt-target="editor">
                     {lines.map((line, i) => (
                         <div key={`ln-${i}`} className="pt-code-line">
                             <em>{i + 1}</em>
@@ -640,25 +691,27 @@ function EditorBody({
                         Ln {lines.length}, Col {lastLine.length + 1}
                     </span>
                 </footer>
-                {paletteOpen ? (
-                    <div className="pt-palette" aria-label="Command palette">
-                        <div className="pt-palette-input">
-                            <Search size={12} strokeWidth={2} aria-hidden />
-                            <span>
-                                {paletteValue}
-                                {paletteCaret ? <Caret /> : null}
-                            </span>
-                        </div>
-                        {palettePhase === 'command' ? (
-                            <ul>
-                                <li className="is-active">SFDX: Create Lightning Web Component</li>
-                                <li>SFDX: Create Apex Class</li>
-                            </ul>
-                        ) : (
-                            <p className="pt-palette-hint">New Lightning web component</p>
-                        )}
+                <div
+                    className={classNames('pt-palette', paletteOpen && 'is-open')}
+                    aria-label="Command palette"
+                    data-pt-target="palette"
+                >
+                    <div className="pt-palette-input">
+                        <Search size={12} strokeWidth={2} aria-hidden />
+                        <span>
+                            {paletteValue}
+                            {paletteCaret ? <Caret /> : null}
+                        </span>
                     </div>
-                ) : null}
+                    {palettePhase === 'command' ? (
+                        <ul>
+                            <li className="is-active">SFDX: Create Lightning Web Component</li>
+                            <li>SFDX: Create Apex Class</li>
+                        </ul>
+                    ) : (
+                        <p className="pt-palette-hint">New Lightning web component</p>
+                    )}
+                </div>
             </div>
         </div>
     );
@@ -669,8 +722,37 @@ const FORM_TOOL: Record<Exclude<FormFocus, null>, string> = {
     email: 'browser_fill · Email',
     order: 'browser_fill · Order #',
     message: 'browser_fill · Message',
-    submit: 'Clicked Submit',
+    submit: 'Submitted the form',
 };
+
+function FormField({
+    label,
+    value,
+    placeholder,
+    focus,
+    target,
+    area,
+}: {
+    label: string;
+    value: string;
+    placeholder: string;
+    focus: boolean;
+    target: string;
+    area?: boolean;
+}): ReactNode {
+    return (
+        <label
+            className={classNames('pt-form-field', area && 'is-area', focus && 'is-focus')}
+            data-pt-target={target}
+        >
+            {label}
+            <span className={classNames(!value && 'is-placeholder')}>
+                {value || placeholder}
+                {focus ? <Caret /> : null}
+            </span>
+        </label>
+    );
+}
 
 function SidePanelForm({
     assistant,
@@ -680,7 +762,6 @@ function SidePanelForm({
     formEmail,
     formOrder,
     formMessage,
-    formSubmitPulse,
 }: {
     assistant: string;
     streaming?: boolean;
@@ -689,13 +770,18 @@ function SidePanelForm({
     formEmail: string;
     formOrder: string;
     formMessage: string;
-    formSubmitPulse: boolean;
 }): ReactNode {
+    const sent = formFocus === 'submit';
     return (
         <div className="pt-sidepanel-scene">
             <div className="pt-acme-site">
                 <header className="pt-acme-header">
-                    <strong>Acme</strong>
+                    <span className="pt-acme-logo">
+                        <i className="pt-acme-mark" aria-hidden>
+                            A
+                        </i>
+                        Acme
+                    </span>
                     <nav>
                         <span>Help Center</span>
                         <span className="is-active">Contact</span>
@@ -703,48 +789,61 @@ function SidePanelForm({
                     </nav>
                 </header>
                 <main className="pt-acme-form">
-                    <p className="pt-acme-kicker">Support</p>
-                    <h3>How can we help?</h3>
-                    <label
-                        className={classNames('pt-form-field', formFocus === 'name' && 'is-focus')}
-                    >
-                        Name
-                        <span>{formName || 'Full name'}</span>
-                    </label>
-                    <label
-                        className={classNames('pt-form-field', formFocus === 'email' && 'is-focus')}
-                    >
-                        Email
-                        <span>{formEmail || 'you@company.com'}</span>
-                    </label>
-                    <label
-                        className={classNames('pt-form-field', formFocus === 'order' && 'is-focus')}
-                    >
-                        Order #<span>{formOrder || 'e.g. 1842'}</span>
-                    </label>
-                    <label
-                        className={classNames(
-                            'pt-form-field is-area',
-                            formFocus === 'message' && 'is-focus'
-                        )}
-                    >
-                        Message
-                        <span>{formMessage || 'Describe the issue'}</span>
-                    </label>
-                    <span
-                        className={classNames(
-                            'pt-form-submit',
-                            (formFocus === 'submit' || formSubmitPulse) && 'is-pulse'
-                        )}
-                    >
-                        Submit
-                    </span>
+                    <div className="pt-acme-form-card">
+                        <p className="pt-acme-kicker">Support</p>
+                        <h3>Contact support</h3>
+                        <p className="pt-acme-lede">Tell us about the issue and we will get back to you.</p>
+                        <div className="pt-form-row">
+                            <FormField
+                                label="Name"
+                                value={formName}
+                                placeholder="Full name"
+                                focus={formFocus === 'name'}
+                                target="form-name"
+                            />
+                            <FormField
+                                label="Email"
+                                value={formEmail}
+                                placeholder="you@company.com"
+                                focus={formFocus === 'email'}
+                                target="form-email"
+                            />
+                        </div>
+                        <FormField
+                            label="Order number"
+                            value={formOrder}
+                            placeholder="e.g. 1842"
+                            focus={formFocus === 'order'}
+                            target="form-order"
+                        />
+                        <FormField
+                            label="Message"
+                            value={formMessage}
+                            placeholder="Describe the issue"
+                            focus={formFocus === 'message'}
+                            target="form-message"
+                            area
+                        />
+                        <span
+                            className={classNames('pt-form-submit', sent && 'is-sent')}
+                            data-pt-target="form-submit"
+                        >
+                            {sent ? (
+                                <>
+                                    <Check size={12} strokeWidth={2.4} aria-hidden />
+                                    Sent
+                                </>
+                            ) : (
+                                'Submit ticket'
+                            )}
+                        </span>
+                    </div>
                 </main>
             </div>
-            <aside className="pt-sidepanel" aria-label="Workbench side panel">
+            <aside className="pt-sidepanel" aria-label="Next Gen Agent">
                 <header>
                     <Bot size={13} strokeWidth={1.75} />
-                    Workbench
+                    Next Gen Agent
                     <Settings size={12} strokeWidth={1.75} aria-hidden />
                 </header>
                 <div className="pt-agent-thread">
@@ -756,7 +855,7 @@ function SidePanelForm({
                             className={classNames('pt-tool', formFocus === 'submit' && 'is-action')}
                         >
                             {formFocus === 'submit' ? (
-                                <MousePointerClick size={11} strokeWidth={2} />
+                                <Check size={11} strokeWidth={2} />
                             ) : (
                                 <Pencil size={11} strokeWidth={2} />
                             )}
@@ -776,8 +875,13 @@ function SidePanelForm({
                     )}
                 </div>
                 <div className="pt-composer">
-                    <span>Ask the agent to fill this form…</span>
-                    <Send size={12} strokeWidth={2} aria-hidden />
+                    <span className="pt-composer-model">GPT-4.1</span>
+                    <div className="pt-composer-row">
+                        <span>Ask the agent to fill this form…</span>
+                        <span className="pt-composer-send" aria-hidden>
+                            <Send size={12} strokeWidth={2} />
+                        </span>
+                    </div>
                 </div>
             </aside>
         </div>
@@ -793,31 +897,9 @@ function LoadingOverlay({ label }: { label: 'editor' | 'soql' }): ReactNode {
     );
 }
 
-export function HomeFlowWireframe({ scene }: { scene: FlowScene }): ReactNode {
-    const soqlBody = (
-        <SoqlBody
-            draft={scene.soqlDraft}
-            caret={scene.caret === 'soql'}
-            resultsVisible={scene.resultsVisible}
-            sendPulse={scene.sendPulse}
-        />
-    );
-    const editorBody = (
-        <EditorBody
-            typedSource={scene.editorTyped}
-            caret={scene.caret === 'editor'}
-            dirty={scene.editorDirty}
-            paletteOpen={scene.paletteOpen}
-            palettePhase={scene.palettePhase}
-            paletteQuery={scene.paletteQuery}
-            paletteName={scene.paletteName}
-            paletteCaret={scene.caret === 'palette'}
-            bundleReady={scene.bundleReady}
-        />
-    );
-    let body: ReactNode;
-    if (scene.view === 'salesforce') {
-        body = (
+function flowViewBody(view: FlowView, scene: FlowScene): ReactNode {
+    if (view === 'salesforce') {
+        return (
             <SalesforcePage
                 overlayOpen={scene.overlayOpen}
                 overlaySearch={scene.overlaySearch}
@@ -826,40 +908,96 @@ export function HomeFlowWireframe({ scene }: { scene: FlowScene }): ReactNode {
                 vscodeHot={scene.vscodeHot}
             />
         );
-    } else if (scene.view === 'editor') {
-        body = (
+    }
+    if (view === 'editor') {
+        return (
             <ToolkitShell activeApp="editor" tabLabel="VS Code">
-                {editorBody}
+                <EditorBody
+                    typedSource={scene.editorTyped}
+                    caret={scene.caret === 'editor'}
+                    dirty={scene.editorDirty}
+                    paletteOpen={scene.paletteOpen}
+                    palettePhase={scene.palettePhase}
+                    paletteQuery={scene.paletteQuery}
+                    paletteName={scene.paletteName}
+                    paletteCaret={scene.caret === 'palette'}
+                    bundleReady={scene.bundleReady}
+                />
             </ToolkitShell>
         );
-    } else if (scene.view === 'soql') {
-        body = (
+    }
+    if (view === 'soql') {
+        return (
             <ToolkitShell activeApp="soql" tabLabel="SOQL Explorer">
-                {soqlBody}
+                <SoqlBody
+                    draft={scene.soqlDraft}
+                    caret={scene.caret === 'soql'}
+                    resultsVisible={scene.resultsVisible}
+                    sendPulse={scene.sendPulse}
+                />
             </ToolkitShell>
-        );
-    } else {
-        body = (
-            <SidePanelForm
-                assistant={scene.assistant}
-                streaming={Boolean(scene.assistant) && scene.formFocus !== 'submit'}
-                formFocus={scene.formFocus}
-                formName={scene.formName}
-                formEmail={scene.formEmail}
-                formOrder={scene.formOrder}
-                formMessage={scene.formMessage}
-                formSubmitPulse={scene.formSubmitPulse}
-            />
         );
     }
     return (
+        <SidePanelForm
+            assistant={scene.assistant}
+            streaming={Boolean(scene.assistant) && scene.formFocus !== 'submit'}
+            formFocus={scene.formFocus}
+            formName={scene.formName}
+            formEmail={scene.formEmail}
+            formOrder={scene.formOrder}
+            formMessage={scene.formMessage}
+        />
+    );
+}
+
+function useHeldView(view: FlowView): { current: FlowView; outgoing: FlowView | null } {
+    const [current, setCurrent] = useState(view);
+    const [outgoing, setOutgoing] = useState<FlowView | null>(null);
+    const timerRef = useRef(0);
+    useEffect(() => {
+        if (view === current) return;
+        setOutgoing(current);
+        setCurrent(view);
+        window.clearTimeout(timerRef.current);
+        timerRef.current = window.setTimeout(() => setOutgoing(null), VIEW_FADE_MS);
+    }, [view, current]);
+    useEffect(() => () => window.clearTimeout(timerRef.current), []);
+    return { current, outgoing };
+}
+
+export function HomeFlowWireframe({
+    scene,
+    loopGen = 0,
+    showCursor,
+}: {
+    scene: FlowScene;
+    loopGen?: number;
+    showCursor?: boolean;
+}): ReactNode {
+    const stageRef = useRef<HTMLDivElement>(null);
+    const { current, outgoing } = useHeldView(scene.view);
+    return (
         <div
+            ref={stageRef}
             className="pt-stage"
             data-flow-view={scene.view}
+            data-loop-gen={loopGen > 0 ? loopGen : undefined}
             style={{ width: AUTHORED_WIDTH, height: AUTHORED_HEIGHT }}
         >
-            {body}
+            {outgoing ? (
+                <div className="pt-view-layer is-exit">{flowViewBody(outgoing, scene)}</div>
+            ) : null}
+            <div className={classNames('pt-view-layer is-current', outgoing && 'is-enter')}>
+                {flowViewBody(current, scene)}
+            </div>
             {scene.loadingTarget ? <LoadingOverlay label={scene.loadingTarget} /> : null}
+            <TourCursor
+                stageRef={stageRef}
+                target={scene.cursorTarget}
+                clicking={scene.vscodeHot || scene.sendPulse}
+                hidden={!showCursor || scene.loading || scene.view === 'sidepanel'}
+            />
         </div>
     );
 }
@@ -867,10 +1005,13 @@ export function HomeFlowWireframe({ scene }: { scene: FlowScene }): ReactNode {
 export function SlideWireframe({
     slideId,
     play,
+    showCursor,
 }: {
     slideId: TourSlideId;
     play?: SlidePlay;
+    showCursor?: boolean;
 }): ReactNode {
+    const stageRef = useRef<HTMLDivElement>(null);
     const scene = play ?? completedSlidePlay(slideId);
     let body: ReactNode;
     if (slideId === 'overlay') {
@@ -931,17 +1072,23 @@ export function SlideWireframe({
                 formEmail={scene.formEmail}
                 formOrder={scene.formOrder}
                 formMessage={scene.formMessage}
-                formSubmitPulse={scene.formSubmitPulse}
             />
         );
     }
     return (
         <div
+            ref={stageRef}
             className="pt-stage"
             data-tour-slide={slideId}
             style={{ width: AUTHORED_WIDTH, height: AUTHORED_HEIGHT }}
         >
-            {body}
+            <div className="pt-view-layer is-current">{body}</div>
+            <TourCursor
+                stageRef={stageRef}
+                target={cursorTargetForPlay(scene)}
+                clicking={scene.vscodeHot || scene.sendPulse}
+                hidden={!showCursor || slideId === 'agent'}
+            />
         </div>
     );
 }

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -383,6 +383,7 @@ h1 {
 .home-tour {
     width: 100%;
     max-width: 1120px;
+    min-width: 0;
     margin: 0 auto;
     opacity: 0;
     transform: translateY(36px);
@@ -448,6 +449,8 @@ h1 {
 .feature-browser {
     opacity: 0;
     transform: translateX(28px);
+    min-width: 0;
+    max-width: 100%;
     transition:
         opacity 0.7s ease,
         transform 0.7s ease;
@@ -568,8 +571,8 @@ h1 {
 }
 
 .fake-browser--tour {
-    width: max-content;
-    max-width: none;
+    width: 100%;
+    max-width: 100%;
 }
 
 .fake-browser-screenshot {
@@ -600,7 +603,7 @@ h1 {
 
 .platforms {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr));
     gap: 1rem;
     margin-top: 1.4rem;
 }
@@ -908,20 +911,35 @@ a:focus-visible {
         padding-left: 1.1rem;
         padding-right: 1.1rem;
         font-size: 0.79rem;
+        flex-wrap: wrap;
     }
 
     .header {
         padding: 0.75rem 1.1rem;
         margin: 0 -1.1rem;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+    }
+
+    .header-nav {
+        gap: 0.55rem;
+        flex-wrap: wrap;
     }
 
     .page {
         padding: 0 1.1rem;
+        overflow-x: clip;
     }
 
     .hero-full {
-        padding-top: 3.5rem;
-        gap: 2.5rem;
+        padding-top: 2.5rem;
+        gap: 1.75rem;
+    }
+
+    .home-tour,
+    .feature-browser,
+    .product-tour {
+        max-width: 100%;
     }
 
     h1 {


### PR DESCRIPTION
## Summary
- Restyle the product tour overlay, toolkit shell, SOQL explorer, and Next Gen Agent chrome so the landing demo matches the real Workbench UI.
- Scale the tour inside the viewport on small screens instead of overflowing the authored 1100px stage.
- Let the agent fill the Acme support form without a demo cursor or a blinking Submit button.

## Test plan
- [ ] On `http://localhost:27100/`, confirm overlay glass + dock, tilted Beta, grouped nav, SOQL header, and agent composer.
- [ ] Check ~375px and ~768px: no horizontal scroll, tour scaled, form readable.
- [ ] Watch the agent beat: fields type in, no mouse cursor, Submit becomes Sent once (no pulse).
- [ ] `node --experimental-strip-types --test apps/ui/src/product-tour/__test__/flow-scene.test.ts`